### PR TITLE
Set PVCATEGORY to an appropriate value

### DIFF
--- a/INSTETC/INSTETC-IOC-01App/Db/inst_real_parameters.substitutions
+++ b/INSTETC/INSTETC-IOC-01App/Db/inst_real_parameters.substitutions
@@ -34,20 +34,20 @@
 #10,Sample Detector Distance,Real,m,sdd
 #11,Journal Blocks,String,,jblocks
 
-pattern { P, Q, DESC, UNITS, OUT }
-    { "\$(P)", "PARS:SAMPLE:WIDTH", "Sample Width", "mm", "DAE:SAMPLEPAR:SP" }
-    { "\$(P)", "PARS:SAMPLE:HEIGHT", "Sample Height", "mm", "DAE:SAMPLEPAR:SP" }
-    { "\$(P)", "PARS:SAMPLE:THICK", "Sample Thickness", "mm", "DAE:SAMPLEPAR:SP" }
-    { "\$(P)", "PARS:SAMPLE:PHI", "Sample Phi Angle", "", "DAE:SAMPLEPAR:SP" }
-    { "\$(P)", "PARS:SAMPLE:AOI", "Angle of Incidence", "", "DAE:SAMPLEPAR:SP" }
-    { "\$(P)", "PARS:BL:L1", "Primary Flight Path (L1)", "m", "DAE:BEAMLINEPAR:SP" }
-    { "\$(P)", "PARS:BL:A1", "Aperture 1 Diameter", "mm", "DAE:BEAMLINEPAR:SP" }
-    { "\$(P)", "PARS:BL:A2", "Aperture 2 Diameter", "mm", "DAE:BEAMLINEPAR:SP" }
-    { "\$(P)", "PARS:BL:A3", "Aperture 3 Diameter", "mm", "DAE:BEAMLINEPAR:SP" }
-    { "\$(P)", "PARS:BL:FOEMIRROR", "FOE Mirror Angle", "", "DAE:BEAMLINEPAR:SP" }
-    { "\$(P)", "PARS:BL:BCX", "Beam Centre X", "mm", "DAE:BEAMLINEPAR:SP" }
-    { "\$(P)", "PARS:BL:BCY", "Beam Centre Y", "mm", "DAE:BEAMLINEPAR:SP" }
-    { "\$(P)", "PARS:BL:SDD", "Sample Detector Distance", "m", "DAE:BEAMLINEPAR:SP" }
-    { "\$(P)", "PARS:BL:CHOPEN:ANG", "Chopper Opening Angle", "", "DAE:BEAMLINEPAR:SP" }
+pattern { P, Q, DESC, CATEGORY, UNITS, OUT }
+    { "\$(P)", "PARS:SAMPLE:WIDTH", "Sample Width", "SAMPLEPAR", "mm", "DAE:SAMPLEPAR:SP" }
+    { "\$(P)", "PARS:SAMPLE:HEIGHT", "Sample Height", "SAMPLEPAR", "mm", "DAE:SAMPLEPAR:SP" }
+    { "\$(P)", "PARS:SAMPLE:THICK", "Sample Thickness", "SAMPLEPAR", "mm", "DAE:SAMPLEPAR:SP" }
+    { "\$(P)", "PARS:SAMPLE:PHI", "Sample Phi Angle", "SAMPLEPAR", "", "DAE:SAMPLEPAR:SP" }
+    { "\$(P)", "PARS:SAMPLE:AOI", "Angle of Incidence", "SAMPLEPAR", "", "DAE:SAMPLEPAR:SP" }
+    { "\$(P)", "PARS:BL:L1", "Primary Flight Path (L1)", "BEAMLINEPAR", "m", "DAE:BEAMLINEPAR:SP" }
+    { "\$(P)", "PARS:BL:A1", "Aperture 1 Diameter", "BEAMLINEPAR", "mm", "DAE:BEAMLINEPAR:SP" }
+    { "\$(P)", "PARS:BL:A2", "Aperture 2 Diameter", "BEAMLINEPAR", "mm", "DAE:BEAMLINEPAR:SP" }
+    { "\$(P)", "PARS:BL:A3", "Aperture 3 Diameter", "BEAMLINEPAR", "mm", "DAE:BEAMLINEPAR:SP" }
+    { "\$(P)", "PARS:BL:FOEMIRROR", "FOE Mirror Angle", "BEAMLINEPAR", "", "DAE:BEAMLINEPAR:SP" }
+    { "\$(P)", "PARS:BL:BCX", "Beam Centre X", "BEAMLINEPAR", "mm", "DAE:BEAMLINEPAR:SP" }
+    { "\$(P)", "PARS:BL:BCY", "Beam Centre Y", "BEAMLINEPAR", "mm", "DAE:BEAMLINEPAR:SP" }
+    { "\$(P)", "PARS:BL:SDD", "Sample Detector Distance", "BEAMLINEPAR", "m", "DAE:BEAMLINEPAR:SP" }
+    { "\$(P)", "PARS:BL:CHOPEN:ANG", "Chopper Opening Angle", "BEAMLINEPAR", "", "DAE:BEAMLINEPAR:SP" }
 
     

--- a/INSTETC/INSTETC-IOC-01App/Db/inst_real_parameters.template
+++ b/INSTETC/INSTETC-IOC-01App/Db/inst_real_parameters.template
@@ -1,4 +1,4 @@
-record(ao, "$(P)$(Q):SP")
+record(ao, "$(P)$(Q)")
 {
    field(DESC, "$(DESC)")  
    field(DTYP, "Soft Channel")
@@ -7,8 +7,9 @@ record(ao, "$(P)$(Q):SP")
    field(OMSL, "supervisory")
    field(PREC, 3)
    info(autosaveFields, "VAL")
+   info(PVCATEGORY, "$(CATEGORY)")
 }
-alias("$(P)$(Q):SP", "$(P)$(Q)")
+alias("$(P)$(Q)", "$(P)$(Q):SP")
 
 # force periodic update of values in case we get out of sync with DAE e.g. program restarts 
 # we use this rather than PINI in above as DAE may not be running when we start this ioc

--- a/INSTETC/INSTETC-IOC-01App/Db/inst_string_parameters.substitutions
+++ b/INSTETC/INSTETC-IOC-01App/Db/inst_string_parameters.substitutions
@@ -34,11 +34,11 @@
 #10,Sample Detector Distance,Real,m,sdd
 #11,Journal Blocks,String,,jblocks
 
-pattern { P, Q, DESC, UNITS, OUT }
-    { "\$(P)", "PARS:SAMPLE:NAME", "Sample Name", "", "DAE:SAMPLEPAR:SP" }
-    { "\$(P)", "PARS:SAMPLE:TYPE", "Sample Type", "", "DAE:SAMPLEPAR:SP" }
-    { "\$(P)", "PARS:SAMPLE:GEOMETRY", "Sample Geometry", "", "DAE:SAMPLEPAR:SP" }
-    { "\$(P)", "PARS:SCRIPT:NAME", "Script Name", "", "DAE:SAMPLEPAR:SP" }
-    { "\$(P)", "PARS:BL:BEAMSTOP:POS", "Beamstop Position", "", "DAE:SAMPLEPAR:SP" }
-    { "\$(P)", "PARS:BL:JOURNAL:BLOCKS", "Journal Blocks", "", "DAE:SAMPLEPAR:SP" }
+pattern { P, Q, DESC, CATEGORY, UNITS, OUT }
+    { "\$(P)", "PARS:SAMPLE:NAME", "Sample Name", "SAMPLEPAR", "", "DAE:SAMPLEPAR:SP" }
+    { "\$(P)", "PARS:SAMPLE:TYPE", "Sample Type", "SAMPLEPAR", "", "DAE:SAMPLEPAR:SP" }
+    { "\$(P)", "PARS:SAMPLE:GEOMETRY", "Sample Geometry", "SAMPLEPAR", "", "DAE:SAMPLEPAR:SP" }
+    { "\$(P)", "PARS:SCRIPT:NAME", "Script Name", "SAMPLEPAR", "", "DAE:SAMPLEPAR:SP" }
+    { "\$(P)", "PARS:BL:BEAMSTOP:POS", "Beamstop Position", "SAMPLEPAR", "", "DAE:SAMPLEPAR:SP" }
+    { "\$(P)", "PARS:BL:JOURNAL:BLOCKS", "Journal Blocks", "SAMPLEPAR", "", "DAE:SAMPLEPAR:SP" }
     

--- a/INSTETC/INSTETC-IOC-01App/Db/inst_string_parameters.template
+++ b/INSTETC/INSTETC-IOC-01App/Db/inst_string_parameters.template
@@ -1,4 +1,4 @@
-record(waveform, "$(P)$(Q):SP")
+record(waveform, "$(P)$(Q)")
 {
    field(DESC, "$(DESC)")  
    field(NELM, "256")
@@ -7,8 +7,9 @@ record(waveform, "$(P)$(Q):SP")
    field(FLNK, "$(P)$(Q):SEND")
    field(EGU, "$(UNITS)")
    info(autosaveFields, "VAL")
+   info(PVCATEGORY, "$(CATEGORY)")
 }
-alias("$(P)$(Q):SP", "$(P)$(Q)")
+alias("$(P)$(Q)", "$(P)$(Q):SP")
 
 # force periodic update of values in case we get out of sync with DAE e.g. program restarts 
 # we use this rather than PINI in above as DAE may not be running when we start this ioc

--- a/INSTETC/INSTETC-IOC-01App/Db/user_parameters.template
+++ b/INSTETC/INSTETC-IOC-01App/Db/user_parameters.template
@@ -12,7 +12,9 @@ record (longin, "$(P)PARS:USER:I$(INDEX)")
     info(archive, "VAL")
     info(autosaveFields, "VAL EGU DESC")
 	info(INTEREST, "MEDIUM")
+    info(PVCATEGORY, "USERPAR")
 }
+alias("$(P)PARS:USER:I$(INDEX)", "$(P)PARS:USER:I$(INDEX):SP")
 
 ## User settable real
 ## Units, value and description are autosaved
@@ -26,7 +28,9 @@ record (ai, "$(P)PARS:USER:R$(INDEX)")
     info(archive, "VAL")
     info(autosaveFields, "VAL EGU DESC")
 	info(INTEREST, "MEDIUM")
+    info(PVCATEGORY, "USERPAR")
 }
+alias("$(P)PARS:USER:R$(INDEX)", "$(P)PARS:USER:R$(INDEX):SP")
 
 ## User settable string
 ## Value and description are autosaved
@@ -38,4 +42,6 @@ record (stringin, "$(P)PARS:USER:S$(INDEX)")
     info(archive, "VAL")
     info(autosaveFields, "VAL DESC")
 	info(INTEREST, "MEDIUM")
+    info(PVCATEGORY, "USERPAR")
 }
+alias("$(P)PARS:USER:S$(INDEX)", "$(P)PARS:USER:S$(INDEX):SP")


### PR DESCRIPTION
This is part of ISISComputingGroup/IBEX#1133 and needs to be merged together with corresponding branch in inst_servers

To test: check 

caget -S -t %MYPVPREFIX%CS:BLOCKSERVER:SAMPLE_PARS

should return a sensible list like
["PARS:SAMPLE:AOI", "PARS:SAMPLE:GEOMETRY", "PARS:SAMPLE:HEIGHT", "PARS:
AME", "PARS:SAMPLE:PHI", "PARS:SAMPLE:THICK", "PARS:SAMPLE:TYPE", "PARS:SAMPLE:WIDTH", "PARS:SCRIPT:NAME"]