### PR TITLE
Run up to 10 PSUs in each IOC

### DIFF
--- a/TDK_LAMBDA_GENESYS/iocBoot/iocGENESYS-IOC-01/st-common.cmd
+++ b/TDK_LAMBDA_GENESYS/iocBoot/iocGENESYS-IOC-01/st-common.cmd
@@ -1,3 +1,6 @@
+## we have no .req files to load
+epicsEnvSet ("AUTOSAVEREQ", "#")
+
 ##ISIS## Run IOC initialisation 
 < $(IOCSTARTUP)/init.cmd
 
@@ -5,14 +8,37 @@
 < $(IOCSTARTUP)/dbload.cmd
 
 ## set path to stream driver protocol file referenced in db files
-epicsEnvSet "STREAM_PROTOCOL_PATH" "$(TDKLAMBDAGENESYS)\data"
+epicsEnvSet "STREAM_PROTOCOL_PATH" "$(TDKLAMBDAGENESYS)/data"
 
 epicsEnvSet(PS,1)
 < st-psu.cmd
 
+epicsEnvSet(PS,2)
+< st-psu.cmd
 
+epicsEnvSet(PS,3)
+< st-psu.cmd
 
+epicsEnvSet(PS,4)
+< st-psu.cmd
 
+epicsEnvSet(PS,5)
+< st-psu.cmd
+
+epicsEnvSet(PS,6)
+< st-psu.cmd
+
+epicsEnvSet(PS,7)
+< st-psu.cmd
+
+epicsEnvSet(PS,8)
+< st-psu.cmd
+
+epicsEnvSet(PS,9)
+< st-psu.cmd
+
+epicsEnvSet(PS,10)
+< st-psu.cmd
 
 ## as we are common, we need to explicity define the 01 area for when we are ran by 02, 03 etc 
 set_requestfile_path("${TOP}/iocBoot/iocGENESYS-IOC-01", "")

--- a/TDK_LAMBDA_GENESYS/iocBoot/iocGENESYS-IOC-01/st-psu.cmd
+++ b/TDK_LAMBDA_GENESYS/iocBoot/iocGENESYS-IOC-01/st-psu.cmd
@@ -3,22 +3,22 @@
 
 
 # this defines macros we can use for conditional loading later
-stringiftest("PORT", "$(PORT$(PN)=)")
+stringiftest("PORT", "$(PORT$(PS)=)")
 
 # create a real serial port, unless in simulation mode then crreate an unconnected asyn port 
-$(IFPORT)$(IFSIM)    drvAsynSerialPortConfigure ("L$(PN)", "NUL", 0, 1)
+$(IFPORT)$(IFSIM)    drvAsynSerialPortConfigure ("L$(PS)", "NUL", 0, 1)
 
-$(IFPORT)$(IFNOTSIM) drvAsynSerialPortConfigure ("L$(PN)", "$(PORT$(PN)=)")
-$(IFPORT)$(IFNOTSIM) asynSetOption ("L$(PN)", 0, "baud", "$(BAUD$(PN)=9600)")
-$(IFPORT)$(IFNOTSIM) asynSetOption ("L$(PN)", 0, "bits", "$(BITS$(PN)=8)")
-$(IFPORT)$(IFNOTSIM) asynSetOption ("L$(PN)", 0, "parity", "$(PARITY$(PN)=none)")
-$(IFPORT)$(IFNOTSIM) asynSetOption ("L$(PN)", 0, "stop", "$(STOP$(PN)=1)")
-$(IFPORT)$(IFNOTSIM) asynOctetSetInputEos("L$(PN)",0,"$(IEOS$(PN)=\\r)")
-$(IFPORT)$(IFNOTSIM) asynOctetSetOutputEos("L$(PN)",0,"$(OEOS$(PN)=\\r)")
+$(IFPORT)$(IFNOTSIM) drvAsynSerialPortConfigure ("L$(PS)", "$(PORT$(PS)=)")
+$(IFPORT)$(IFNOTSIM) asynSetOption ("L$(PS)", 0, "baud", "$(BAUD$(PS)=9600)")
+$(IFPORT)$(IFNOTSIM) asynSetOption ("L$(PS)", 0, "bits", "$(BITS$(PS)=8)")
+$(IFPORT)$(IFNOTSIM) asynSetOption ("L$(PS)", 0, "parity", "$(PARITY$(PS)=none)")
+$(IFPORT)$(IFNOTSIM) asynSetOption ("L$(PS)", 0, "stop", "$(STOP$(PS)=1)")
+$(IFPORT)$(IFNOTSIM) asynOctetSetInputEos("L$(PS)",0,"$(IEOS$(PS)=\\r)")
+$(IFPORT)$(IFNOTSIM) asynOctetSetOutputEos("L$(PS)",0,"$(OEOS$(PS)=\\r)")
 
 ## Initialise the comms with the PSU
-$(IFPORT)$(IFNOTSIM) asynOctetConnect L$(PN) GENESYS_01$(PN)
-$(IFPORT)$(IFNOTSIM) asynOctetWrite GENESYS_01$(PN) “ADR $(ADDR$(PN))”
+$(IFPORT)$(IFNOTSIM) asynOctetConnect L$(PS) GENESYS_01$(PS)
+$(IFPORT)$(IFNOTSIM) asynOctetWrite GENESYS_01$(PS) “ADR $(ADDR$(PS))”
 
 ## Load record instances for connected psu
-$(IFPORT)  dbLoadRecords("db/GENESYS.db", "P=$(MYPVPREFIX)$(IOCNAME):$(PN):, PORT=L$(PN), ADR=$(ADDR$(PN))")
+$(IFPORT)  dbLoadRecords("$(TOP)/db/TDK_LAMBDA_GENESYS.db", "P=$(MYPVPREFIX)$(IOCNAME):$(PS):, PORT=L$(PS), ADR=$(ADDR$(PS))")

--- a/TDK_LAMBDA_GENESYS/iocBoot/iocGENESYS-IOC-01/st.cmd
+++ b/TDK_LAMBDA_GENESYS/iocBoot/iocGENESYS-IOC-01/st.cmd
@@ -9,7 +9,7 @@ errlogInit2(65536, 256)
 < envPaths
 
 ## Register all support components
-dbLoadDatabase "dbd/GENESYS-IOC-01.dbd"
+dbLoadDatabase ("$(TOP)/dbd/GENESYS-IOC-01.dbd",0,0)
 GENESYS_IOC_01_registerRecordDeviceDriver pdbbase
 
 < st-common.cmd

--- a/TDK_LAMBDA_GENESYS/iocBoot/iocGENESYS-IOC-02/st.cmd
+++ b/TDK_LAMBDA_GENESYS/iocBoot/iocGENESYS-IOC-02/st.cmd
@@ -1,6 +1,6 @@
-#!../../bin/windows-x64/GENESYS-IOC-01
+#!../../bin/windows-x64/GENESYS-IOC-02
 
-## You may have to change GENESYS-IOC-01 to something else
+## You may have to change GENESYS-IOC-02 to something else
 ## everywhere it appears in this file
 
 # Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
@@ -8,43 +8,10 @@ errlogInit2(65536, 256)
 
 < envPaths
 
-epicsEnvSet "STREAM_PROTOCOL_PATH" "$(TDKLAMBDAGENESYS)"
-epicsEnvSet "TTY" "$(TTY=\\\\\\\\.\\\\COM20)"
-
-cd ${TOP}
-
 ## Register all support components
-dbLoadDatabase "dbd/GENESYS-IOC-02.dbd"
-GENESYS_IOC_01_registerRecordDeviceDriver pdbbase
+dbLoadDatabase ("$(TOP)/dbd/GENESYS-IOC-02.dbd",0,0)
+GENESYS_IOC_02_registerRecordDeviceDriver pdbbase
 
-##ISIS## Run IOC initialisation 
-< $(IOCSTARTUP)/init.cmd
+cd ../iocGENESYS-IOC-01
 
-drvAsynSerialPortConfigure("L0", "$(TTY)", 0, 0, 0, 0)
-asynSetOption("L0", -1, "baud", "9600")
-asynSetOption("L0", -1, "bits", "8")
-asynSetOption("L0", -1, "parity", "none")
-asynSetOption("L0", -1, "stop", "1")
-asynOctetSetInputEos("L0", -1, "\r")
-asynOctetSetOutputEos("L0", -1, "\r")
-
-## Load record instances
-
-##ISIS## Load common DB records 
-< $(IOCSTARTUP)/dbload.cmd
-
-## Load our record instances
-#dbLoadRecords("db/xxx.db","user=kvlb23Host")
-dbLoadRecords("db/GENESYS.db", "P=$(MYPVPREFIX)$(IOCNAME):, PORT=L0")
-
-##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
-< $(IOCSTARTUP)/preiocinit.cmd
-
-cd ${TOP}/iocBoot/${IOC}
-iocInit
-
-## Start any sequence programs
-#seq sncxxx,"user=kvlb23Host"
-
-##ISIS## Stuff that needs to be done after iocInit is called e.g. sequence programs 
-< $(IOCSTARTUP)/postiocinit.cmd
+< st-common.cmd

--- a/TDK_LAMBDA_GENESYS/iocBoot/iocGENESYS-IOC-03/st.cmd
+++ b/TDK_LAMBDA_GENESYS/iocBoot/iocGENESYS-IOC-03/st.cmd
@@ -1,6 +1,6 @@
-#!../../bin/windows-x64/GENESYS-IOC-01
+#!../../bin/windows-x64/GENESYS-IOC-03
 
-## You may have to change GENESYS-IOC-01 to something else
+## You may have to change GENESYS-IOC-03 to something else
 ## everywhere it appears in this file
 
 # Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
@@ -8,43 +8,10 @@ errlogInit2(65536, 256)
 
 < envPaths
 
-epicsEnvSet "STREAM_PROTOCOL_PATH" "$(TDKLAMBDAGENESYS)"
-epicsEnvSet "TTY" "$(TTY=\\\\\\\\.\\\\COM20)"
-
-cd ${TOP}
-
 ## Register all support components
-dbLoadDatabase "dbd/GENESYS-IOC-03.dbd"
-GENESYS_IOC_01_registerRecordDeviceDriver pdbbase
+dbLoadDatabase ("$(TOP)/dbd/GENESYS-IOC-03.dbd",0,0)
+GENESYS_IOC_03_registerRecordDeviceDriver pdbbase
 
-##ISIS## Run IOC initialisation 
-< $(IOCSTARTUP)/init.cmd
+cd ../iocGENESYS-IOC-01
 
-drvAsynSerialPortConfigure("L0", "$(TTY)", 0, 0, 0, 0)
-asynSetOption("L0", -1, "baud", "9600")
-asynSetOption("L0", -1, "bits", "8")
-asynSetOption("L0", -1, "parity", "none")
-asynSetOption("L0", -1, "stop", "1")
-asynOctetSetInputEos("L0", -1, "\r")
-asynOctetSetOutputEos("L0", -1, "\r")
-
-## Load record instances
-
-##ISIS## Load common DB records 
-< $(IOCSTARTUP)/dbload.cmd
-
-## Load our record instances
-#dbLoadRecords("db/xxx.db","user=kvlb23Host")
-dbLoadRecords("db/GENESYS.db", "P=$(MYPVPREFIX)$(IOCNAME):, PORT=L0")
-
-##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
-< $(IOCSTARTUP)/preiocinit.cmd
-
-cd ${TOP}/iocBoot/${IOC}
-iocInit
-
-## Start any sequence programs
-#seq sncxxx,"user=kvlb23Host"
-
-##ISIS## Stuff that needs to be done after iocInit is called e.g. sequence programs 
-< $(IOCSTARTUP)/postiocinit.cmd
+< st-common.cmd

--- a/TDK_LAMBDA_GENESYS/iocBoot/iocGENESYS-IOC-04/st.cmd
+++ b/TDK_LAMBDA_GENESYS/iocBoot/iocGENESYS-IOC-04/st.cmd
@@ -1,6 +1,6 @@
-#!../../bin/windows-x64/GENESYS-IOC-01
+#!../../bin/windows-x64/GENESYS-IOC-04
 
-## You may have to change GENESYS-IOC-01 to something else
+## You may have to change GENESYS-IOC-04 to something else
 ## everywhere it appears in this file
 
 # Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
@@ -8,43 +8,10 @@ errlogInit2(65536, 256)
 
 < envPaths
 
-epicsEnvSet "STREAM_PROTOCOL_PATH" "$(TDKLAMBDAGENESYS)"
-epicsEnvSet "TTY" "$(TTY=\\\\\\\\.\\\\COM20)"
-
-cd ${TOP}
-
 ## Register all support components
-dbLoadDatabase "dbd/GENESYS-IOC-04.dbd"
-GENESYS_IOC_01_registerRecordDeviceDriver pdbbase
+dbLoadDatabase ("$(TOP)/dbd/GENESYS-IOC-04.dbd",0,0)
+GENESYS_IOC_04_registerRecordDeviceDriver pdbbase
 
-##ISIS## Run IOC initialisation 
-< $(IOCSTARTUP)/init.cmd
+cd ../iocGENESYS-IOC-01
 
-drvAsynSerialPortConfigure("L0", "$(TTY)", 0, 0, 0, 0)
-asynSetOption("L0", -1, "baud", "9600")
-asynSetOption("L0", -1, "bits", "8")
-asynSetOption("L0", -1, "parity", "none")
-asynSetOption("L0", -1, "stop", "1")
-asynOctetSetInputEos("L0", -1, "\r")
-asynOctetSetOutputEos("L0", -1, "\r")
-
-## Load record instances
-
-##ISIS## Load common DB records 
-< $(IOCSTARTUP)/dbload.cmd
-
-## Load our record instances
-#dbLoadRecords("db/xxx.db","user=kvlb23Host")
-dbLoadRecords("db/GENESYS.db", "P=$(MYPVPREFIX)$(IOCNAME):, PORT=L0")
-
-##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
-< $(IOCSTARTUP)/preiocinit.cmd
-
-cd ${TOP}/iocBoot/${IOC}
-iocInit
-
-## Start any sequence programs
-#seq sncxxx,"user=kvlb23Host"
-
-##ISIS## Stuff that needs to be done after iocInit is called e.g. sequence programs 
-< $(IOCSTARTUP)/postiocinit.cmd
+< st-common.cmd


### PR DESCRIPTION
Corrections to the st.cmd set-ups so that the IOC will run.

To test:

Via the console app, any of these should load, but unless the macros/global changes mentioned below have been made there should be no records beyond the standard ones

The easiest method if to alter your globals.txt, although any of these macros can be set via the configurations.

In the file C:\Instrument\Settings\config\#######\globals.txt, where ####### is the server you are testing on, add the following as an example (if you have a PSU available use those settings) as part of the IOC specific macros:
GENESYS_01__PORT1=COM10
GENESYS_01__ADDR1=10
GENESYS_02__PORT1=COM11
GENESYS_02__ADDR1=10
GENESYS_02__PORT3=COM12
GENESYS_02__ADDR3=10

Starting the IOC GENESYS_01 will likely lead to a lot of errors, but should relate to PVs of the format:
PVPREFIX:GENESYS_01:1:*****

Starting the IOC GENESYS_02 will likely lead to a lot of errors, but should relate to PVs of the format:
PVPREFIX:GENESYS_02:1:*****
PVPREFIX:GENESYS_02:3:*****

Note that the update to the modules in support are likely to be needed before this can be tested, otherwise there may be other errors relating to missing values from the protocol file.