### PR TITLE
Escape __ as looks like anonymous hyperlink to rst

### DIFF
--- a/SDTEST/sdtest_docs/sdtest.rst
+++ b/SDTEST/sdtest_docs/sdtest.rst
@@ -7,7 +7,7 @@ The serial device test module consists of IOCs called SDTEST_01, SDTEST_02 etc. 
 Configuration of the devices is via EPICS macros, which can be defined in the globals.txt file located in c:/Instrument/settings/config/NDXLARMOR/configurations
 This globals.txt file is loaded on IOC startup, so you will need to stop/start the IOC after making a change. 
 
-All macros in globals.txt start with the IOC name followed by two underscores, so SDTEST_01__ for IOC SDTEST_01   Defining a macro  SDTEST_01__NAME3 here will create one that can be referenced as $(NAME3) by IOC SDTEST_01
+All macros in globals.txt start with the IOC name followed by two underscores, so SDTEST_01\_\_ for IOC SDTEST_01   Defining a macro  SDTEST_01__NAME3 here will create one that can be referenced as $(NAME3) by IOC SDTEST_01
 
 Each SDTEST IOC supports 8 devices numbered 1 to 8. Settings for each of these have the device number appended e.g. $(PORT3) is COM/serial port for the third device attached etc.
 
@@ -30,7 +30,7 @@ By way of example we will consider a power supply. In globals.txt we have:
     SDTEST_01__SETOUTC3=%f           # third part of string to send for setting special numeric value
     SDTEST_01__SETIN3=OK             # expected reply from SETOUT* Use e.g. %*40c to ignore reply
 
-As these all start SDTEST_01__ and end in 3 they refer to the third device attahced to IOC SDTEST_01
+As these all start SDTEST_01\_\_ and end in 3 they refer to the third device attached to IOC SDTEST_01
 You do not need to specify all values, here are defaults
 
 ======= =======   ================================================================================================================
@@ -52,9 +52,9 @@ SCAN    Passive   Any valid EPICS scan value (Passive, .1 second, .2 second,
 
 Process variables defined are of the form {instrument prefix}{ioc name}{device index}{variable} e.g. for the first device (P1) on IOC SDTEST_01
 
-==================================== ======= ===================================================================================
+==================================== ======= =====================================================================================
 Process variable                     Access  Description
-==================================== ======= ===================================================================================
+==================================== ======= =====================================================================================
 IN:LARMOR:SDTEST_01:P1:NAME          (read)  short name of device 
 IN:LARMOR:SDTEST_01:P1:DEVICE        (read)  COM port of device
 IN:LARMOR:SDTEST_01:P1:INIT          (write) initialise device
@@ -68,16 +68,16 @@ IN:LARMOR:SDTEST_01:P1:SETVAL        (write) write a numeric value to device usi
                                              .. specified command format
 IN:LARMOR:SDTEST_01:P1:GETVAL        (read)  numeric value read from device (ususally because 
                                              .. of a periodic SCAN)
-IN:LARMOR:SDTEST_01:P1:ASYNREC       (write) Access to an EPICS ASYN record 
-                                             .. http://www.aps.anl.gov/epics/modules/soft/asyn/R4-26/asynRecord.html 
-==================================== ======= ===================================================================================
+IN:LARMOR:SDTEST_01:P1:ASYNREC       (write) Access to an EPICS 
+                                             .. _ASYN Record: http://www.aps.anl.gov/epics/modules/soft/asyn/R4-26/asynRecord.html 
+==================================== ======= =====================================================================================
 
 When polling the GETVAL process variable, the the IOC will send $(GETOUT) and expect to receive $(GETIN)  Within $(GETIN) can be printf style format characters to match
-the value being read. For valid format converters see http://epics.web.psi.ch/software/streamdevice/doc/formats.html
+the value being read. For valid format converters see __ http://epics.web.psi.ch/software/streamdevice/doc/formats.html
 
 When writing to the SETVAL process variable, the IOC will construct a string from concaternating $(SETOUTA), $(SETOUTB) and $(SETOUTC). The writing format character (e.g. %f)
 must be in SETOUTC, normally only SETOUTA and SETOUTC are specified, sometimes just SETOUTC. SETOUTB is for sending a special character between these two values, such as a space.
-SETOUTA and SETOUTC are quoted strings as per http://epics.web.psi.ch/software/streamdevice/doc/protocol.html whereas SETOUTB can be a byte number such as 0x20 for a space character.  Only use SETOUTB is you have trouble with using SETOUTA and SETOUTC - in particular needing to send a space character between and string
+SETOUTA and SETOUTC are quoted strings as per __ http://epics.web.psi.ch/software/streamdevice/doc/protocol.html whereas SETOUTB can be a byte number such as 0x20 for a space character.  Only use SETOUTB is you have trouble with using SETOUTA and SETOUTC - in particular needing to send a space character between and string
 and a format converter that seems to get stripped otherwise.
 
 For INIT, macros INITOUT and INITIN 
@@ -90,7 +90,7 @@ SDTEST Synoptic OPI
 
 An OPI file SDTEST.opt exists that opens a display for managing the serial device, which
 includes the option to open an ayn record OPI - see screenshots at bottom 
-of http://www.aps.anl.gov/epics/modules/soft/asyn/R4-26/asynRecord.html
+of _ASYN Record: http://www.aps.anl.gov/epics/modules/soft/asyn/R4-26/asynRecord.html
 
 ------------------
 More complex cases
@@ -100,9 +100,10 @@ More complex cases
 Macro Default               Notes
 ===== ====================  ================================================================================================================
 PROTO SDTEST-default.proto  Stream device protocol file to use
+===== ====================  ================================================================================================================
 
 You can specify your own protocol file to use. Details of protocol file format are at
-http://epics.web.psi.ch/software/streamdevice/doc/  
+__ http://epics.web.psi.ch/software/streamdevice/doc/  
 
 because you will load the same DB file, you will need to provide the same functions as SDTEST-default.proto  i.e. getValue() and setValue()
 Place files in $(ICPCONFIGROOT)/SDTEST on machine


### PR DESCRIPTION
Explicitly mark some hyperlinks as anonymous, but probably only needed to escape the trailing __

To test, check that running    isisdoc\make_manual.bat     gives no errors