### PR TITLE
Ticket1220 macro for com ports

### DIFF
--- a/AG3631A/iocBoot/iocAG3631A-IOC-01/st.cmd
+++ b/AG3631A/iocBoot/iocAG3631A-IOC-01/st.cmd
@@ -25,7 +25,7 @@ AG3631A_IOC_01_registerRecordDeviceDriver pdbbase
 #asynOctetSetOutputEos("GPIB0", 1, "\n")
 
 #Set up serial port
-drvAsynSerialPortConfigure("L0", "$(TTY)", 0, 0, 0, 0)
+drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
 asynSetOption("L0", -1, "baud", "9600")
 asynSetOption("L0", -1, "bits", "8")
 asynSetOption("L0", -1, "parity", "none")

--- a/DELFTBPMAG/iocBoot/iocDELFTBPMAG-IOC-01/st.cmd
+++ b/DELFTBPMAG/iocBoot/iocDELFTBPMAG-IOC-01/st.cmd
@@ -15,12 +15,11 @@ dbLoadDatabase "dbd/DELFTBPMAG-IOC-01.dbd"
 DELFTBPMAG_IOC_01_registerRecordDeviceDriver pdbbase
 
 epicsEnvSet "STREAM_PROTOCOL_PATH" "$(TOP)/data"
-epicsEnvSet "TTY" "$(TTY=COM17)"
 
 ##ISIS## Run IOC initialisation 
 < $(IOCSTARTUP)/init.cmd
 
-drvAsynSerialPortConfigure("L0", "$(TTY)", 0, 0, 0, 0)
+drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
 asynSetOption("L0", -1, "baud", "9600")
 asynSetOption("L0", -1, "bits", "8")
 asynSetOption("L0", -1, "parity", "none")

--- a/DELFTBPMAG/iocBoot/iocDELFTBPMAG-IOC-02/st.cmd
+++ b/DELFTBPMAG/iocBoot/iocDELFTBPMAG-IOC-02/st.cmd
@@ -15,12 +15,11 @@ dbLoadDatabase "dbd/DELFTBPMAG-IOC-02.dbd"
 DELFTBPMAG_IOC_02_registerRecordDeviceDriver pdbbase
 
 epicsEnvSet "STREAM_PROTOCOL_PATH" "$(TOP)/data"
-epicsEnvSet "TTY" "$(TTY=COM17)"
 
 ##ISIS## Run IOC initialisation 
 < $(IOCSTARTUP)/init.cmd
 
-drvAsynSerialPortConfigure("L0", "$(TTY)", 0, 0, 0, 0)
+drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
 asynSetOption("L0", -1, "baud", "9600")
 asynSetOption("L0", -1, "bits", "8")
 asynSetOption("L0", -1, "parity", "none")

--- a/EUROTHERM/iocBoot/iocEUROTHERM-IOC-01/st.cmd
+++ b/EUROTHERM/iocBoot/iocEUROTHERM-IOC-01/st.cmd
@@ -7,7 +7,6 @@
 
 epicsEnvSet "IOCNAME" "EUROTHERM_01"
 epicsEnvSet "STREAM_PROTOCOL_PATH" "$(EUROTHERM2K)/eurotherm2kApp/protocol"
-epicsEnvSet "TTY" "$(TTY=COM21)"
 epicsEnvSet "SENS_DIR" "C:/Instrument/Settings/calib/sensors"
 epicsEnvSet "SENS_PAT" "^C.*"
 epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
@@ -21,7 +20,7 @@ EUROTHERM_IOC_01_registerRecordDeviceDriver pdbbase
 
 < $(IOCSTARTUP)/init.cmd
 
-drvAsynSerialPortConfigure("L0", "$(TTY)", 0, 0, 0, 0)
+drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
 asynSetOption("L0", -1, "baud", "9600")
 asynSetOption("L0", -1, "bits", "7")
 asynSetOption("L0", -1, "parity", "even")

--- a/EUROTHERM/iocBoot/iocEUROTHERM-IOC-02/st.cmd
+++ b/EUROTHERM/iocBoot/iocEUROTHERM-IOC-02/st.cmd
@@ -7,7 +7,6 @@
 
 epicsEnvSet "IOCNAME" "EUROTHERM_02"
 epicsEnvSet "STREAM_PROTOCOL_PATH" "$(EUROTHERM2K)/eurotherm2kApp/protocol"
-epicsEnvSet "TTY" "$(TTY=COM22)"
 epicsEnvSet "SENS_DIR" "C:/Instrument/Settings/calib/sensors"
 epicsEnvSet "SENS_PAT" "^C.*"
 epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
@@ -21,7 +20,7 @@ EUROTHERM_IOC_02_registerRecordDeviceDriver pdbbase
 
 < $(IOCSTARTUP)/init.cmd
 
-drvAsynSerialPortConfigure("L0", "$(TTY)", 0, 0, 0, 0)
+drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
 asynSetOption("L0", -1, "baud", "9600")
 asynSetOption("L0", -1, "bits", "7")
 asynSetOption("L0", -1, "parity", "even")

--- a/HAMEG8123/iocBoot/iocHAMEG8123-IOC-01/st.cmd
+++ b/HAMEG8123/iocBoot/iocHAMEG8123-IOC-01/st.cmd
@@ -9,7 +9,6 @@ errlogInit2(65536, 256)
 < envPaths
 
 epicsEnvSet "STREAM_PROTOCOL_PATH" "$(HAMEG8123)/Hameg_8123Sup"    
-epicsEnvSet "TTY" "$(TTY=\\\\\\\\.\\\\COM19)"                                   
 
 cd ${TOP}
 
@@ -20,7 +19,7 @@ HAMEG8123_IOC_01_registerRecordDeviceDriver pdbbase
 ##ISIS## Run IOC initialisation 
 < $(IOCSTARTUP)/init.cmd
 
-drvAsynSerialPortConfigure("L0", "$(TTY)", 0, 0, 0, 0)                          
+drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)                          
 asynSetOption("L0", -1, "baud", "9600")                                         
 asynSetOption("L0", -1, "bits", "8")                                            
 asynSetOption("L0", -1, "parity", "none")                                       

--- a/HAMEG8123/iocBoot/iocHAMEG8123-IOC-02/st.cmd
+++ b/HAMEG8123/iocBoot/iocHAMEG8123-IOC-02/st.cmd
@@ -9,7 +9,6 @@ errlogInit2(65536, 256)
 < envPaths
 
 epicsEnvSet "STREAM_PROTOCOL_PATH" "$(HAMEG8123)/Hameg_8123Sup"    
-epicsEnvSet "TTY" "$(TTY=\\\\\\\\.\\\\COM20)"  
 
 cd ${TOP}
 
@@ -20,7 +19,7 @@ HAMEG8123_IOC_02_registerRecordDeviceDriver pdbbase
 ##ISIS## Run IOC initialisation 
 < $(IOCSTARTUP)/init.cmd
 
-drvAsynSerialPortConfigure("L0", "$(TTY)", 0, 0, 0, 0)                          
+drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)                          
 asynSetOption("L0", -1, "baud", "9600")                                         
 asynSetOption("L0", -1, "bits", "8")                                            
 asynSetOption("L0", -1, "parity", "none")                                       

--- a/JULABO/iocBoot/iocJULABO-IOC-01/st.cmd
+++ b/JULABO/iocBoot/iocJULABO-IOC-01/st.cmd
@@ -11,7 +11,6 @@ errlogInit2(65536, 256)
 cd ${TOP}
 
 epicsEnvSet "STREAM_PROTOCOL_PATH" "$(JULABO)/julaboApp/protocol"
-epicsEnvSet "TTY" "$(TTY=COM17)"
 
 ## Register all support components
 dbLoadDatabase "dbd/JULABO-IOC-01.dbd"
@@ -20,7 +19,7 @@ JULABO_IOC_01_registerRecordDeviceDriver pdbbase
 ##ISIS## Run IOC initialisation 
 < $(IOCSTARTUP)/init.cmd
 
-drvAsynSerialPortConfigure("L0", "$(TTY)", 0, 0, 0, 0)
+drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
 asynSetOption("L0", -1, "baud", "4800")
 asynSetOption("L0", -1, "bits", "7")
 asynSetOption("L0", -1, "parity", "even")

--- a/JULABO/iocBoot/iocJULABO-IOC-02/st.cmd
+++ b/JULABO/iocBoot/iocJULABO-IOC-02/st.cmd
@@ -11,7 +11,6 @@ errlogInit2(65536, 256)
 cd ${TOP}
 
 epicsEnvSet "STREAM_PROTOCOL_PATH" "$(JULABO)/julaboApp/protocol"
-epicsEnvSet "TTY" "$(TTY=COM18)"
 
 ## Register all support components
 dbLoadDatabase "dbd/JULABO-IOC-02.dbd"
@@ -20,7 +19,7 @@ JULABO_IOC_02_registerRecordDeviceDriver pdbbase
 ##ISIS## Run IOC initialisation 
 < $(IOCSTARTUP)/init.cmd
 
-drvAsynSerialPortConfigure("L0", "$(TTY)", 0, 0, 0, 0)
+drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
 asynSetOption("L0", -1, "baud", "4800")
 asynSetOption("L0", -1, "bits", "7")
 asynSetOption("L0", -1, "parity", "even")

--- a/KEPCO/iocBoot/iocKEPCO-IOC-01/st.cmd
+++ b/KEPCO/iocBoot/iocKEPCO-IOC-01/st.cmd
@@ -6,7 +6,6 @@
 < envPaths
 
 epicsEnvSet "STREAM_PROTOCOL_PATH" "$(KEPCO)/kepcoApp/protocol"
-epicsEnvSet "TTY" "$(TTY=COM19)"
 
 cd ${TOP}
 
@@ -16,7 +15,7 @@ KEPCO_IOC_01_registerRecordDeviceDriver pdbbase
 
 < $(IOCSTARTUP)/init.cmd
 
-drvAsynSerialPortConfigure("L0", "$(TTY)", 0, 0, 0, 0)
+drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
 asynSetOption("L0", -1, "baud", "9600")
 asynSetOption("L0", -1, "bits", "8")
 asynSetOption("L0", -1, "parity", "none")

--- a/KEPCO/iocBoot/iocKEPCO-IOC-02/st.cmd
+++ b/KEPCO/iocBoot/iocKEPCO-IOC-02/st.cmd
@@ -6,7 +6,6 @@
 < envPaths
 
 epicsEnvSet "STREAM_PROTOCOL_PATH" "$(KEPCO)/kepcoApp/protocol"
-epicsEnvSet "TTY" "$(TTY=\\\\\\\\.\\\\COM19)"
 
 cd ${TOP}
 
@@ -16,7 +15,7 @@ KEPCO_IOC_02_registerRecordDeviceDriver pdbbase
 
 < $(IOCSTARTUP)/init.cmd
 
-drvAsynSerialPortConfigure("L0", "$(TTY)", 0, 0, 0, 0)
+drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
 asynSetOption("L0", -1, "baud", "9600")
 asynSetOption("L0", -1, "bits", "8")
 asynSetOption("L0", -1, "parity", "none")

--- a/LAKESHORE218/iocBoot/iocLakeshore218-IOC-01/st.cmd
+++ b/LAKESHORE218/iocBoot/iocLakeshore218-IOC-01/st.cmd
@@ -8,7 +8,7 @@ errlogInit2(65536, 256)
 
 < envPaths
 
-epicsEnvSet "TTY" "$(TTY=\\\\\\\\.\\\\COM4)"                                   
+epicsEnvSet "TTY" "$(PORT)"                                   
 
 cd ${TOP}
 

--- a/LAKESHORE218/iocBoot/iocLakeshore218-IOC-02/st.cmd
+++ b/LAKESHORE218/iocBoot/iocLakeshore218-IOC-02/st.cmd
@@ -8,7 +8,7 @@ errlogInit2(65536, 256)
 
 < envPaths
 
-epicsEnvSet "TTY" "$(TTY=\\\\\\\\.\\\\COM5)"                                   
+epicsEnvSet "TTY" "$(PORT)"                                   
 
 cd ${TOP}
 

--- a/SPINFLIPPER306015/iocBoot/iocSPINFLIPPER-IOC-01/st.cmd
+++ b/SPINFLIPPER306015/iocBoot/iocSPINFLIPPER-IOC-01/st.cmd
@@ -11,7 +11,6 @@ errlogInit2(65536, 256)
 cd ${TOP}
 
 epicsEnvSet "STREAM_PROTOCOL_PATH" "$(TOP)/SPINFLIPPER-IOC-01App/protocol"
-epicsEnvSet "TTY" "$(TTY=COM19)"
 
 ## Register all support components
 dbLoadDatabase "dbd/SPINFLIPPER-IOC-01.dbd"
@@ -20,7 +19,7 @@ SPINFLIPPER_IOC_01_registerRecordDeviceDriver pdbbase
 ##ISIS## Run IOC initialisation 
 < $(IOCSTARTUP)/init.cmd
 
-drvAsynSerialPortConfigure("L0", "$(TTY)", 0, 0, 0, 0)
+drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
 asynSetOption("L0", -1, "baud", "9600")
 asynSetOption("L0", -1, "bits", "8")
 asynSetOption("L0", -1, "parity", "none")

--- a/TEKDMM40X0/iocBoot/iocTEKDMM4040-IOC-01/st.cmd
+++ b/TEKDMM40X0/iocBoot/iocTEKDMM4040-IOC-01/st.cmd
@@ -9,7 +9,6 @@ errlogInit2(65536, 256)
 < envPaths
 
 epicsEnvSet "STREAM_PROTOCOL_PATH" "$(TEKDMM40X0)/DMM40X0Sup"
-epicsEnvSet "TTY" "$(TTY=\\\\\\\\.\\\\COM19)"
 
 cd ${TOP}
 
@@ -20,7 +19,7 @@ TEKDMM4040_IOC_01_registerRecordDeviceDriver pdbbase
 ##ISIS## Run IOC initialisation 
 < $(IOCSTARTUP)/init.cmd
 
-drvAsynSerialPortConfigure("L0", "$(TTY)", 0, 0, 0, 0)
+drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
 asynSetOption("L0", -1, "baud", "9600")
 asynSetOption("L0", -1, "bits", "8")
 asynSetOption("L0", -1, "parity", "none")

--- a/TPG300/iocBoot/iocTPG300-IOC-01/st.cmd
+++ b/TPG300/iocBoot/iocTPG300-IOC-01/st.cmd
@@ -8,8 +8,7 @@ errlogInit2(65536, 256)
 
 < envPaths
 
-epicsEnvSet "STREAM_PROTOCOL_PATH" "$(TPG300)/TPG300Sup"
-#epicsEnvSet "TTY" "$(TTY=\\\\\\\\.\\\\COM13)"                                   
+epicsEnvSet "STREAM_PROTOCOL_PATH" "$(TPG300)/TPG300Sup"                                  
 
 cd ${TOP}
 
@@ -20,7 +19,7 @@ TPG300_IOC_01_registerRecordDeviceDriver pdbbase
 ##ISIS## Run IOC initialisation 
 < $(IOCSTARTUP)/init.cmd
 
-drvAsynSerialPortConfigure("L0", "$(TTY)", 0, 0, 0, 0)
+drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
 asynSetOption("L0", -1, "baud", "9600")
 asynSetOption("L0", -1, "bits", "8")
 asynSetOption("L0", -1, "parity", "none")

--- a/TPG300/iocBoot/iocTPG300-IOC-02/st.cmd
+++ b/TPG300/iocBoot/iocTPG300-IOC-02/st.cmd
@@ -9,7 +9,6 @@ errlogInit2(65536, 256)
 < envPaths
 
 epicsEnvSet "STREAM_PROTOCOL_PATH" "$(TPG300)/TPG300Sup"
-#epicsEnvSet "TTY" "$(TTY=\\\\\\\\.\\\\COM20)"  
 
 cd ${TOP}
 
@@ -20,7 +19,7 @@ TPG300_IOC_02_registerRecordDeviceDriver pdbbase
 ##ISIS## Run IOC initialisation 
 < $(IOCSTARTUP)/init.cmd
 
-drvAsynSerialPortConfigure("L0", "$(TTY)", 0, 0, 0, 0)
+drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
 asynSetOption("L0", -1, "baud", "9600")
 asynSetOption("L0", -1, "bits", "8")
 asynSetOption("L0", -1, "parity", "none")

--- a/TPG300/iocBoot/iocTPG300-IOC-03/st.cmd
+++ b/TPG300/iocBoot/iocTPG300-IOC-03/st.cmd
@@ -9,7 +9,6 @@ errlogInit2(65536, 256)
 < envPaths
 
 epicsEnvSet "STREAM_PROTOCOL_PATH" "$(TPG300)/TPG300Sup"
-#epicsEnvSet "TTY" "$(TTY=\\\\\\\\.\\\\COM20)"  
 
 cd ${TOP}
 
@@ -20,7 +19,7 @@ TPG300_IOC_02_registerRecordDeviceDriver pdbbase
 ##ISIS## Run IOC initialisation 
 < $(IOCSTARTUP)/init.cmd
 
-drvAsynSerialPortConfigure("L0", "$(TTY)", 0, 0, 0, 0)
+drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
 asynSetOption("L0", -1, "baud", "9600")
 asynSetOption("L0", -1, "bits", "8")
 asynSetOption("L0", -1, "parity", "none")

--- a/TTIEX355P/iocBoot/iocTTIEX355P-IOC-01/st.cmd
+++ b/TTIEX355P/iocBoot/iocTTIEX355P-IOC-01/st.cmd
@@ -9,7 +9,6 @@ errlogInit2(65536, 256)
 < envPaths
 
 epicsEnvSet "STREAM_PROTOCOL_PATH" "$(TTIEX355P)/ttiEX355PApp/protocol"
-epicsEnvSet "TTY" "$(TTY=\\\\\\\\.\\\\COM18)"
 
 cd ${TOP}
 
@@ -20,7 +19,7 @@ TTIEX355P_IOC_01_registerRecordDeviceDriver pdbbase
 ##ISIS## Run IOC initialisation 
 < $(IOCSTARTUP)/init.cmd
 
-drvAsynSerialPortConfigure("L0", "$(TTY)", 0, 0, 0, 0)
+drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
 asynSetOption("L0", -1, "baud", "9600")
 asynSetOption("L0", -1, "bits", "8")
 asynSetOption("L0", -1, "parity", "none")

--- a/TTIEX355P/iocBoot/iocTTIEX355P-IOC-02/st.cmd
+++ b/TTIEX355P/iocBoot/iocTTIEX355P-IOC-02/st.cmd
@@ -9,7 +9,6 @@ errlogInit2(65536, 256)
 < envPaths
 
 epicsEnvSet "STREAM_PROTOCOL_PATH" "$(TTIEX355P)/ttiEX355PApp/protocol"
-epicsEnvSet "TTY" "$(TTY=\\\\\\\\.\\\\COM19)"
 
 cd ${TOP}
 
@@ -20,7 +19,7 @@ TTIEX355P_IOC_02_registerRecordDeviceDriver pdbbase
 ##ISIS## Run IOC initialisation 
 < $(IOCSTARTUP)/init.cmd
 
-drvAsynSerialPortConfigure("L0", "$(TTY)", 0, 0, 0, 0)
+drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
 asynSetOption("L0", -1, "baud", "9600")
 asynSetOption("L0", -1, "bits", "8")
 asynSetOption("L0", -1, "parity", "none")


### PR DESCRIPTION
All COM ports are now available as Macros, for LARMOR these macros have been added to globals.txt so that no change at all should be seen.

Without hardware there is no way to test this, but this system of macros has been used and is tested.

Have standardised to PORT as the macro name, as it is not that hard to change when we have decided on final names, and at least if they are standard, and the majority of values being set externally were already using PORT.
Have also deleted anywhere where a COM value is set in an st.cmd, whether it was commented out or not, just for clarity.