### PR TITLE
Ticket979 imat attenuator

### DIFF
--- a/FINS/FINS-IOC-01App/Db/Makefile
+++ b/FINS/FINS-IOC-01App/Db/Makefile
@@ -12,6 +12,7 @@ include $(TOP)/configure/CONFIG
 # databases, templates, substitutions like this
 DB += larmor-air.db
 DB += wish-vacuum.db
+DB += imat-attn.db
 
 #----------------------------------------------------
 # If <anyname>.db template is not named <anyname>*.template add

--- a/FINS/FINS-IOC-01App/Db/imat-attn.substitutions
+++ b/FINS/FINS-IOC-01App/Db/imat-attn.substitutions
@@ -1,0 +1,14 @@
+# Control Word: W510       (This word will self-reset to 0)
+#                 W510.00               set true to request Sample Attenuator to Open
+#                 W510.01               set true to request Sample Attenuator to Close
+#
+#Status Word: W511
+#                 W511.00               true when Sample Attenuator requested to open via HMI or EPICS
+#                 W511.01               true when Sample Attenuator is OPEN
+#                 W511.02               true when Sample Attenuator is CLOSED
+#
+# 
+
+file "$(TOP)/FINS-IOC-01App/Db/imat-attn.template" {
+	{ P=\$(P), Q=\$(Q) }
+}

--- a/FINS/FINS-IOC-01App/Db/imat-attn.template
+++ b/FINS/FINS-IOC-01App/Db/imat-attn.template
@@ -35,7 +35,7 @@ record(bi, "$(P)$(Q)CLOSED")
     field(SIML, "$(P)$(Q)SIM")
     field(SIOL, "$(P)$(Q)SIM:CLOSE")
 }
-record(bo, "$(P)$(Q)OPEN_SP")
+record(bo, "$(P)$(Q)OPEN:SP")
 {
 	field(DESC, "Open Attenuator")
 	field(DTYP, "asynInt32")
@@ -45,7 +45,7 @@ record(bo, "$(P)$(Q)OPEN_SP")
     field(SIML, "$(P)$(Q)SIM")
     field(SIOL, "$(P)$(Q)SIM:OPEN")
 }
-record(bo, "$(P)$(Q)CLOSE_SP")
+record(bo, "$(P)$(Q)CLOSE:SP")
 {
 	field(DESC, "Close Attenuator")
 	field(DTYP, "asynInt32")

--- a/FINS/FINS-IOC-01App/Db/imat-attn.template
+++ b/FINS/FINS-IOC-01App/Db/imat-attn.template
@@ -1,0 +1,89 @@
+record(longin, "$(P)$(Q)STATUS")
+{
+    field(DESC, "Attenuator Status")
+	field(DTYP, "asynInt32")
+	field(INP,  "@asyn(PLC, 511, 5.0) FINS_WR_READ")
+	field(SCAN, "1 second")
+    info(INTEREST, "HIGH")
+	info(alarm, "Attenuator")
+    field(SIML, "$(P)$(Q)SIM")
+    field(SIOL, "$(P)$(Q)SIM:STATUS")
+}
+record(bi, "$(P)$(Q)OPEN")
+{
+    field(DESC, "Attenuator Open")
+	field(DTYP, "asynInt32")
+	field(ZNAM, "0")
+    field(ONAM, "1")
+	field(INP,  "@asyn(PLC, 511, 5.0) FINS_WR_READ_B1")
+	field(SCAN, "1 second")
+    info(INTEREST, "HIGH")
+	info(alarm, "Attenuator Open")
+    field(SIML, "$(P)$(Q)SIM")
+    field(SIOL, "$(P)$(Q)SIM:OPEN")
+}
+record(bi, "$(P)$(Q)CLOSED")
+{
+    field(DESC, "Attenuator Closed")
+	field(DTYP, "asynInt32")
+	field(ZNAM, "0")
+    field(ONAM, "1")
+	field(INP,  "@asyn(PLC, 511, 5.0) FINS_WR_READ_B2")
+	field(SCAN, "1 second")
+    info(INTEREST, "HIGH")
+	info(alarm, "Attenuator Open")
+    field(SIML, "$(P)$(Q)SIM")
+    field(SIOL, "$(P)$(Q)SIM:CLOSE")
+}
+record(bo, "$(P)$(Q)OPEN_SP")
+{
+	field(DESC, "Open Attenuator")
+	field(DTYP, "asynInt32")
+	field(ZNAM, "...")
+    field(ONAM, "OPEN")
+	field(OUT,  "@asyn(PLC, 510, 5.0) FINS_WR_WRITE_B0")
+    field(SIML, "$(P)$(Q)SIM")
+    field(SIOL, "$(P)$(Q)SIM:OPEN")
+}
+record(bo, "$(P)$(Q)CLOSE_SP")
+{
+	field(DESC, "Close Attenuator")
+	field(DTYP, "asynInt32")
+	field(ZNAM, "...")
+    field(ONAM, "CLOSE")
+	field(OUT,  "@asyn(PLC, 510, 5.0) FINS_WR_WRITE_B1")
+    field(SIML, "$(P)$(Q)SIM")
+    field(SIOL, "$(P)$(Q)SIM:CLOSE")
+}
+
+
+### SIMULATION RECORDS ###
+
+record(bo, "$(P)$(Q)SIM")
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+    field(ZNAM, "NO")
+    field(ONAM, "YES")
+}
+
+record(bi, "$(P)$(Q)SIM:CLOSE")
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+	field(VAL, "1")
+}
+
+record(bi, "$(P)$(Q)SIM:OPEN")
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+	field(VAL, "1")
+}
+
+record(longin, "$(P)$(Q)SIM:STATUS")
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+	field(VAL, "1")
+}


### PR DESCRIPTION
Relates to https://github.com/ISISComputingGroup/IBEX/issues/979

Without access to the PLC, this can only be tested that the db file is created from the template and substitutions.

It may be possible to test this with the IOC, in which case an appropriate st.cmd will need to be created within the settings/configurations directory loading the imat-attn.db, and the appropriate IP address would need to be added as a macro somewhere (I recommend globals.txt). For that IP address, either contact Gareth/Kathryn for the information, or look at IMAT.
When testing it, merely monitor the OPEN and CLOSED PVs, and set the OPEN:SP and CLOSED:SP to open and close the attenuator as expected.