### PR TITLE
Adding the config.xml to make the macros available in the GUI

### DIFF
--- a/AG3631A/iocBoot/iocAG3631A-IOC-01/config.xml
+++ b/AG3631A/iocBoot/iocAG3631A-IOC-01/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<config_part>
+<macros>
+<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" />
+</macros>
+</config_part>
+</ioc_config>

--- a/CONEXAGP/iocBoot/iocCONEXAGP-IOC-01/config.xml
+++ b/CONEXAGP/iocBoot/iocCONEXAGP-IOC-01/config.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<config_part>
+<macros>
+<macro name="PORT1" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD1" pattern="^[0-9]+$" description="port baud rate (default: 57600)" />
+<macro name="PORT2" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD2" pattern="^[0-9]+$" description="port baud rate (default: 57600)" />
+<macro name="PORT3" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD3" pattern="^[0-9]+$" description="port baud rate (default: 57600)" />
+<macro name="PORT4" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD4" pattern="^[0-9]+$" description="port baud rate (default: 57600)" />
+<macro name="PORT5" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD5" pattern="^[0-9]+$" description="port baud rate (default: 57600)" />
+<macro name="PORT6" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD6" pattern="^[0-9]+$" description="port baud rate (default: 57600)" />
+<macro name="PORT7" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD7" pattern="^[0-9]+$" description="port baud rate (default: 57600)" />
+<macro name="PORT8" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD8" pattern="^[0-9]+$" description="port baud rate (default: 57600)" />
+</macros>
+</config_part>
+</ioc_config>

--- a/DELFTBPMAG/iocBoot/iocDELFTBPMAG-IOC-01/config.xml
+++ b/DELFTBPMAG/iocBoot/iocDELFTBPMAG-IOC-01/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<config_part>
+<macros>
+<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" />
+</macros>
+</config_part>
+</ioc_config>

--- a/DELFTBPMAG/iocBoot/iocDELFTBPMAG-IOC-02/config.xml
+++ b/DELFTBPMAG/iocBoot/iocDELFTBPMAG-IOC-02/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDELFTBPMAG-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-01/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-01/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<config_part>
+<macros>
+<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" />
+</macros>
+</config_part>
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-02/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-02/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-03/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-03/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-04/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-04/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-05/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-05/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-06/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-06/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-07/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-07/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-08/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-08/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-09/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-09/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/EUROTHERM/iocBoot/iocEUROTHERM-IOC-01/config.xml
+++ b/EUROTHERM/iocBoot/iocEUROTHERM-IOC-01/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<config_part>
+<macros>
+<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" />
+</macros>
+</config_part>
+</ioc_config>

--- a/EUROTHERM/iocBoot/iocEUROTHERM-IOC-02/config.xml
+++ b/EUROTHERM/iocBoot/iocEUROTHERM-IOC-02/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocEUROTHERM-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/FINS/FINS-IOC-01App/Db/imat-attn-header.template
+++ b/FINS/FINS-IOC-01App/Db/imat-attn-header.template
@@ -1,0 +1,10 @@
+# Control Word: W510       (This word will self-reset to 0)
+#                 W510.00               set true to request Sample Attenuator to Open
+#                 W510.01               set true to request Sample Attenuator to Close
+#
+#Status Word: W511
+#                 W511.00               true when Sample Attenuator requested to open via HMI or EPICS
+#                 W511.01               true when Sample Attenuator is OPEN
+#                 W511.02               true when Sample Attenuator is CLOSED
+#
+# 

--- a/HAMEG8123/iocBoot/iocHAMEG8123-IOC-01/config.xml
+++ b/HAMEG8123/iocBoot/iocHAMEG8123-IOC-01/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<config_part>
+<macros>
+<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" />
+</macros>
+</config_part>
+</ioc_config>

--- a/HAMEG8123/iocBoot/iocHAMEG8123-IOC-02/config.xml
+++ b/HAMEG8123/iocBoot/iocHAMEG8123-IOC-02/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocHAMEG8123-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/JULABO/iocBoot/iocJULABO-IOC-01/config.xml
+++ b/JULABO/iocBoot/iocJULABO-IOC-01/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<config_part>
+<macros>
+<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" />
+</macros>
+</config_part>
+</ioc_config>

--- a/JULABO/iocBoot/iocJULABO-IOC-02/config.xml
+++ b/JULABO/iocBoot/iocJULABO-IOC-02/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocJULABO-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/KEPCO/iocBoot/iocKEPCO-IOC-01/config.xml
+++ b/KEPCO/iocBoot/iocKEPCO-IOC-01/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<config_part>
+<macros>
+<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" />
+</macros>
+</config_part>
+</ioc_config>

--- a/KEPCO/iocBoot/iocKEPCO-IOC-02/config.xml
+++ b/KEPCO/iocBoot/iocKEPCO-IOC-02/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocKEPCO-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/LAKESHORE218/iocBoot/iocLakeshore218-IOC-01/config.xml
+++ b/LAKESHORE218/iocBoot/iocLakeshore218-IOC-01/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<config_part>
+<macros>
+<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" />
+</macros>
+</config_part>
+</ioc_config>

--- a/LAKESHORE218/iocBoot/iocLakeshore218-IOC-02/config.xml
+++ b/LAKESHORE218/iocBoot/iocLakeshore218-IOC-02/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocLakeshore218-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/LINKAM95/iocBoot/iocLINKAM95-IOC-01/config.xml
+++ b/LINKAM95/iocBoot/iocLINKAM95-IOC-01/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<config_part>
+<macros>
+<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" />
+</macros>
+</config_part>
+</ioc_config>

--- a/LINKAM95/iocBoot/iocLINKAM95-IOC-02/config.xml
+++ b/LINKAM95/iocBoot/iocLINKAM95-IOC-02/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocLINKAM95-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/PIMOT/iocBoot/iocPIMOT-IOC-01/config.xml
+++ b/PIMOT/iocBoot/iocPIMOT-IOC-01/config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<config_part>
+<macros>
+<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD" pattern="^[0-9]+$" description="port baud rate (default: 38400)" />
+</macros>
+</config_part>
+</ioc_config>

--- a/PIMOT/iocBoot/iocPIMOT-IOC-01/config.xml
+++ b/PIMOT/iocBoot/iocPIMOT-IOC-01/config.xml
@@ -2,8 +2,8 @@
 <ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
 <config_part>
 <macros>
-<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" />
-<macro name="BAUD" pattern="^[0-9]+$" description="port baud rate (default: 38400)" />
+<macro name="PORT1" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD1" pattern="^[0-9]+$" description="port baud rate (default: 38400)" />
 </macros>
 </config_part>
 </ioc_config>

--- a/SMC100/iocBoot/iocSMC100-IOC-01/config.xml
+++ b/SMC100/iocBoot/iocSMC100-IOC-01/config.xml
@@ -2,7 +2,22 @@
 <ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
 <config_part>
 <macros>
-<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="PORT1" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD1" pattern="^[0-9]+$" description="port baud rate (default: 57600)" />
+<macro name="PORT2" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD2" pattern="^[0-9]+$" description="port baud rate (default: 57600)" />
+<macro name="PORT3" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD3" pattern="^[0-9]+$" description="port baud rate (default: 57600)" />
+<macro name="PORT4" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD4" pattern="^[0-9]+$" description="port baud rate (default: 57600)" />
+<macro name="PORT5" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD5" pattern="^[0-9]+$" description="port baud rate (default: 57600)" />
+<macro name="PORT6" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD6" pattern="^[0-9]+$" description="port baud rate (default: 57600)" />
+<macro name="PORT7" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD7" pattern="^[0-9]+$" description="port baud rate (default: 57600)" />
+<macro name="PORT8" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD8" pattern="^[0-9]+$" description="port baud rate (default: 57600)" />
 </macros>
 </config_part>
 </ioc_config>

--- a/SMC100/iocBoot/iocSMC100-IOC-01/config.xml
+++ b/SMC100/iocBoot/iocSMC100-IOC-01/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<config_part>
+<macros>
+<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" />
+</macros>
+</config_part>
+</ioc_config>

--- a/SPINFLIPPER306015/iocBoot/iocSPINFLIPPER-IOC-01/config.xml
+++ b/SPINFLIPPER306015/iocBoot/iocSPINFLIPPER-IOC-01/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<config_part>
+<macros>
+<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" />
+</macros>
+</config_part>
+</ioc_config>

--- a/TDK_LAMBDA_GENESYS/iocBoot/iocGENESYS-IOC-01/config.xml
+++ b/TDK_LAMBDA_GENESYS/iocBoot/iocGENESYS-IOC-01/config.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<config_part>
+<macros>
+<macro name="PORT1" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD1" pattern="^[0-9]+$" description="port baud rate (default: 9600)" />
+<macro name="BITS1" pattern="^[7-8]$" description="port data bits (default: 8)" />
+<macro name="PARITY1" pattern="^(even|odd|none)$" description="port parity (default: none)" />
+<macro name="STOP1" pattern="^[0-2]$" description="port stop bits (default: 1)" />
+<macro name="OEOS1" pattern="^.*$" description="output end of line separator (default: \\r\\n)" />
+<macro name="IEOS1" pattern="^.*$" description="input end of line separator (default: \\r\\n)" />
+
+<macro name="PORT2" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD2" pattern="^[0-9]+$" description="port baud rate (default: 9600)" />
+<macro name="BITS2" pattern="^[7-8]$" description="port data bits (default: 8)" />
+<macro name="PARITY2" pattern="^(even|odd|none)$" description="port parity (default: none)" />
+<macro name="STOP2" pattern="^[0-2]$" description="port stop bits (default: 1)" />
+<macro name="OEOS2" pattern="^.*$" description="output end of line separator (default: \\r\\n)" />
+<macro name="IEOS2" pattern="^.*$" description="input end of line separator (default: \\r\\n)" />
+<macro name="PORT3" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD3" pattern="^[0-9]+$" description="port baud rate (default: 9600)" />
+<macro name="BITS3" pattern="^[7-8]$" description="port data bits (default: 8)" />
+<macro name="PARITY3" pattern="^(even|odd|none)$" description="port parity (default: none)" />
+<macro name="STOP3" pattern="^[0-2]$" description="port stop bits (default: 1)" />
+<macro name="OEOS3" pattern="^.*$" description="output end of line separator (default: \\r\\n)" />
+<macro name="IEOS3" pattern="^.*$" description="input end of line separator (default: \\r\\n)" />
+<macro name="PORT4" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD4" pattern="^[0-9]+$" description="port baud rate (default: 9600)" />
+<macro name="BITS4" pattern="^[7-8]$" description="port data bits (default: 8)" />
+<macro name="PARITY4" pattern="^(even|odd|none)$" description="port parity (default: none)" />
+<macro name="STOP4" pattern="^[0-2]$" description="port stop bits (default: 1)" />
+<macro name="OEOS4" pattern="^.*$" description="output end of line separator (default: \\r\\n)" />
+<macro name="IEOS4" pattern="^.*$" description="input end of line separator (default: \\r\\n)" />
+<macro name="PORT5" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD5" pattern="^[0-9]+$" description="port baud rate (default: 9600)" />
+<macro name="BITS5" pattern="^[7-8]$" description="port data bits (default: 8)" />
+<macro name="PARITY5" pattern="^(even|odd|none)$" description="port parity (default: none)" />
+<macro name="STOP5" pattern="^[0-2]$" description="port stop bits (default: 1)" />
+<macro name="OEOS5" pattern="^.*$" description="output end of line separator (default: \\r\\n)" />
+<macro name="IEOS5" pattern="^.*$" description="input end of line separator (default: \\r\\n)" />
+<macro name="PORT6" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD6" pattern="^[0-9]+$" description="port baud rate (default: 9600)" />
+<macro name="BITS6" pattern="^[7-8]$" description="port data bits (default: 8)" />
+<macro name="PARITY6" pattern="^(even|odd|none)$" description="port parity (default: none)" />
+<macro name="STOP6" pattern="^[0-2]$" description="port stop bits (default: 1)" />
+<macro name="OEOS6" pattern="^.*$" description="output end of line separator (default: \\r\\n)" />
+<macro name="IEOS6" pattern="^.*$" description="input end of line separator (default: \\r\\n)" />
+<macro name="PORT7" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD7" pattern="^[0-9]+$" description="port baud rate (default: 9600)" />
+<macro name="BITS7" pattern="^[7-8]$" description="port data bits (default: 8)" />
+<macro name="PARITY7" pattern="^(even|odd|none)$" description="port parity (default: none)" />
+<macro name="STOP7" pattern="^[0-2]$" description="port stop bits (default: 1)" />
+<macro name="OEOS7" pattern="^.*$" description="output end of line separator (default: \\r\\n)" />
+<macro name="IEOS7" pattern="^.*$" description="input end of line separator (default: \\r\\n)" />
+<macro name="PORT8" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD8" pattern="^[0-9]+$" description="port baud rate (default: 9600)" />
+<macro name="BITS8" pattern="^[7-8]$" description="port data bits (default: 8)" />
+<macro name="PARITY8" pattern="^(even|odd|none)$" description="port parity (default: none)" />
+<macro name="STOP8" pattern="^[0-2]$" description="port stop bits (default: 1)" />
+<macro name="OEOS8" pattern="^.*$" description="output end of line separator (default: \\r\\n)" />
+<macro name="IEOS8" pattern="^.*$" description="input end of line separator (default: \\r\\n)" />
+<macro name="PORT9" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD9" pattern="^[0-9]+$" description="port baud rate (default: 9600)" />
+<macro name="BITS9" pattern="^[7-8]$" description="port data bits (default: 8)" />
+<macro name="PARITY9" pattern="^(even|odd|none)$" description="port parity (default: none)" />
+<macro name="STOP9" pattern="^[0-2]$" description="port stop bits (default: 1)" />
+<macro name="OEOS9" pattern="^.*$" description="output end of line separator (default: \\r\\n)" />
+<macro name="IEOS9" pattern="^.*$" description="input end of line separator (default: \\r\\n)" />
+<macro name="PORT10" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="BAUD10" pattern="^[0-9]+$" description="port baud rate (default: 9600)" />
+<macro name="BITS10" pattern="^[7-8]$" description="port data bits (default: 8)" />
+<macro name="PARITY10" pattern="^(even|odd|none)$" description="port parity (default: none)" />
+<macro name="STOP10" pattern="^[0-2]$" description="port stop bits (default: 1)" />
+<macro name="OEOS10" pattern="^.*$" description="output end of line separator (default: \\r\\n)" />
+<macro name="IEOS10" pattern="^.*$" description="input end of line separator (default: \\r\\n)" />
+</macros>
+</config_part>
+</ioc_config>

--- a/TDK_LAMBDA_GENESYS/iocBoot/iocGENESYS-IOC-02/config.xml
+++ b/TDK_LAMBDA_GENESYS/iocBoot/iocGENESYS-IOC-02/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocGENESYS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/TDK_LAMBDA_GENESYS/iocBoot/iocGENESYS-IOC-03/config.xml
+++ b/TDK_LAMBDA_GENESYS/iocBoot/iocGENESYS-IOC-03/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocGENESYS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/TDK_LAMBDA_GENESYS/iocBoot/iocGENESYS-IOC-04/config.xml
+++ b/TDK_LAMBDA_GENESYS/iocBoot/iocGENESYS-IOC-04/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocGENESYS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/TEKDMM40X0/iocBoot/iocTEKDMM4040-IOC-01/config.xml
+++ b/TEKDMM40X0/iocBoot/iocTEKDMM4040-IOC-01/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<config_part>
+<macros>
+<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" />
+</macros>
+</config_part>
+</ioc_config>

--- a/TPG300/iocBoot/iocTPG300-IOC-01/config.xml
+++ b/TPG300/iocBoot/iocTPG300-IOC-01/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<config_part>
+<macros>
+<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" />
+</macros>
+</config_part>
+</ioc_config>

--- a/TPG300/iocBoot/iocTPG300-IOC-02/config.xml
+++ b/TPG300/iocBoot/iocTPG300-IOC-02/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocTPG300-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/TPG300/iocBoot/iocTPG300-IOC-03/config.xml
+++ b/TPG300/iocBoot/iocTPG300-IOC-03/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocTPG300-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/TTIEX355P/iocBoot/iocTTIEX355P-IOC-01/config.xml
+++ b/TTIEX355P/iocBoot/iocTTIEX355P-IOC-01/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<config_part>
+<macros>
+<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" />
+</macros>
+</config_part>
+</ioc_config>

--- a/TTIEX355P/iocBoot/iocTTIEX355P-IOC-02/config.xml
+++ b/TTIEX355P/iocBoot/iocTTIEX355P-IOC-02/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocTTIEX355P-IOC-01/config.xml"  />
+
+</ioc_config>


### PR DESCRIPTION
Tidying up for https://github.com/ISISComputingGroup/IBEX/issues/1220

Focused again on just adding the COM ports, so that the macros are visible to the GUI

To test:
Check out this branch, run `make iocstartups` at your base EPICS level, look at the macros tab in the GUI, and for the edited IOCs you should see macros, typically just the COM port, but others in a few cases.