### PR TITLE
Capture change to ensure LARMOR can be updated

### DIFF
--- a/DFKPS/DFKPS-IOC-01App/Db/DFKPS.db
+++ b/DFKPS/DFKPS-IOC-01App/Db/DFKPS.db
@@ -229,6 +229,7 @@ record(ao, "$(P)SETIRAW")
     field(SDIS, "$(P)DISABLE")
     field(EGU, "")
 }
+alias("$(P)SETIRAW", "$(P)SETIRAW:SP")
 
 record(mbbo, "$(P)FIELD:UNIT") {
     field(DESC, "Field Unit to Display")


### PR DESCRIPTION
Relates to https://github.com/ISISComputingGroup/IBEX/issues/1313

There was a need for a block that meant and alias was required for the SETIRAW PV, this was done and tested on the fly on LARMOR, this is already on the live system so doesn't need to be tested.