### PR TITLE
Ticket1274 time channel settings in dae tab (IOC)

### DIFF
--- a/ISISDAE/iocBoot/iocISISDAE-IOC-01/st.cmd
+++ b/ISISDAE/iocBoot/iocISISDAE-IOC-01/st.cmd
@@ -64,7 +64,7 @@ iocInit
 #seq sncxxx,"user=faa59Host"
 
 ##ISIS## Stuff that needs to be done after iocInit is called e.g. sequence programs 
-#< $(IOCSTARTUP)/postiocinit.cmd
+< $(IOCSTARTUP)/postiocinit.cmd
 
 # Save motor positions every 5 seconds
 create_monitor_set("$(IOCNAME)_positions.req", 5, "P=$(MYPVPREFIX)DAE:")

--- a/ISISDAE/iocBoot/iocISISDAE-IOC-01/st.cmd
+++ b/ISISDAE/iocBoot/iocISISDAE-IOC-01/st.cmd
@@ -15,6 +15,8 @@ epicsEnvSet "SPECTRA_DIR" "$(ICPCONFIGROOT)/tables"
 epicsEnvSet "SPECTRA_PATTERN" ".*spec.*"
 epicsEnvSet "PERIOD_DIR" "$(ICPCONFIGROOT)/tables"
 epicsEnvSet "PERIOD_PATTERN" ".*"
+epicsEnvSet "TCB_DIR" "$(ICPCONFIGROOT)/tcb"
+epicsEnvSet "TCB_PATTERN" ".*tcb.*"
 
 cd ${TOP}
 
@@ -42,6 +44,7 @@ FileListConfigure("WLIST", "$(WIRING_DIR)", "$(WIRING_PATTERN)", 1)
 FileListConfigure("DLIST", "$(DETECTOR_DIR)", "$(DETECTOR_PATTERN)", 1)
 FileListConfigure("SLIST", "$(SPECTRA_DIR)", "$(SPECTRA_PATTERN)", 1)
 FileListConfigure("PLIST", "$(PERIOD_DIR)", "$(PERIOD_PATTERN)", 1)
+FileListConfigure("TLIST", "$(TCB_DIR)", "$(TCB_PATTERN)", 1)
 
 ## Load record instances
 
@@ -49,7 +52,7 @@ FileListConfigure("PLIST", "$(PERIOD_DIR)", "$(PERIOD_PATTERN)", 1)
 < $(IOCSTARTUP)/dbload.cmd
 
 ## Load our record instances
-dbLoadRecords("$(ISISDAE)/db/isisdae.db","S=$(MYPVPREFIX), P=$(MYPVPREFIX)DAE:, WIRINGLIST=WLIST, DETECTORLIST=DLIST, SPECTRALIST=SLIST, PERIODLIST=PLIST")
+dbLoadRecords("$(ISISDAE)/db/isisdae.db","S=$(MYPVPREFIX), P=$(MYPVPREFIX)DAE:, WIRINGLIST=WLIST, DETECTORLIST=DLIST, SPECTRALIST=SLIST, PERIODLIST=PLIST, TCBLIST = TLIST")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd
@@ -61,7 +64,7 @@ iocInit
 #seq sncxxx,"user=faa59Host"
 
 ##ISIS## Stuff that needs to be done after iocInit is called e.g. sequence programs 
-< $(IOCSTARTUP)/postiocinit.cmd
+#< $(IOCSTARTUP)/postiocinit.cmd
 
 # Save motor positions every 5 seconds
 create_monitor_set("$(IOCNAME)_positions.req", 5, "P=$(MYPVPREFIX)DAE:")


### PR DESCRIPTION
https://github.com/ISISComputingGroup/IBEX/issues/1274

Added  macros for Time Channel Boundaries file paths, naming pattern etc. to ISISDAE IOC.
TCB files live in `Instrument/Settings//config/[Instrument Name]/configurations/tcb` and contain "tcb" in their filename.
