### PR TITLE
Ticket #1360: Small change to read PHASE SP

### DIFF
--- a/MK3CHOPPER/MK3CHOPPER-IOC-01App/src/mk3Driver.cpp
+++ b/MK3CHOPPER/MK3CHOPPER-IOC-01App/src/mk3Driver.cpp
@@ -111,6 +111,13 @@ asynStatus mk3Driver::readFloat64(asynUser *pasynUser, epicsFloat64 *value)
         *value = result;
         checkErrorCode(errCode);
     }
+    else if (function == P_NominalPhase)
+    {
+        unsigned int result;
+        errCode = m_interface->getNominalPhase(channel, &result);
+        *value = result;
+        checkErrorCode(errCode);
+    }
     else if (function == P_NominalPhaseError)
     {
         unsigned int result;


### PR DESCRIPTION
ISISComputingGroup/IBEX/issues/1360

Stay on master, open the st.cmd and change 0 to 1 in the following line to put into sim mode:

mk3DriverConfigure("MK3", "C:/MK3_Chopper.config", `1`)

start the IOC

caget %MYPVPREFIX%MK3CHOPPER_01:CH1:PHAS:SP

This probably will return 10 (I don't know why! Something to do with asyn holding a value from a different read?)

Change to this branch and rebuild then repeat the previous steps. The caget should return 100 (because that is what the simulator sets it to)