### PR TITLE
Add support for barndoors

### DIFF
--- a/GALIL/GALIL-IOC-01App/src/build.mak
+++ b/GALIL/GALIL-IOC-01App/src/build.mak
@@ -40,6 +40,9 @@ $(APPNAME)_DBD += motionSetPoints.dbd
 $(APPNAME)_DBD += sampleChanger.dbd 
 $(APPNAME)_DBD += stdSupport.dbd 
 $(APPNAME)_DBD += asubFunctions.dbd 
+## dbd for barndoors
+$(APPNAME)_DBD += cvtRecord.dbd
+
 
 # Add all the support libraries needed by this IOC
 ## ISIS standard libraries ##
@@ -63,6 +66,8 @@ $(APPNAME)_LIBS += busy asyn
 $(APPNAME)_LIBS += std
 $(APPNAME)_LIBS += asubFunctions
 $(APPNAME)_LIBS += TinyXML
+#libs for barndoors
+$(APPNAME)_LIBS += cvtRecord csmbase
 
 $(APPNAME)_LIBS += $(EPICS_BASE_IOC_LIBS)
 

--- a/GALIL/iocBoot/iocGALIL-IOC-01/barndoors.cmd
+++ b/GALIL/iocBoot/iocGALIL-IOC-01/barndoors.cmd
@@ -1,0 +1,1 @@
+< $(GALILCONFIG)/barndoors.cmd

--- a/GALIL/iocBoot/iocGALIL-IOC-01/st-common.cmd
+++ b/GALIL/iocBoot/iocGALIL-IOC-01/st-common.cmd
@@ -45,6 +45,9 @@ epicsEnvSet("GALILCONFIG","$(ICPCONFIGROOT)/galil")
 # configure jaws
 < jaws.cmd
 
+# configure barndoors
+< barndoors.cmd
+
 # configure axes
 < axes.cmd
 


### PR DESCRIPTION
### Description of work

Muon front end barn doors. See https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Barndoors-and-Momentum-Slits-on-MUON-Front-End for description.

Other pull requests:
  https://github.com/ISISComputingGroup/EPICS-barndoors/pull/1
  https://github.com/ISISComputingGroup/ibex_gui/pull/287
  https://github.com/ISISComputingGroup/EPICS/pull/31

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1388

### Acceptance criteria

1. Create the Gallil settings for the Muon front end (see release notes).
1. User can start a Galili_01 and it will start the barndoors and momentum slits records (if configured).
1. User can see a muon front end on a synoptic
1. Test gap for barndoors and momentum slits above the minimum (for barndoors) when set set motors to correct position as per calibration table (at end)
1. Given motor set to positions before the minimum then  gap is correctly reported
1. Given the position is before the minimum and user set a gap less than the set number then motor sets itself to relevant point after the minimum.

#### Calibration Table

|	Voltage	|	EMU 	|	MUSR	|	HIFI	|
| --- | --- | --- | --- | 
|	0	|	22.7	|	24.2	|	13.4	|
|	0.2	|	21.3	|	22.9	|	13	|
|	0.4	|	19.8	|	21.5	|	12.6	|
|	0.6	|	18.4	|	20	|	12	|
|	0.8	|	17	|	18.6	|	11.3	|
|	1	|	15.6	|	17.2	|	10.4	|
|	1.2	|	14.1	|	15.2	|	9.3	|
|	1.4	|	12.7	|	14.3	|	8	|
|	1.6	|	11.3	|	12.8	|	6.6	|
|	1.8	|	9.9	|	11.4	|	5.2	|
|	2	|	8.4	|	10	|	3.8	|
|	2.2	|	7	|	8.5	|	2.9	|
|	2.4	|	5.6	|	7.1	|	3.1	|
|	2.6	|	4.2	|	5.6	|	3.8	|
|	2.8	|	3.2	|	4.2	|	5	|
|	3	|	3.3	|	2.9	|	6.6	|
|	3.2	|	4	|	2.7	|	8.5	|
|	3.4	|	5.1	|	3.2	|	10.6	|
|	3.6	|	6.5	|	4.2	|	13.1	|
|	3.8	|	8.3	|	5.6	|	15.8	|
|	4	|	10.3	|	7.3	|	18.7	|
|	4.2	|	12.7	|	9.3	|	21.9	|
|	4.4	|	15.2	|	11.7	|	25.3	|
|	4.6	|	18.1	|	14.2	|	28.9	|
|	4.8	|	21.1	|	17.1	|	32.7	|
|	5	|	24.4	|	20.2	|	36.6	|
|	5.2	|	27.9	|	23.5	|	40.8	|
|	5.4	|	31.5	|	27	|	45.1	|
|	5.6	|	35.4	|	30.7	|	49.6	|
|	5.8	|	39.4	|	34.6	|	54.3	|
|	6	|	43.7	|	38.7	|	59.1	|
|	6.2	|	48.1	|	42.9	|	64	|
|	6.4	|	52.6	|	47.4	|	69.1	|
|	6.6	|	57.3	|	52	|	74.4	|
|	6.8	|	62.2	|	56.8	|	79.8	|
|	7	|	67.3	|	61.7	|	85.3	|
|	7.2	|	72.5	|	66.9	|	91	|
|	7.4	|	77.8	|	72.1	|	96.8	|
|	7.6	|	83.3	|	77.5	|	102.7	|
|	7.8	|	88.9	|	83.1	|	108.8	|
|	8	|	94.7	|	88.8	|	115	|
|	8.2	|	100.6	|	94.7	|	121.3	|
|	8.4	|	106.6	|	100.7	|	127.7	|
|	8.6	|	112.8	|	106.8	|	131.1	|
|	8.8	|	119.1	|	113.1	|	131.1	|
|	9	|	125.5	|	119.5	|	131.1	|
|	9.2	|	132.1	|	126	|	131.1	|
|	9.4	|	132.9	|	131.9	|	131.1	|
|	9.6	|	132.9	|	131.9	|	131.1	|
|	9.8	|	132.9	|	131.9	|	131.1	|
|	10	|	132.9	|	131.9	|	131.1	|


#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Are the PVs named according to the [naming standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
- [x] Have suitable [disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records) been added?
- [x] Have suitable [simulation records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation) been added?
- [x] Have the [finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches) been applied?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Review has copied the release note to on master and **ALSO** copied muon front end instructions to master
