### PR TITLE
fixed macro description

### DIFF
--- a/DFKPS/iocBoot/iocDFKPS-IOC-01/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-01/config.xml
@@ -3,9 +3,9 @@
 <config_part>
 <macros>
 <macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" />
-<macro name="CALIBRATED" pattern="^(0|1)$" description="Name of Calibration File" />
-<macro name="CFILE" description="Name of Calibration File" />
-<macro name="CPATH" description="Location of Calibration File" />
+<macro name="CALIBRATED" pattern="^(0|1)$" description="Toggle calibration" />
+<macro name="CFILE" description="Name of calibration file" />
+<macro name="CPATH" description="Location of calibration file" />
 </macros>
 </config_part>
 </ioc_config>


### PR DESCRIPTION
### Description of work

Fixed description of "CALIBRATED" macro in DFKPS IOC

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1475

### Acceptance criteria

Correct macro descriptions for DFKPS IOCs are displayed in IBEX.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Are the PVs named according to the [naming standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
- [x] Have suitable [disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records) been added?
- [x] Have suitable [simulation records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation) been added?
- [x] Have the [finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches) been applied?
- [x] Is there an [emulator](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Emulating-Devices) for the device?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- [x] If there are multiple _0n IOCs, do they run correctly?

### Final steps

- [x] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.

