### PR TITLE
Ticket #1314: Mk3Chopper will automatically adjust to the number of choppers found on startup

### DIFF
--- a/MK3CHOPPER/MK3CHOPPER-IOC-01App/src/mk3Driver.cpp
+++ b/MK3CHOPPER/MK3CHOPPER-IOC-01App/src/mk3Driver.cpp
@@ -369,7 +369,8 @@ void mk3Driver::checkErrorCode(int code)
 
 void mk3Driver::getNumberEnabledChannels(unsigned int* result)
 {
-    m_interface->getNumberEnabledChannels(result);
+    int errCode = m_interface->getNumberEnabledChannels(result);
+    checkErrorCode(errCode);
 }
 
 /* Configuration routine.  Called directly, or from the iocsh function below */

--- a/MK3CHOPPER/MK3CHOPPER-IOC-01App/src/mk3Driver.cpp
+++ b/MK3CHOPPER/MK3CHOPPER-IOC-01App/src/mk3Driver.cpp
@@ -13,6 +13,7 @@
 #include <epicsTimer.h>
 #include <epicsMutex.h>
 #include <epicsEvent.h>
+#include "envDefs.h"
 #include <iocsh.h>
 #include "errlog.h"
 #include "mk3Driver.h"
@@ -366,6 +367,11 @@ void mk3Driver::checkErrorCode(int code)
     }
 }
 
+void mk3Driver::getNumberEnabledChannels(unsigned int* result)
+{
+    m_interface->getNumberEnabledChannels(result);
+}
+
 /* Configuration routine.  Called directly, or from the iocsh function below */
 
 extern "C" {
@@ -373,7 +379,23 @@ extern "C" {
 // EPICS iocsh callable function to call constructor for the class.
 int mk3DriverConfigure(const char *portName, const char *configFilePath, int mockChopper)
 {
-    new mk3Driver(portName, configFilePath, mockChopper);
+    mk3Driver* driver = new mk3Driver(portName, configFilePath, mockChopper);
+    
+    // Check to see how many choppers we have
+    if (driver)
+    {
+        unsigned int result;
+        driver->getNumberEnabledChannels(&result);
+        std::cout << "There are " << result << " choppers on this controller" << std::endl;
+        for (unsigned int i = 0; i < result; ++i)
+        {
+            // Set a macro for iocsh to use
+            std::ostringstream oss;
+            oss << "CHOPPER_" << i + 1 << "_PRESENT";           
+            epicsEnvSet(oss.str().c_str(), " ");
+        }
+    }
+    
     return(asynSuccess);
 }
 

--- a/MK3CHOPPER/MK3CHOPPER-IOC-01App/src/mk3Driver.h
+++ b/MK3CHOPPER/MK3CHOPPER-IOC-01App/src/mk3Driver.h
@@ -15,6 +15,8 @@ public:
     virtual asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);
     virtual asynStatus writeFloat64(asynUser *pasynUser, epicsFloat64 value);
     
+    void getNumberEnabledChannels(unsigned int* result); 
+    
 private:
     asynUser* pasynUser;
     mk3Interface* m_interface;

--- a/MK3CHOPPER/iocBoot/iocMk3CHOPPER-IOC-01/st.cmd
+++ b/MK3CHOPPER/iocBoot/iocMk3CHOPPER-IOC-01/st.cmd
@@ -25,10 +25,12 @@ mk3DriverConfigure("MK3", "C:/LabVIEW Modules/Drivers/ISIS MK3 Disc Chopper/MK3_
 ##ISIS## Load common DB records 
 < $(IOCSTARTUP)/dbload.cmd
 
-## Load our record instances
-dbLoadRecords("db/mk3.db","P=$(MYPVPREFIX)$(IOCNAME):, Q=CH1:, PORT=MK3, CHANNEL=1")
-dbLoadRecords("db/mk3.db","P=$(MYPVPREFIX)$(IOCNAME):, Q=CH2:, PORT=MK3, CHANNEL=2")
-dbLoadRecords("db/mk3.db","P=$(MYPVPREFIX)$(IOCNAME):, Q=CH3:, PORT=MK3, CHANNEL=3")
+## Load our record instances (conditionally!) 
+$(CHOPPER_1_PRESENT=#) dbLoadRecords("db/mk3.db","P=$(MYPVPREFIX)$(IOCNAME):, Q=CH1:, PORT=MK3, CHANNEL=1")
+$(CHOPPER_2_PRESENT=#) dbLoadRecords("db/mk3.db","P=$(MYPVPREFIX)$(IOCNAME):, Q=CH2:, PORT=MK3, CHANNEL=2")
+$(CHOPPER_3_PRESENT=#) dbLoadRecords("db/mk3.db","P=$(MYPVPREFIX)$(IOCNAME):, Q=CH3:, PORT=MK3, CHANNEL=3")
+$(CHOPPER_4_PRESENT=#) dbLoadRecords("db/mk3.db","P=$(MYPVPREFIX)$(IOCNAME):, Q=CH4:, PORT=MK3, CHANNEL=4")
+$(CHOPPER_5_PRESENT=#) dbLoadRecords("db/mk3.db","P=$(MYPVPREFIX)$(IOCNAME):, Q=CH5:, PORT=MK3, CHANNEL=5")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd


### PR DESCRIPTION
https://github.com/ISISComputingGroup/IBEX/issues/1314

### Description of work

The Mk3Chopper knows how many choppers it has, so if we get that value first then we can only load the records for the choppers present.

As part of the IOC starting up it creates macros for each chopper that is present.
If the macro is defined then the records are loaded for that chopper.

### To test

* Update the MK3CHOPPER folder in this repo.
* Type 'make' in this directory
* Move to iocBoot\iocMk3CHOPPER-IOC-01
* Open the st.cmd and **change it to use a mock chopper**

```
# Portname, path to config file, use mock (=1 for mock)
mk3DriverConfigure("MK3", "C:/LabVIEW Modules/Drivers/ISIS MK3 Disc Chopper/MK3_Chopper.config", 1)
```
* Run the IOC (runIOC.bat st.cmd)
* Check the IOC messages to see the following text.
```
## Load our record instances (conditionally!)
  dbLoadRecords("db/mk3.db","P=IBEX_MATT:MJC23:MK3CHOPPER_01:, Q=CH1:, PORT=MK3, CHANNEL=1")
# dbLoadRecords("db/mk3.db","P=IBEX_MATT:MJC23:MK3CHOPPER_01:, Q=CH2:, PORT=MK3, CHANNEL=2")
# dbLoadRecords("db/mk3.db","P=IBEX_MATT:MJC23:MK3CHOPPER_01:, Q=CH3:, PORT=MK3, CHANNEL=3")
# dbLoadRecords("db/mk3.db","P=IBEX_MATT:MJC23:MK3CHOPPER_01:, Q=CH4:, PORT=MK3, CHANNEL=4")
# dbLoadRecords("db/mk3.db","P=IBEX_MATT:MJC23:MK3CHOPPER_01:, Q=CH5:, PORT=MK3, CHANNEL=5")
```
The load records command should be commented out for all but CH1

* Now a hack to try it for more choppers. Open mk3Driver.cpp and insert the following line into the mk3DriverConfigure function

```
result = 2;
```

so it looks like:

```
// EPICS iocsh callable function to call constructor for the class.
int mk3DriverConfigure(const char *portName, const char *configFilePath, int mockChopper)
{
    mk3Driver* driver = new mk3Driver(portName, configFilePath, mockChopper);
    
    // Check to see how many choppers we have
    if (driver)
    {
        unsigned int result;
        driver->getNumberEnabledChannels(&result);
        result = 2;
        std::cout << "There are " << result << " choppers on this controller" << std::endl;
        for (unsigned int i = 0; i < result; ++i)
        {
            // Set a macro for iocsh to use
            std::ostringstream oss;
            oss << "CHOPPER_" << i + 1 << "_PRESENT";           
            epicsEnvSet(oss.str().c_str(), " ");
        }
    }
    
    return(asynSuccess);
}
```

* make

* Restart the IOC

* The startup messages should contain

```
## Load our record instances (conditionally!)
  dbLoadRecords("db/mk3.db","P=IBEX_MATT:MJC23:MK3CHOPPER_01:, Q=CH1:, PORT=MK3, CHANNEL=1")
  dbLoadRecords("db/mk3.db","P=IBEX_MATT:MJC23:MK3CHOPPER_01:, Q=CH2:, PORT=MK3, CHANNEL=2")
# dbLoadRecords("db/mk3.db","P=IBEX_MATT:MJC23:MK3CHOPPER_01:, Q=CH3:, PORT=MK3, CHANNEL=3")
# dbLoadRecords("db/mk3.db","P=IBEX_MATT:MJC23:MK3CHOPPER_01:, Q=CH4:, PORT=MK3, CHANNEL=4")
# dbLoadRecords("db/mk3.db","P=IBEX_MATT:MJC23:MK3CHOPPER_01:, Q=CH5:, PORT=MK3, CHANNEL=5")
```

The load records command should now not be commented out for CH2

* `dbl` should show PVs for CH1 and CH2

* Repeat the hack for 3 choppers if you wish

### Acceptance criteria

If there are 3 choppers there are PVs for CH1, CH2 and CH3

---

#### Code Review

- [x] Is the code of an acceptable quality?
- N/A Are the PVs named according to the [naming standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
- N/A Have suitable [disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records) been added?
- N/A Have suitable [simulation records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation) been added?
- [x] Have the [finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches) been applied?
- N/A Is there an [emulator](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Emulating-Devices) for the device?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- N/A Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- N/A If there are multiple _0n IOCs, do they run correctly?

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.

