### PR TITLE
IOC: Cannot have multiple simulated motors attached to single MCLEN IOC

### DIFF
--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/st-motor.cmd
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/st-motor.cmd
@@ -19,12 +19,12 @@ epicsEnvSet("AMOTORPV", "MOT:$(AMOTORNAME)")
 #$(IFSIM) motorSimCreate( 0, 0, -32000, 32000, 0, 1, 1 )
 ## Setup the Asyn layer (portname, low-level driver drvet name, card, number of axes on card)
 ##$(IFSIM) drvAsynMotorConfigure("sim1", "motorSim", 0, 1)
-$(IFSIM) motorSimCreateController("motorSim", 1)
-$(IFSIM) motorSimConfigAxis("motorSim", 0, 20000, -20000,  500, 0)
+$(IFSIM) motorSimCreateController("$(AMOTOR)", 1)
+$(IFSIM) motorSimConfigAxis("$(AMOTOR)", 0, 20000, -20000,  500, 0)
 
 
 $(IFSIM) drvAsynSerialPortConfigure("$(ASERIAL)", "NUL", 0, 1)
-$(IFSIM) epicsEnvSet "SIMSFX" "Sim"
+$(IFSIM) epicsEnvSet("SIMSFX","Sim")
  
 $(IFNOTSIM) drvAsynSerialPortConfigure("$(ASERIAL)", "$(PORT$(PN)=NUL)", 0, 0, 0)
 $(IFNOTSIM) asynSetTraceIOMask("$(ASERIAL)", -1, 0xFF )


### PR DESCRIPTION
### Description of work

Change the name associated with motor sims for McLennan motors so that if I use multiple motors on the same IOC, it will launch correctly. Previously the launch aborted almost straight away.

### To test
https://github.com/ISISComputingGroup/IBEX/issues/1546

### Acceptance criteria

Can launch multiple simulated motors on the same McLennan IOC. These macros may be helpful:

```
SIMULATE=1
MCLEN_01__MTRCTRL=1
MCLEN_01__PORT1=COM1
MCLEN_01__PORT2=COM1
```


---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Are the PVs named according to the [naming standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
- [ ] Have suitable [disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records) been added?
- [ ] Have suitable [simulation records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation) been added?
- [ ] Have the [finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches) been applied?
- [ ] Is there an [emulator](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Emulating-Devices) for the device?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [ ] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- [ ] If there are multiple _0n IOCs, do they run correctly?

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
