### PR TITLE
Ticket 1589: changed lakeshore 336 IPADDR macro to be the host name i…

### DIFF
--- a/LKSH336/iocBoot/iocLKSH336-IOC-01/config.xml
+++ b/LKSH336/iocBoot/iocLKSH336-IOC-01/config.xml
@@ -2,7 +2,7 @@
 <ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
 <config_part>
 <macros>
-<macro name="IPADDR" pattern="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]$" description="IP address of Lakeshore 336 controller" />
+<macro name="HOST" description="Host name of Lakeshore 336 controller" />
 </macros>
 </config_part>
 </ioc_config>

--- a/LKSH336/iocBoot/iocLKSH336-IOC-01/st-common.cmd
+++ b/LKSH336/iocBoot/iocLKSH336-IOC-01/st-common.cmd
@@ -10,7 +10,7 @@ cd ${TOP}
 $(IFDEVSIM) drvAsynIPPortConfigure("$(DEVICE)", "localhost:55626")
 
 ## For real device use:
-$(IFNOTDEVSIM) drvAsynIPPortConfigure ("$(DEVICE)", "$(IPADDR):7777")
+$(IFNOTDEVSIM) drvAsynIPPortConfigure ("$(DEVICE)", "$(HOST):7777")
 
 ## Load record instances
 


### PR DESCRIPTION
### Description of work

Changed the IPADDR macro to be the host name. 

### To test

This is for ISISComputingGroup/IBEX#1589

### Acceptance criteria

Do a `make iocstartups`.
Restart the instrument.
From the GUI, you should be able to see the HOST macro in the LKSH336 IOCs. You can try setting this macro to something random, save the config and start the IOC. When looking at the IOC output or log you should see the macro being set.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [ ] Are the PVs named according to the [naming standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
- [ ] Have suitable [disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records) been added?
- [ ] Have suitable [simulation records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation) been added?
- [ ] Have the [finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches) been applied?
- [ ] Is there an [emulator](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Emulating-Devices) for the device?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- [x] If there are multiple _0n IOCs, do they run correctly?

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
