### PR TITLE
Add aliases for CV status

### DIFF
--- a/CRYVALVE/CRYVALVE-IOC-01App/Db/CRYVALVE.db
+++ b/CRYVALVE/CRYVALVE-IOC-01App/Db/CRYVALVE.db
@@ -5,9 +5,9 @@
 ################################################################
 #
 # Activities needed and their associated PVs
-# open       Write  Opens the valve                $(P)OPEN
-# close      Write  Closes the valve               $(P)CLOSE
-# getStatus  Read   Queries the state of the valve $(P)STATUS
+# open       Write  Opens the valve                $(P)STAT:SP [1]
+# close      Write  Closes the valve               $(P)STAT:SP [0]
+# getStatus  Read   Queries the state of the valve $(P)STAT
 
 record(bo, "$(P)SIM")
 {
@@ -32,12 +32,12 @@ record(bo, "$(P)DISABLE")
 #### getStatus command ####
 ###########################
 
-record(stringin, "$(P)STATUS")
+record(stringin, "$(P)STAT")
 {
     field(SCAN, "1 second")
     field(DTYP, "stream")
     field(INP,  "@cryValve.proto getStatus $(PORT)")
-	field(SIOL, "$(P)SIM:STATUS")
+	field(SIOL, "$(P)SIM:STAT")
 	field(SIML, "$(P)SIM")
     field(SDIS, "$(P)DISABLE")
     info(INTEREST, "HIGH")
@@ -45,10 +45,10 @@ record(stringin, "$(P)STATUS")
     field(DESC, "Iris cryo valve status")
 }
 
-# Stat fits in with PV naming conventions
-alias("$(P)STATUS","$(P)STAT")
+# Preserve old PV for backwards-compatibility
+alias("$(P)STAT","$(P)STATUS")
 
-record(stringout, "$(P)SIM:STATUS")
+record(stringout, "$(P)SIM:STAT")
 {
 	field(DTYP, "Soft Channel")
 	field(VAL, "Simulated")
@@ -58,7 +58,7 @@ record(stringout, "$(P)SIM:STATUS")
 #### Open command ####
 #####################################################
 
-record(bo, "$(P)OPEN:CMD") {
+record(bo, "$(P)STAT:SP") {
     field(DESC, "Solenoid open/close control")
     field(DTYP, "stream")
     field(OUT, "@cryValve.proto setOpen $(PORT)")
@@ -66,16 +66,16 @@ record(bo, "$(P)OPEN:CMD") {
     field(ONAM, "OPEN")
     field(SDIS, "$(P)DISABLE")
     field(SIML, "$(P)SIM")
-    field(SIOL, "$(P)SIM:OPEN:CMD PP")
+    field(SIOL, "$(P)SIM:STAT:SP PP")
     info(archive, "VAL")
     info(INTEREST, "HIGH")
 }
 
 # Need PVs of form [VALUE]:SP to work with blockserver cset
-alias("$(P)OPEN:CMD","$(P)STAT:SP")
-alias("$(P)OPEN:CMD","$(P)STATUS:SP")
+alias("$(P)STAT:SP","$(P)OPEN:CMD")
+alias("$(P)STAT:SP","$(P)STATUS:SP")
 
-record(bo, "$(P)SIM:OPEN:CMD")
+record(bo, "$(P)SIM:STAT:SP")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")

--- a/CRYVALVE/CRYVALVE-IOC-01App/Db/CRYVALVE.db
+++ b/CRYVALVE/CRYVALVE-IOC-01App/Db/CRYVALVE.db
@@ -45,6 +45,9 @@ record(stringin, "$(P)STATUS")
     field(DESC, "Iris cryo valve status")
 }
 
+# Stat fits in with PV naming conventions
+alias("$(P)STATUS","$(P)STAT")
+
 record(stringout, "$(P)SIM:STATUS")
 {
 	field(DTYP, "Soft Channel")
@@ -67,6 +70,10 @@ record(bo, "$(P)OPEN:CMD") {
     info(archive, "VAL")
     info(INTEREST, "HIGH")
 }
+
+# Need PVs of form [VALUE]:SP to work with blockserver cset
+alias("$(P)OPEN:CMD","$(P)STAT:SP")
+alias("$(P)OPEN:CMD","$(P)STATUS:SP")
 
 record(bo, "$(P)SIM:OPEN:CMD")
 {

--- a/CRYVALVE/iocBoot/iocCRYVALVE-IOC-01/st.cmd
+++ b/CRYVALVE/iocBoot/iocCRYVALVE-IOC-01/st.cmd
@@ -20,13 +20,14 @@ CRYVALVE_IOC_01_registerRecordDeviceDriver pdbbase
 ##ISIS## Run IOC initialisation
 < $(IOCSTARTUP)/init.cmd
 
-drvAsynSerialPortConfigure("$(DEVICE)", "$(PORT)", 0, 0, 0, 0)
-asynSetOption("$(DEVICE)", -1, "baud", "$(BAUD=9600)")
-asynSetOption("$(DEVICE)", -1, "bits", "$(BITS=8)")
-asynSetOption("$(DEVICE)", -1, "parity", "$(PARITY=none)")
-asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)")
-asynOctetSetInputEos("$(DEVICE)", -1, "$(OEOS=\r)")
-asynOctetSetOutputEos("$(DEVICE)", -1, "$(IEOS=\r)")
+$(IFDEVSIM) drvAsynIPPortConfigure("$(DEVICE)", "localhost:57677")
+$(IFNOTDEVSIM) drvAsynSerialPortConfigure("$(DEVICE)", "$(PORT)", 0, 0, 0, 0)
+$(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "baud", "$(BAUD=9600)")
+$(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "bits", "$(BITS=8)")
+$(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "parity", "$(PARITY=none)")
+$(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)")
+$(IFNOTDEVSIM) asynOctetSetInputEos("$(DEVICE)", -1, "$(OEOS=\r)")
+$(IFNOTDEVSIM) asynOctetSetOutputEos("$(DEVICE)", -1, "$(IEOS=\r)")
 
 ## Load record instances
 

--- a/CRYVALVE/iocBoot/iocCRYVALVE-IOC-02/st.cmd
+++ b/CRYVALVE/iocBoot/iocCRYVALVE-IOC-02/st.cmd
@@ -20,13 +20,14 @@ CRYVALVE_IOC_02_registerRecordDeviceDriver pdbbase
 ##ISIS## Run IOC initialisation
 < $(IOCSTARTUP)/init.cmd
 
-drvAsynSerialPortConfigure("$(DEVICE)", "$(PORT)", 0, 0, 0, 0)
-asynSetOption("$(DEVICE)", -1, "baud", "$(BAUD=9600)")
-asynSetOption("$(DEVICE)", -1, "bits", "$(BITS=8)")
-asynSetOption("$(DEVICE)", -1, "parity", "$(PARITY=none)")
-asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)")
-asynOctetSetInputEos("$(DEVICE)", -1, "$(OEOS=\r)")
-asynOctetSetOutputEos("$(DEVICE)", -1, "$(IEOS=\r)")
+$(IFDEVSIM) drvAsynIPPortConfigure("$(DEVICE)", "localhost:57678")
+$(IFNOTDEVSIM) drvAsynSerialPortConfigure("$(DEVICE)", "$(PORT)", 0, 0, 0, 0)
+$(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "baud", "$(BAUD=9600)")
+$(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "bits", "$(BITS=8)")
+$(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "parity", "$(PARITY=none)")
+$(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)")
+$(IFNOTDEVSIM) asynOctetSetInputEos("$(DEVICE)", -1, "$(OEOS=\r)")
+$(IFNOTDEVSIM) asynOctetSetOutputEos("$(DEVICE)", -1, "$(IEOS=\r)")
 
 ## Load record instances
 


### PR DESCRIPTION
### Description of work

Create aliases for some of the Cryovalve PVs so they work with cset. Cset assumes PVs of the form `[PV]`, `[PV]:SP` so that when `cset([PV],value)` is called, it really sets the value on `[PV]:SP`. The old form of the cryvalve IOC didn't allow that.

The new db structure has a `STATUS:SP` PV so it works with the existing status PV. I've also created the pair `STAT` and `STAT:SP` in line with PV naming standards. I've left the old PVs in place to preserve backwards compatibility. 

I only updated the Cryovalve IOC. I looked at the others listed in the ticket and didn't identify any further changes that were necessary.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1663

### Acceptance criteria

- [x] Cryovalve state can be changed using the `cset` command with PVs `CRYOVALVE_01:STAT` and `CRYOVALVE_01:STATUS`
- [x] Old and new PVs behave as expected and aliases report the same value

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [x] Are the PVs named according to the [naming standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
- [ ] Have suitable [disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records) been added?
- [ ] Have suitable [simulation records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation) been added?
- [ ] Have the [finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches) been applied?
- [ ] Is there an [emulator](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Emulating-Devices) for the device?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [ ] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- [x] If there are multiple _0n IOCs, do they run correctly?

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
