### PR TITLE
Check and resend eurotherm setpoint

### DIFF
--- a/EUROTHERM/EUROTHERM-IOC-01App/Db/devEurotherm.db
+++ b/EUROTHERM/EUROTHERM-IOC-01App/Db/devEurotherm.db
@@ -725,6 +725,7 @@ record(ai, "$(P)RBV") {
     field(PREC, "3")
 	field(FLNK, "$(P)TEMP.PROC PP")
     info(archive, "VAL")
+	info(alarm, "Euro")
 }
 
 record(ai, "$(P)SP:RBV") {
@@ -739,6 +740,7 @@ record(ai, "$(P)SP:RBV") {
 	field(EGU, "")
     field(PREC, "3")
     info(archive, "VAL")
+	info(alarm, "Euro")
 }
 
 record(ao, "$(P)SP") {
@@ -753,6 +755,7 @@ record(ao, "$(P)SP") {
     field(PREC, "3")
 	field(FLNK, "$(P)_CHECKSPFAN.PROC PP")
     info(archive, "VAL")
+	info(alarm, "Euro")
 }
 
 record(fanout, "$(P)_CHECKSPFAN") {

--- a/EUROTHERM/EUROTHERM-IOC-01App/Db/devEurotherm.db
+++ b/EUROTHERM/EUROTHERM-IOC-01App/Db/devEurotherm.db
@@ -775,13 +775,15 @@ record(ao, "$(P)_SP") {
 ## how many times to resend a setpoint if it doesn't match readback
 record(longout, "$(P)SP:NRETRY") {
     field(VAL, "5")
+	field(OUT, "$(P)SP:RETRYCNT.HIGH")
+	field(PINI, "YES")
 }
 
 ## current setpoint retry number
 record(longout, "$(P)SP:RETRYCNT") {
     field(DESC, "Last setpoint retry count")
     field(VAL, "0")
-	field(HIGH, "1")
+	field(HIGH, "5")
 	field(HSV, "MINOR")
     info(archive, "VAL")
 	info(alarm, "Euro")

--- a/EUROTHERM/EUROTHERM-IOC-01App/Db/devEurotherm.db
+++ b/EUROTHERM/EUROTHERM-IOC-01App/Db/devEurotherm.db
@@ -383,6 +383,7 @@ record(mbbi, "$(P)ERR") {
     field(SIML, "$(Q)SIM")
     field(SIOL, "$(P)SIM:ERR")
     field(SDIS, "$(Q)DISABLE")
+    info(archive, "VAL")
 }
 
 record(ai, "$(P)P") {
@@ -750,8 +751,43 @@ record(ao, "$(P)SP") {
     field(SDIS, "$(Q)DISABLE")
 	field(EGU, "")
     field(PREC, "3")
-	field(FLNK, "$(P)SP:RBV.PROC PP")
+	field(FLNK, "$(P)_CHECKSPFAN.PROC PP")
     info(archive, "VAL")
+}
+
+record(fanout, "$(P)_CHECKSPFAN") {
+	field(SELM, "All")
+	field(LNK1, "$(P)SP:RBV.PROC PP")
+	field(LNK2, "$(P)_CHECKSP.PROC PP")
+}
+
+## difference between sent SP and readback SP to trigger a resend of SP
+## note this is a tolerance on the raw value sent to the eurotherm via the stream device command
+record(ai, "$(P)SP:CHKTOL") {
+    field(DESC, "Setpoint check tolerance")
+    field(VAL, "0.01")
+}
+
+## check difference between sent and readback SP and re-issue send if necessary
+record(calcout, "$(P)_CHECKSP") {
+    field(DESC, "Check SP received or resend")
+    field(INPA, "$(P)SP NPP")
+    field(INPB, "$(P)SP:RBV NPP")
+    field(INPC, "$(P)SP:CHKTOL NPP")
+	field(CALC, "ABS(A-B) > C ? 1 : 0")
+	field(OOPT, "When Non-zero")
+	field(OUT, "$(P)_RESENDSP.PROC PP")
+}
+
+## request resend setpoint after a 1 second delay
+## Use delay in case we get caught in an infinite retry loop
+record(seq, "$(P)_RESENDSP") {
+    field(DESC, "Resend setpoint")
+	field(SELM, "All")
+    field(DOL1, "1")
+	field(DLY1, "1")
+	# we need to use CA as otherwise SP will not reprocess as we are currently part of its existing processing chain
+	field(LNK1, "$(P)SP.PROC CA")
 }
 
 record(ai, "$(P)HILIM") {

--- a/EUROTHERM/EUROTHERM-IOC-01App/Db/devEurotherm.db
+++ b/EUROTHERM/EUROTHERM-IOC-01App/Db/devEurotherm.db
@@ -768,7 +768,7 @@ record(fanout, "$(P)_CHECKSPFAN") {
 ## note this is a tolerance on the raw value sent to the eurotherm via the stream device command
 record(ai, "$(P)SP:CHKTOL") {
     field(DESC, "Setpoint check tolerance")
-    field(VAL, "0.01")
+    field(VAL, "0.001")
 }
 
 ## check difference between sent and readback SP and re-issue send if necessary

--- a/EUROTHERM/EUROTHERM-IOC-01App/Db/devEurotherm.db
+++ b/EUROTHERM/EUROTHERM-IOC-01App/Db/devEurotherm.db
@@ -780,6 +780,10 @@ record(calcout, "$(P)_CHECKSP") {
 	field(CALC, "ABS(A-B) > C ? 1 : 0")
 	field(OOPT, "When Non-zero")
 	field(OUT, "$(P)_RESENDSP.PROC PP")
+	field(HIGH, "0.5")
+	field(HSV, "MINOR")
+    info(archive, "VAL")
+	info(alarm, "Euro")
 }
 
 ## request resend setpoint after a 1 second delay

--- a/EUROTHERM/EUROTHERM-IOC-01App/Db/devEurotherm.db
+++ b/EUROTHERM/EUROTHERM-IOC-01App/Db/devEurotherm.db
@@ -746,6 +746,20 @@ record(ai, "$(P)SP:RBV") {
 record(ao, "$(P)SP") {
     info(INTEREST, "MEDIUM")
     field(DESC, "Temperature Setpoint")
+    field(OUT, "$(P)_SP NPP")
+	field(EGU, "")
+    field(PREC, "3")
+    info(archive, "VAL")
+	field(FLNK, "$(P)_DOSP.PROC PP")
+}
+
+record(longout, "$(P)_DOSP") {
+    field(VAL, "0")
+	field(OUT, "$(P)SP:RETRYCNT PP")
+	field(FLNK, "$(P)_SP.PROC PP")
+}
+
+record(ao, "$(P)_SP") {
     field(DTYP, "stream")
     field(OUT, "@eurotherm2k.proto write($(P),SL) $(PORT)")
 	field(SIML, "$(Q)SIM")
@@ -753,15 +767,24 @@ record(ao, "$(P)SP") {
     field(SDIS, "$(Q)DISABLE")
 	field(EGU, "")
     field(PREC, "3")
-	field(FLNK, "$(P)_CHECKSPFAN.PROC PP")
+	field(FLNK, "$(P)_CHECKSP.PROC PP")
     info(archive, "VAL")
 	info(alarm, "Euro")
 }
 
-record(fanout, "$(P)_CHECKSPFAN") {
-	field(SELM, "All")
-	field(LNK1, "$(P)SP:RBV.PROC PP")
-	field(LNK2, "$(P)_CHECKSP.PROC PP")
+## how many times to resend a setpoint if it doesn't match readback
+record(longout, "$(P)SP:NRETRY") {
+    field(VAL, "5")
+}
+
+## current setpoint retry number
+record(longout, "$(P)SP:RETRYCNT") {
+    field(DESC, "Last setpoint retry count")
+    field(VAL, "0")
+	field(HIGH, "1")
+	field(HSV, "MINOR")
+    info(archive, "VAL")
+	info(alarm, "Euro")
 }
 
 ## difference between sent SP and readback SP to trigger a resend of SP
@@ -772,29 +795,33 @@ record(ai, "$(P)SP:CHKTOL") {
 }
 
 ## check difference between sent and readback SP and re-issue send if necessary
+## the PP on INPB forces a setpoint readback
+## request resend setpoint after a 1 second delay
 record(calcout, "$(P)_CHECKSP") {
     field(DESC, "Check SP received or resend")
-    field(INPA, "$(P)SP NPP")
-    field(INPB, "$(P)SP:RBV NPP")
+    field(INPA, "$(P)_SP NPP")
+    field(INPB, "$(P)SP:RBV PP")
     field(INPC, "$(P)SP:CHKTOL NPP")
-	field(CALC, "ABS(A-B) > C ? 1 : 0")
+    field(INPD, "$(P)SP:NRETRY NPP")
+    field(INPE, "$(P)SP:RETRYCNT NPP")
+	field(CALC, "(ABS(A-B)>C)&&(E<D)?1:0")
 	field(OOPT, "When Non-zero")
-	field(OUT, "$(P)_RESENDSP.PROC PP")
+	# we need to use CA on OUT as otherwise SP will not reprocess as we are currently part of its existing processing chain
+	field(OUT, "$(P)_DORETRY.PROC PP")
 	field(HIGH, "0.5")
 	field(HSV, "MINOR")
+	field(ODLY, 1)
     info(archive, "VAL")
 	info(alarm, "Euro")
 }
 
-## request resend setpoint after a 1 second delay
-## Use delay in case we get caught in an infinite retry loop
-record(seq, "$(P)_RESENDSP") {
-    field(DESC, "Resend setpoint")
-	field(SELM, "All")
-    field(DOL1, "1")
-	field(DLY1, "1")
-	# we need to use CA as otherwise SP will not reprocess as we are currently part of its existing processing chain
-	field(LNK1, "$(P)SP.PROC CA")
+record(calcout, "$(P)_DORETRY") {
+    field(INPA, "$(P)SP:RETRYCNT NPP")
+	field(CALC, "A+1")
+	field(OOPT, "Every Time")
+	field(OUT, "$(P)SP:RETRYCNT PP")
+	# we need to use CA on OUT as otherwise SP will not reprocess as we are currently part of its existing processing chain
+	field(FLNK, "$(P)_SP.PROC CA")
 }
 
 record(ai, "$(P)HILIM") {


### PR DESCRIPTION
### Description of work

If the raw (as in steam device string) setpoint and readback
differ by more than $(P)SP:CHKTOL then a request is made to
reissue the setpoint up to $(P)SP:NRETRY times at 1 second intervals. 

See ISISComputingGroup/IBEX#1703

### To test

To test, you could set  $(P)SP:CHKTOL to  -1  with a CAPUT and
then the next setpoint sent should automatically get resent every second NRETRY times to 
the hardware. While retrying,  $(P)_CHECKSP  should have the value of 1 and also be in a MINOR alarm state.

To check for missed setpoints, maybe write a genie-python script to send setpoints in a loop to the  hardware with the default .001 tolerance and have a camonitor on  $(P)_CHECKSP to see if any get lost and are picked up. Don't send setpoints too fast, say every few seconds. If you send them too fast they could interfere with the retry loop.

### Acceptance criteria

above test works

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Are the PVs named according to the [naming standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
- [x] Have suitable [disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records) been added?
- [ ] Have suitable [simulation records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation) been added?
- [ ] Have the [finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches) been applied?
- [ ] Is there an [emulator](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Emulating-Devices) for the device?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed. **Tested on the Eurotherm device that is in the office, using two addresses. Could not reproduce the issue of setpoints being missed, but the number of retries does go up when the SP:RBV takes some time to update (the SP on the actual device was never missed). I have also tested by setting an SP higher than the SP high limit on the device itself**
- [ ] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- [ ] If there are multiple _0n IOCs, do they run correctly?

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

