### PR TITLE
Ticket 1709: commented out SCAN field of SP_OUT

### DIFF
--- a/EUROTHERM/EUROTHERM-IOC-01App/Db/devEurotherm.db
+++ b/EUROTHERM/EUROTHERM-IOC-01App/Db/devEurotherm.db
@@ -178,7 +178,7 @@ record(ai, "$(P)OUT_SP")
    field(DTYP, "asynFloat64")
    field(INP,  "@asyn($(READ),0,1)SP")
    field(PREC, "5")
-   field(SCAN, "I/O Intr")
+#   field(SCAN, "I/O Intr")
    field(FLNK, "$(P)RAMP_SP.PROC PP")
 }
 


### PR DESCRIPTION
### Description of work

Commented out SCAN field of OUT_SP, as per ISISComputingGroup/IBEX#1630

### To test

ISISComputingGroup/IBEX#1709

### Acceptance criteria

Setpoint does NOT get sent at startup.
This was already tested as part of ISISComputingGroup/IBEX#1630 and is currently in as a hotfix on IRIS

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Are the PVs named according to the [naming standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
- [ ] Have suitable [disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records) been added?
- [ ] Have suitable [simulation records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation) been added?
- [ ] Have the [finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches) been applied?
- [ ] Is there an [emulator](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Emulating-Devices) for the device?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [ ] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- [x] If there are multiple _0n IOCs, do they run correctly?

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
