### PR TITLE
Ticket1708 iris mclennan

### DIFF
--- a/MCLEN/MCLEN-IOC-01App/src/build.mak
+++ b/MCLEN/MCLEN-IOC-01App/src/build.mak
@@ -36,6 +36,7 @@ $(APPNAME)_DBD += drvAsynSerialPort.dbd
 $(APPNAME)_DBD += drvAsynIPPort.dbd
 $(APPNAME)_DBD += busySupport.dbd
 $(APPNAME)_DBD += motionSetPoints.dbd
+$(APPNAME)_DBD += sampleChanger.dbd 
 $(APPNAME)_DBD += stdSupport.dbd
 $(APPNAME)_DBD += asubFunctions.dbd 
 
@@ -56,6 +57,7 @@ $(APPNAME)_LIBS += motorSimSupport
 $(APPNAME)_LIBS += softMotor
 $(APPNAME)_LIBS += motor
 $(APPNAME)_LIBS += motionSetPoints
+$(APPNAME)_LIBS += sampleChanger
 $(APPNAME)_LIBS += busy asyn
 $(APPNAME)_LIBS += std sscan
 

--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/axes.cmd
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/axes.cmd
@@ -1,0 +1,1 @@
+< $(MCLENCONFIG)/axes.cmd

--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/config.xml
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/config.xml
@@ -15,7 +15,7 @@
 <macro name="VELO1" pattern="[0-9]*\.?[0-9]*$" description="motor velocity (default: 1)" />
 <macro name="ACCL1" pattern="[0-9]*\.?[0-9]*$" description="motor acceleration (default: 1)" />
 <macro name="MRES1" pattern="[0-9]*\.?[0-9]*$" description="motor pulses per revolution (default: 0.0025)" />
-<macro name="ERES1" pattern="[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
+<macro name="ERES1" pattern="-?[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
 <macro name="DHLM1" pattern="-?[0-9]*\.?[0-9]*$" description="motor upper limit (default: 200)" />
 <macro name="DLLM1" pattern="-?[0-9]*\.?[0-9]*$" description="motor lower limit (default: -200)" />
 <macro name="MODE1" pattern="^(OPEN|CLOSED)$" description="motor control mode (default: OPEN)" />
@@ -28,7 +28,7 @@
 <macro name="VELO2" pattern="[0-9]*\.?[0-9]*$" description="motor velocity (default: 1)" />
 <macro name="ACCL2" pattern="[0-9]*\.?[0-9]*$" description="motor acceleration (default: 1)" />
 <macro name="MRES2" pattern="[0-9]*\.?[0-9]*$" description="motor pulses per revolution (default: 0.0025)" />
-<macro name="ERES2" pattern="[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
+<macro name="ERES2" pattern="-?[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
 <macro name="DHLM2" pattern="-?[0-9]*\.?[0-9]*$" description="motor upper limit (default: 200)" />
 <macro name="DLLM2" pattern="-?[0-9]*\.?[0-9]*$" description="motor lower limit (default: -200)" />
 <macro name="MODE2" pattern="^(OPEN|CLOSED)$" description="motor control mode (default: OPEN)" />
@@ -41,7 +41,7 @@
 <macro name="VELO3" pattern="[0-9]*\.?[0-9]*$" description="motor velocity (default: 1)" />
 <macro name="ACCL3" pattern="[0-9]*\.?[0-9]*$" description="motor acceleration (default: 1)" />
 <macro name="MRES3" pattern="[0-9]*\.?[0-9]*$" description="motor pulses per revolution (default: 0.0025)" />
-<macro name="ERES3" pattern="[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
+<macro name="ERES3" pattern="-?[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
 <macro name="DHLM3" pattern="-?[0-9]*\.?[0-9]*$" description="motor upper limit (default: 200)" />
 <macro name="DLLM3" pattern="-?[0-9]*\.?[0-9]*$" description="motor lower limit (default: -200)" />
 <macro name="MODE3" pattern="^(OPEN|CLOSED)$" description="motor control mode (default: OPEN)" />
@@ -54,7 +54,7 @@
 <macro name="VELO4" pattern="[0-9]*\.?[0-9]*$" description="motor velocity (default: 1)" />
 <macro name="ACCL4" pattern="[0-9]*\.?[0-9]*$" description="motor acceleration (default: 1)" />
 <macro name="MRES4" pattern="[0-9]*\.?[0-9]*$" description="motor pulses per revolution (default: 0.0025)" />
-<macro name="ERES4" pattern="[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
+<macro name="ERES4" pattern="-?[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
 <macro name="DHLM4" pattern="-?[0-9]*\.?[0-9]*$" description="motor upper limit (default: 200)" />
 <macro name="DLLM4" pattern="-?[0-9]*\.?[0-9]*$" description="motor lower limit (default: -200)" />
 <macro name="MODE4" pattern="^(OPEN|CLOSED)$" description="motor control mode (default: OPEN)" />
@@ -67,7 +67,7 @@
 <macro name="VELO5" pattern="[0-9]*\.?[0-9]*$" description="motor velocity (default: 1)" />
 <macro name="ACCL5" pattern="[0-9]*\.?[0-9]*$" description="motor acceleration (default: 1)" />
 <macro name="MRES5" pattern="[0-9]*\.?[0-9]*$" description="motor pulses per revolution (default: 0.0025)" />
-<macro name="ERES5" pattern="[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
+<macro name="ERES5" pattern="-?[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
 <macro name="DHLM5" pattern="-?[0-9]*\.?[0-9]*$" description="motor upper limit (default: 200)" />
 <macro name="DLLM5" pattern="-?[0-9]*\.?[0-9]*$" description="motor lower limit (default: -200)" />
 <macro name="MODE5" pattern="^(OPEN|CLOSED)$" description="motor control mode (default: OPEN)" />
@@ -80,7 +80,7 @@
 <macro name="VELO6" pattern="[0-9]*\.?[0-9]*$" description="motor velocity (default: 1)" />
 <macro name="ACCL6" pattern="[0-9]*\.?[0-9]*$" description="motor acceleration (default: 1)" />
 <macro name="MRES6" pattern="[0-9]*\.?[0-9]*$" description="motor pulses per revolution (default: 0.0025)" />
-<macro name="ERES6" pattern="[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
+<macro name="ERES6" pattern="-?[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
 <macro name="DHLM6" pattern="-?[0-9]*\.?[0-9]*$" description="motor upper limit (default: 200)" />
 <macro name="DLLM6" pattern="-?[0-9]*\.?[0-9]*$" description="motor lower limit (default: -200)" />
 <macro name="MODE6" pattern="^(OPEN|CLOSED)$" description="motor control mode (default: OPEN)" />
@@ -93,7 +93,7 @@
 <macro name="VELO7" pattern="[0-9]*\.?[0-9]*$" description="motor velocity (default: 1)" />
 <macro name="ACCL7" pattern="[0-9]*\.?[0-9]*$" description="motor acceleration (default: 1)" />
 <macro name="MRES7" pattern="[0-9]*\.?[0-9]*$" description="motor pulses per revolution (default: 0.0025)" />
-<macro name="ERES7" pattern="[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
+<macro name="ERES7" pattern="-?[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
 <macro name="DHLM7" pattern="-?[0-9]*\.?[0-9]*$" description="motor upper limit (default: 200)" />
 <macro name="DLLM7" pattern="-?[0-9]*\.?[0-9]*$" description="motor lower limit (default: -200)" />
 <macro name="MODE7" pattern="^(OPEN|CLOSED)$" description="motor control mode (default: OPEN)" />
@@ -106,7 +106,7 @@
 <macro name="VELO8" pattern="[0-9]*\.?[0-9]*$" description="motor velocity (default: 1)" />
 <macro name="ACCL8" pattern="[0-9]*\.?[0-9]*$" description="motor acceleration (default: 1)" />
 <macro name="MRES8" pattern="[0-9]*\.?[0-9]*$" description="motor pulses per revolution (default: 0.0025)" />
-<macro name="ERES8" pattern="[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
+<macro name="ERES8" pattern="-?[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
 <macro name="DHLM8" pattern="-?[0-9]*\.?[0-9]*$" description="motor upper limit (default: 200)" />
 <macro name="DLLM8" pattern="-?[0-9]*\.?[0-9]*$" description="motor lower limit (default: -200)" />
 <macro name="MODE8" pattern="^(OPEN|CLOSED)$" description="motor control mode (default: OPEN)" />

--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/motionsetpoints.cmd
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/motionsetpoints.cmd
@@ -1,0 +1,1 @@
+< $(MCLENCONFIG)/motionsetpoints.cmd

--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/sampleChanger.cmd
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/sampleChanger.cmd
@@ -1,0 +1,1 @@
+< $(MCLENCONFIG)/sampleChanger.cmd

--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/st-common.cmd
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/st-common.cmd
@@ -32,6 +32,12 @@ epicsEnvSet(PN,7)
 epicsEnvSet(PN,8)
 < st-port.cmd
 
+epicsEnvSet("MCLENCONFIG","$(ICPCONFIGROOT)/mclennan")
+
+# motion set points
+< motionsetpoints.cmd
+< sampleChanger.cmd
+
 ## motor util package
 dbLoadRecords("$(MOTOR)/db/motorUtil.db","P=$(MYPVPREFIX)$(IOCNAME):,$(IFIOC)= ,PVPREFIX=$(MYPVPREFIX)")
 

--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/st-common.cmd
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/st-common.cmd
@@ -34,6 +34,9 @@ epicsEnvSet(PN,8)
 
 epicsEnvSet("MCLENCONFIG","$(ICPCONFIGROOT)/mclennan")
 
+# configure axes
+< axes.cmd
+
 # motion set points
 < motionsetpoints.cmd
 < sampleChanger.cmd


### PR DESCRIPTION
### Description of work

- McLennan to call routines to initialize the sampleChanger
- Encoder ratio can be negative

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1708

### Acceptance criteria

- Can run a sample changer/linear sample changer using a McLennan motor
- Can set the encoder ratio of a McLennan to be negative

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Are the PVs named according to the [naming standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
- [ ] Have suitable [disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records) been added?
- [ ] Have suitable [simulation records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation) been added?
- [ ] Have the [finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches) been applied?
- [ ] Is there an [emulator](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Emulating-Devices) for the device?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.
- [ ] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- [ ] If there are multiple _0n IOCs, do they run correctly?

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section