### PR TITLE
Mark as defined on startup to avoid alarm trigger

### DIFF
--- a/EUROTHERM/EUROTHERM-IOC-01App/Db/devEurotherm.db
+++ b/EUROTHERM/EUROTHERM-IOC-01App/Db/devEurotherm.db
@@ -798,6 +798,7 @@ record(longout, "$(P)SP:NRETRY") {
 }
 
 ## current setpoint retry number
+## HIGH alarm value should be same as retry count NRETRY  
 record(longout, "$(P)SP:RETRYCNT") {
     field(DESC, "Last setpoint retry count")
     field(VAL, "0")
@@ -832,9 +833,7 @@ record(calcout, "$(P)_CHECKSP") {
 	field(HIGH, "0.5")
 	field(HSV, "MINOR")
 	field(ODLY, 1)
-	field(UDF, 0)
-    info(archive, "VAL")
-	info(alarm, "Euro")
+   info(archive, "VAL")
 }
 
 record(calcout, "$(P)_DORETRY") {

--- a/EUROTHERM/EUROTHERM-IOC-01App/Db/devEurotherm.db
+++ b/EUROTHERM/EUROTHERM-IOC-01App/Db/devEurotherm.db
@@ -832,6 +832,7 @@ record(calcout, "$(P)_CHECKSP") {
 	field(HIGH, "0.5")
 	field(HSV, "MINOR")
 	field(ODLY, 1)
+	field(UDF, 0)
     info(archive, "VAL")
 	info(alarm, "Euro")
 }


### PR DESCRIPTION
### Description of work

Mark CHECKSP as defined on startup to avoid "undefined" alarm being raised

See ISISComputingGroup/IBEX#1733
### To test

Start eurothem ioc and check that no alarms are raised
### Acceptance criteria

above is true
---
#### Code Review
- [x] Is the code of an acceptable quality?
- [x] Are the PVs named according to the [naming standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
- [ ] Have suitable [disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records) been added?
- [ ] Have suitable [simulation records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation) been added?
- [ ] Have the [finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches) been applied?
- [ ] Is there an [emulator](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Emulating-Devices) for the device?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- [ ] If there are multiple _0n IOCs, do they run correctly?
### Final steps
- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
