### PR TITLE
Ticket1725 custom mc lennan homing routines

### DIFF
--- a/MCLEN/MCLEN-IOC-01App/src/build.mak
+++ b/MCLEN/MCLEN-IOC-01App/src/build.mak
@@ -31,6 +31,7 @@ $(APPNAME)_DBD += calcSupport.dbd
 $(APPNAME)_DBD += motorSupport.dbd
 $(APPNAME)_DBD += motorSimSupport.dbd
 $(APPNAME)_DBD += devMclennanMotor.dbd
+$(APPNAME)_DBD += homing.dbd
 $(APPNAME)_DBD += devSoftMotor.dbd
 $(APPNAME)_DBD += drvAsynSerialPort.dbd
 $(APPNAME)_DBD += drvAsynIPPort.dbd

--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/st-motor.cmd
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/st-motor.cmd
@@ -79,3 +79,6 @@ dbLoadRecords("$(MOTOR)/db/motorStatus.db", "P=$(MYPVPREFIX),M=$(AMOTORPV)")
 dbLoadRecords("$(AXIS)/db/axis.db", "P=$(MYPVPREFIX),AXIS=$(IOCNAME):AXIS$(PN),mAXIS=$(AMOTORPV)") 
 
 #autosaveBuild("$(IOCNAME)_$(PN)_built_settings.req", "_settings.req", 0)
+
+## Start homing sequencer
+seq homing, "MOTPV=$(MYPVPREFIX)$(AMOTORPV)"

--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/st-motor.cmd
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/st-motor.cmd
@@ -81,4 +81,4 @@ dbLoadRecords("$(AXIS)/db/axis.db", "P=$(MYPVPREFIX),AXIS=$(IOCNAME):AXIS$(PN),m
 #autosaveBuild("$(IOCNAME)_$(PN)_built_settings.req", "_settings.req", 0)
 
 ## Start homing sequencer
-seq homing, "MOTPV=$(MYPVPREFIX)$(AMOTORPV)"
+seq homing, "MOTPV=$(MYPVPREFIX)$(AMOTORPV),MODE='Constant_velocity'"


### PR DESCRIPTION
### Description of work

McLennan connects to the new homing sequencer at startup. Requires corresponding change in motorApp

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1725

### Acceptance criteria

McLennan IOC homing behaviour is as expected:

- [x] Request homing forward. Motor moves forward at a constant velocity until it hits limit switch
- [x] As above but in reverse
- [x] As above, but interrupt with a different command. Make sure motor behaves as expected (executes new command) [Forward]
- [x] As above [Reverse]

The behaviour should effectively be the same as before. What is important that it is the view of the reviewer that the infrastructure is in place so that we can define custom behaviour easily in future. Note that are several things that aren't explicit in the current implementation:

- The homing mode is sent from the IOC to the sequencer at startup, but it is never used because we only have one mode
- The homing mechanism works by setting PV values in the McLennan motor, not by talking to the motor directly (much easier). Constant velocity homing is easy because we can simply call the JOG behaviour instead. More complex behaviour might not be covered by existing commands so would require extension of the driver. I expect most behaviour should be controllable by sequentially setting PVs though.
- I haven't yet added macros for changing the homing mode. While there is only one mode available, a macro seems superfluous

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- [x] If there are multiple _0n IOCs, do they run correctly?

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section