### PR TITLE
Do not record writes to MOVING PV

### DIFF
--- a/INSTETC/INSTETC-IOC-01App/Db/INSTETC.db
+++ b/INSTETC/INSTETC-IOC-01App/Db/INSTETC.db
@@ -17,6 +17,7 @@ record(calc, "$(P)CS:MOT:MOVING")
     field(VAL, "0")
 	field(SCAN, "Passive")
 	field(CALC, "(A+B+C+D+E+F+G+H+I) > 0 ? 1 : 0")
+	field(ASG, "NOTRAPW")
     info(archive, "VAL")
 }
 
@@ -29,6 +30,7 @@ record(calcout, "$(P)CS:MOT:_MOVING1")
 	field(OUT, "$(P)CS:MOT:MOVING.I PP")
 	field(OOPT, "Every Time")
 	field(DOPT, "Use CALC")
+	field(ASG, "NOTRAPW")
     info(archive, "VAL")
 }
 


### PR DESCRIPTION
### Description of work

Assign MOVING PVs to the NOTRAPW access security group so they are not reported by CAPutLog

### To test

See ISISComputingGroup/IBEX#1847

### Acceptance criteria

Before merge, you should see MOVING.A etc info log messages as described in ticket above whenever a motor moves. After merge you should see no such messages when a motor moves. 

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Are the PVs named according to the [naming standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
- [ ] Have suitable [disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records) been added?
- [ ] Have suitable [simulation records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation) been added?
- [ ] Have the [finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches) been applied?
- [ ] Is there an [emulator](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Emulating-Devices) for the device?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [ ] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- [ ] If there are multiple _0n IOCs, do they run correctly?

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
