### PR TITLE
Added freeport finder to julabo IOCs

### DIFF
--- a/JULABO/iocBoot/iocJULABO-IOC-01/st-common.cmd
+++ b/JULABO/iocBoot/iocJULABO-IOC-01/st-common.cmd
@@ -1,0 +1,37 @@
+epicsEnvSet "STREAM_PROTOCOL_PATH" "$(JULABO)/julaboApp/protocol"
+
+cd ${TOP}
+
+##ISIS## Run IOC initialisation 
+< $(IOCSTARTUP)/init.cmd
+
+## For emulator use:
+$(IFDEVSIM) freeIPPort("FREEPORT")  
+$(IFDEVSIM) epicsEnvShow("FREEPORT") 
+$(IFDEVSIM) drvAsynIPPortConfigure("L0", "localhost:$(FREEPORT)")
+
+## For real device use:
+$(IFNOTDEVSIM) drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
+$(IFNOTDEVSIM) asynSetOption("L0", -1, "baud", "4800")
+$(IFNOTDEVSIM) asynSetOption("L0", -1, "bits", "7")
+$(IFNOTDEVSIM) asynSetOption("L0", -1, "parity", "even")
+$(IFNOTDEVSIM) asynSetOption("L0", -1, "stop", "1")
+
+## Load record instances
+
+##ISIS## Load common DB records 
+< $(IOCSTARTUP)/dbload.cmd
+
+## Load our record instances
+dbLoadRecords("$(DB_FILE)","P=$(MYPVPREFIX)$(IOCNAME):, PORT=L0")
+
+##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
+< $(IOCSTARTUP)/preiocinit.cmd
+
+cd ${TOP}/iocBoot/${IOC}
+iocInit
+
+## Start any sequence programs
+
+##ISIS## Stuff that needs to be done after iocInit is called e.g. sequence programs 
+< $(IOCSTARTUP)/postiocinit.cmd

--- a/JULABO/iocBoot/iocJULABO-IOC-01/st.cmd
+++ b/JULABO/iocBoot/iocJULABO-IOC-01/st.cmd
@@ -6,41 +6,17 @@
 # Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
 errlogInit2(65536, 256)
 
+## Set the specific db file to use here because the command set can vary across models
+epicsEnvSet "DB_FILE" "db/FP50_MH.db"
+
 < envPaths
 
 cd ${TOP}
-
-epicsEnvSet "STREAM_PROTOCOL_PATH" "$(JULABO)/julaboApp/protocol"
 
 ## Register all support components
 dbLoadDatabase "dbd/JULABO-IOC-01.dbd"
 JULABO_IOC_01_registerRecordDeviceDriver pdbbase
 
-##ISIS## Run IOC initialisation 
-< $(IOCSTARTUP)/init.cmd
+cd ${TOP}/iocBoot/iocJULABO-IOC-01
 
-drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
-asynSetOption("L0", -1, "baud", "4800")
-asynSetOption("L0", -1, "bits", "7")
-asynSetOption("L0", -1, "parity", "even")
-asynSetOption("L0", -1, "stop", "1")
-
-## Load record instances
-
-##ISIS## Load common DB records 
-< $(IOCSTARTUP)/dbload.cmd
-
-## Load our record instances
-dbLoadRecords("db/FP50_MH.db","P=$(MYPVPREFIX)$(IOCNAME):, PORT=L0")
-
-##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
-< $(IOCSTARTUP)/preiocinit.cmd
-
-cd ${TOP}/iocBoot/${IOC}
-iocInit
-
-## Start any sequence programs
-#seq sncxxx,"user=mjc23Host"
-
-##ISIS## Stuff that needs to be done after iocInit is called e.g. sequence programs 
-< $(IOCSTARTUP)/postiocinit.cmd
+< st-common.cmd

--- a/JULABO/iocBoot/iocJULABO-IOC-02/st.cmd
+++ b/JULABO/iocBoot/iocJULABO-IOC-02/st.cmd
@@ -6,41 +6,17 @@
 # Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
 errlogInit2(65536, 256)
 
+## Set the specific db file to use here because the command set can vary across models
+epicsEnvSet "DB_FILE" "db/FP50_MH.db"
+
 < envPaths
 
 cd ${TOP}
-
-epicsEnvSet "STREAM_PROTOCOL_PATH" "$(JULABO)/julaboApp/protocol"
 
 ## Register all support components
 dbLoadDatabase "dbd/JULABO-IOC-02.dbd"
 JULABO_IOC_02_registerRecordDeviceDriver pdbbase
 
-##ISIS## Run IOC initialisation 
-< $(IOCSTARTUP)/init.cmd
+cd ${TOP}/iocBoot/iocJULABO-IOC-01
 
-drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
-asynSetOption("L0", -1, "baud", "4800")
-asynSetOption("L0", -1, "bits", "7")
-asynSetOption("L0", -1, "parity", "even")
-asynSetOption("L0", -1, "stop", "1")
-
-## Load record instances
-
-##ISIS## Load common DB records 
-< $(IOCSTARTUP)/dbload.cmd
-
-## Load our record instances
-dbLoadRecords("db/FP50_MH.db","P=$(MYPVPREFIX)$(IOCNAME):, PORT=L0")
-
-##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
-< $(IOCSTARTUP)/preiocinit.cmd
-
-cd ${TOP}/iocBoot/${IOC}
-iocInit
-
-## Start any sequence programs
-#seq sncxxx,"user=mjc23Host"
-
-##ISIS## Stuff that needs to be done after iocInit is called e.g. sequence programs 
-< $(IOCSTARTUP)/postiocinit.cmd
+< st-common.cmd

--- a/LKSH336/iocBoot/iocLKSH336-IOC-01/st-common.cmd
+++ b/LKSH336/iocBoot/iocLKSH336-IOC-01/st-common.cmd
@@ -18,7 +18,6 @@ $(IFNOTDEVSIM) drvAsynIPPortConfigure ("$(DEVICE)", "$(HOST):7777")
 < $(IOCSTARTUP)/dbload.cmd
 
 ## Load our record instances
-#dbLoadRecords("db/xxx.db","user=iew83206Host")
 dbLoadRecords("db/lakeshore336.db", "P=$(MYPVPREFIX)$(IOCNAME), PORT=$(DEVICE), ADDR=0, TEMPSCAN=1, SCAN=2, TOLERANCE=1, RECSIM=$(RECSIM=0), DISABLE=$(DISABLE=0)")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
@@ -28,7 +27,6 @@ cd ${TOP}/iocBoot/${IOC}
 iocInit
 
 ## Start any sequence programs
-#seq sncxxx,"user=iew83206Host"
 
 ##ISIS## Stuff that needs to be done after iocInit is called e.g. sequence programs 
 < $(IOCSTARTUP)/postiocinit.cmd


### PR DESCRIPTION
### Description of work

https://github.com/ISISComputingGroup/IBEX/issues/1530

Freddie added support for IOCs to find a free port for Lewis (née Plankton). This PR adds it to the JULABO IOCs as an example of how to use it.

### To test

If you put the JULABO into DEVSIM then it should find a free port which could be used for Lewis. You can see this by looking through the IOCs output on start up.

It will complain about there being nothing on that port as Lewis won't be running, but that is a story for another day.

### Acceptance criteria

In DEVSIM mode,  the JULABO will find a free port.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- [x] If there are multiple _0n IOCs, do they run correctly?

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section