### PR TITLE
Add LVDCOM macros to allow settings for Labview Start

### DIFF
--- a/SCIMAG3D/iocBoot/iocSCIMAG3D-IOC-01/config.xml
+++ b/SCIMAG3D/iocBoot/iocSCIMAG3D-IOC-01/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+ <config_part>
+  <ioc_desc>3D Magnet</ioc_desc>
+  <ioc_details>3D Vector Magnet System from Scientific Magnetics</ioc_details>
+  <macros>
+    <macro name="LVDCOM_OPTIONS" pattern="^\d?\d?$" description="Options that define how the VI is started. Add selected options together to make the final value. 1 - warn if idle, 2 - start if idle, 4 - stop VIs if started on exit, 6 - stop VI on exit. (Default 1)" />
+	<macro name="LVDCOM_HOST" pattern="^.*$" description="Host on which the vi is running, blank for localhost (Default '')" />
+  </macros>
+ </config_part>
+</ioc_config>

--- a/SCIMAG3D/iocBoot/iocSCIMAG3D-IOC-01/config.xml
+++ b/SCIMAG3D/iocBoot/iocSCIMAG3D-IOC-01/config.xml
@@ -6,6 +6,7 @@
   <macros>
     <macro name="LVDCOM_OPTIONS" pattern="^\d?\d?$" description="Options that define how the VI is started. Add selected options together to make the final value. 1 - warn if idle, 2 - start if idle, 4 - stop VIs if started on exit, 6 - stop VI on exit. (Default 1)" />
 	<macro name="LVDCOM_HOST" pattern="^.*$" description="Host on which the vi is running, blank for localhost (Default '')" />
+	<macro name="LVDCOM_PROGID" pattern="^.*$" description="DCOM ProgID, required if connecting to a compiled LabVIEW application (Default '')" />
   </macros>
  </config_part>
 </ioc_config>

--- a/SCIMAG3D/iocBoot/iocSCIMAG3D-IOC-01/st.cmd
+++ b/SCIMAG3D/iocBoot/iocSCIMAG3D-IOC-01/st.cmd
@@ -17,7 +17,7 @@ SCIMAG3D_IOC_01_registerRecordDeviceDriver pdbbase
 ##ISIS## Run IOC initialisation 
 < $(IOCSTARTUP)/init.cmd
 
-lvDCOMConfigure("lvfp", "frontpanel", "$(MAGNET3D)/data/lv_controls.xml", "$(LVDCOM_HOST="")", $(LVDCOM_OPTIONS=1))
+lvDCOMConfigure("lvfp", "frontpanel", "$(MAGNET3D)/data/lv_controls.xml", "$(LVDCOM_HOST="")", $(LVDCOM_OPTIONS=1), "$(LVDCOM_USER="")", "$(LVDCOM_PASS="")")
 ## Load record instances
 
 

--- a/SCIMAG3D/iocBoot/iocSCIMAG3D-IOC-01/st.cmd
+++ b/SCIMAG3D/iocBoot/iocSCIMAG3D-IOC-01/st.cmd
@@ -17,7 +17,7 @@ SCIMAG3D_IOC_01_registerRecordDeviceDriver pdbbase
 ##ISIS## Run IOC initialisation 
 < $(IOCSTARTUP)/init.cmd
 
-lvDCOMConfigure("lvfp", "frontpanel", "$(MAGNET3D)/data/lv_controls.xml")
+lvDCOMConfigure("lvfp", "frontpanel", "$(MAGNET3D)/data/lv_controls.xml", "$(LVDCOM_HOST="")", $(LVDCOM_OPTIONS=1))
 ## Load record instances
 
 

--- a/SCIMAG3D/iocBoot/iocSCIMAG3D-IOC-01/st.cmd
+++ b/SCIMAG3D/iocBoot/iocSCIMAG3D-IOC-01/st.cmd
@@ -17,7 +17,7 @@ SCIMAG3D_IOC_01_registerRecordDeviceDriver pdbbase
 ##ISIS## Run IOC initialisation 
 < $(IOCSTARTUP)/init.cmd
 
-lvDCOMConfigure("lvfp", "frontpanel", "$(MAGNET3D)/data/lv_controls.xml", "$(LVDCOM_HOST="")", $(LVDCOM_OPTIONS=1), "$(LVDCOM_USER="")", "$(LVDCOM_PASS="")")
+lvDCOMConfigure("lvfp", "frontpanel", "$(MAGNET3D)/data/lv_controls.xml", "$(LVDCOM_HOST=)", $(LVDCOM_OPTIONS=1), "$(LVDCOM_PROGID=)", "$(LVDCOM_USER=)", "$(LVDCOM_PASS=)")
 ## Load record instances
 
 


### PR DESCRIPTION
### Description of work

Allow the instrument scientist to set the LVDcom options and host.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1979

### Acceptance criteria

* Without a setting vi should not start but a warning message should be written in IOC which says `"C:\LabVIEW Modules\Drivers\Scientific Instruments\3D Magnet\Source Code\Vector-
control-v16isis.vi" is not running on localhost and autostart is disabled`. 
* With setting it should do what setting suggests.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [ ] Are the PVs named according to the [naming standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
- [ ] Have suitable [disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records) been added?
- [ ] Have suitable [simulation records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation) been added?
- [x] Have the [finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches) been applied?
- [ ] Is there an [emulator](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Emulating-Devices) for the device?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)? There is a script called `check_opi_format.py` to help with this.

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [ ] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- [ ] If there are multiple _0n IOCs, do they run correctly?

### Final steps

- [x] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
