### PR TITLE
Ticket2063 fix tpg300 ioc

### DIFF
--- a/TPG300/iocBoot/iocTPG300-IOC-02/st.cmd
+++ b/TPG300/iocBoot/iocTPG300-IOC-02/st.cmd
@@ -14,4 +14,4 @@ cd ${TOP}
 dbLoadDatabase "dbd/TPG300-IOC-02.dbd"
 TPG300_IOC_02_registerRecordDeviceDriver pdbbase
 
-< ${TOP}/iocBoot/${IOC}/st-common.cmd
+< ${TOP}/iocBoot/iocTPG300-IOC-01/st-common.cmd

--- a/TPG300/iocBoot/iocTPG300-IOC-03/st.cmd
+++ b/TPG300/iocBoot/iocTPG300-IOC-03/st.cmd
@@ -12,6 +12,6 @@ cd ${TOP}
 
 ## Register all support components
 dbLoadDatabase "dbd/TPG300-IOC-03.dbd"
-TPG300_IOC_02_registerRecordDeviceDriver pdbbase
+TPG300_IOC_03_registerRecordDeviceDriver pdbbase
 
 < ${TOP}/iocBoot/iocTPG300-IOC-01/st-common.cmd

--- a/TPG300/iocBoot/iocTPG300-IOC-03/st.cmd
+++ b/TPG300/iocBoot/iocTPG300-IOC-03/st.cmd
@@ -14,4 +14,4 @@ cd ${TOP}
 dbLoadDatabase "dbd/TPG300-IOC-03.dbd"
 TPG300_IOC_02_registerRecordDeviceDriver pdbbase
 
-< ${TOP}/iocBoot/${IOC}/st-common.cmd
+< ${TOP}/iocBoot/iocTPG300-IOC-01/st-common.cmd


### PR DESCRIPTION
### Description of work

The TPG300 IOCs didn't start. With this patch, they should start successfully.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2063

### Acceptance criteria

All three TPG300 IOCs start successfully.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? 
- [x] If there are multiple _0n IOCs, do they run correctly?

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
