### PR TITLE
Link areaDetector into DAE

### DIFF
--- a/ISISDAE/ISISDAE-IOC-01App/src/build.mak
+++ b/ISISDAE/ISISDAE-IOC-01App/src/build.mak
@@ -44,6 +44,14 @@ $(APPNAME)_LIBS += autosave
 $(APPNAME)_LIBS += utilities
 ## Add other libraries here ##
 $(APPNAME)_LIBS += FileList isisdae asyn oncrpc zlib efsw pcrecpp pcre cas gdd
+$(APPNAME)_LIBS += ffmpegServer
+$(APPNAME)_LIBS += avdevice
+$(APPNAME)_LIBS += avformat
+$(APPNAME)_LIBS += avcodec
+$(APPNAME)_LIBS += avutil
+$(APPNAME)_LIBS += swscale
+$(APPNAME)_LIBS += ADnEDSupport
+$(APPNAME)_LIBS += ADnEDTransform
 
 # ISISDAE-IOC-01_registerRecordDeviceDriver.cpp derives from ISISDAE-IOC-01.dbd
 $(APPNAME)_SRCS += $(APPNAME)_registerRecordDeviceDriver.cpp
@@ -57,6 +65,9 @@ $(APPNAME)_SRCS_vxWorks += -nil-
 
 # Finally link to the EPICS Base libraries
 $(APPNAME)_LIBS += $(EPICS_BASE_IOC_LIBS)
+
+PROD_NAME = $(APPNAME)
+include $(ADCORE)/ADApp/commonDriverMakefile
 
 #===========================
 

--- a/ISISDAE/configure/CONFIG_SITE
+++ b/ISISDAE/configure/CONFIG_SITE
@@ -31,3 +31,5 @@ CHECK_RELEASE = YES
 # You must rebuild in the iocBoot directory for this to
 #   take effect.
 #IOCS_APPL_TOP = </IOC/path/to/application/top>
+
+include $(AREA_DETECTOR)/configure/CONFIG_SITE

--- a/ISISDAE/configure/RELEASE
+++ b/ISISDAE/configure/RELEASE
@@ -9,3 +9,6 @@ include $(TOP)/../../../configure/MASTER_RELEASE
 
 include $(TOP)/../../../ISIS_CONFIG
 -include $(TOP)/../../../ISIS_CONFIG.$(EPICS_HOST_ARCH)
+
+include $(AREA_DETECTOR)/configure/RELEASE.local
+include $(AREA_DETECTOR)/configure/RELEASE_LIBS.local


### PR DESCRIPTION
### Description of work

Reference, but not call, areaDetector framework in preparation for ZOOM work 

### To test

See ISISComputingGroup/IBEX#2100

### Acceptance criteria

Everything still builds

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Are the PVs named according to the [naming standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
- [ ] Have suitable [disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records) been added?
- [ ] Have suitable [simulation records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation) been added?
- [ ] Have the [finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches) been applied?
- [ ] Is there an [emulator](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Emulating-Devices) for the device?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)? There is a script called `check_opi_format.py` to help with this.

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.
- [ ] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- [ ] If there are multiple _0n IOCs, do they run correctly?

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
