### PR TITLE
Ticket2045 Keithley general read/write separated

### DIFF
--- a/KHLY2400/KHLY2400-IOC-01App/Db/KHLY2400.db
+++ b/KHLY2400/KHLY2400-IOC-01App/Db/KHLY2400.db
@@ -200,41 +200,79 @@ record(ai, "$(P)SIM:R")
 #### General input ####
 #######################
 
-record(stringout, "$(P)GEN:SP")
+record(stringout, "$(P)READ:SP")
 {
-	field(DESC, "General input command")
-	field(FLNK, "$(P)GEN PP")
-	field(PINI, "YES")
+	field(DESC, "General read command")
 	field(VAL, "*IDN?")
+	field(PINI, "YES")
+	field(FLNK, "$(P)READ PP")
     field(SIML, "$(P)SIM")
-    field(SIOL, "$(P)SIM:GEN")
+    field(SIOL, "$(P)SIM:READ")
     field(SDIS, "$(P)DISABLE")
     info(archive, "VAL")
     info(INTEREST, "HIGH")
 }
 
-record(stringin, "$(P)GEN")
+record(stringin, "$(P)READ")
 {
     field(DESC, "General input command response")
     field(DTYP, "stream")
-    field(INP, "@Keithley2400.proto gen($(P)GEN:SP) $(PORT)")
+    field(INP, "@Keithley2400.proto gen($(P)READ:SP) $(PORT)")
     field(SCAN, "Passive")
-    field(SIOL, "$(P)SIM:GEN")
+    field(SIOL, "$(P)SIM:READ")
     field(SIML, "$(P)SIM")
     field(SDIS, "$(P)DISABLE")
     info(archive, "VAL")
     info(INTEREST, "HIGH")
 }
 
-record(stringin, "$(P)SIM:GEN")
+record(stringin, "$(P)SIM:READ")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")
 }
 
-alias("$(P)GEN", "$(P)GEN:SP:RBV")
-alias("$(P)SIM:GEN", "$(P)SIM:GEN:SP")
-alias("$(P)SIM:GEN", "$(P)SIM:GEN:SP:RBV")
+alias("$(P)READ", "$(P)READ:SP:RBV")
+alias("$(P)SIM:READ", "$(P)SIM:READ:SP")
+alias("$(P)SIM:READ", "$(P)SIM:READ:SP:RBV")
+
+# Write is identical to read except that the return value isn't printed
+# by the UI. This is handled as two separate PV blocks so the controls can
+# act independently.
+
+record(stringout, "$(P)WRITE:SP")
+{
+	field(DESC, "General write command")
+	field(FLNK, "$(P)WRITE PP")
+    field(SIML, "$(P)SIM")
+    field(SIOL, "$(P)SIM:WRITE")
+    field(SDIS, "$(P)DISABLE")
+    info(archive, "VAL")
+    info(INTEREST, "HIGH")
+}
+
+record(stringin, "$(P)WRITE")
+{
+    field(DESC, "General input command response")
+    field(DTYP, "stream")
+    field(INP, "@Keithley2400.proto gen($(P)WRITE:SP) $(PORT)")
+    field(SCAN, "Passive")
+    field(SIOL, "$(P)SIM:WRITE")
+    field(SIML, "$(P)SIM")
+    field(SDIS, "$(P)DISABLE")
+    info(archive, "VAL")
+    info(INTEREST, "HIGH")
+}
+
+record(stringin, "$(P)SIM:WRITE")
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+}
+
+alias("$(P)WRITE", "$(P)WRITE:SP:RBV")
+alias("$(P)SIM:WRITE", "$(P)SIM:WRITE:SP")
+alias("$(P)SIM:WRITE", "$(P)SIM:WRITE:SP:RBV")
 
 ###############
 #### Reset ####


### PR DESCRIPTION
### Description of work

I've separated out the "general" PVs into separate read/write controls. They do the same thing but allow us to have two independent controls on the OPI as in the VI.

GUI PR is here: https://github.com/ISISComputingGroup/ibex_gui/pull/465

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2045

### Acceptance criteria

Note that it is perfectly possible to put set commands in the read PV and get commands in write. You'll just get too much/too little output respectively.

- [x] Read and write controls work (Try using get `*IDN?` and set `:OUTP 1`)
- [x] Two controls work independently (write output doesn't appear in read PV)

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Are the PVs named according to the [naming standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
- [ ] Have suitable [disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records) been added?
- [x] Have suitable [simulation records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation) been added?
- [x] Have the [finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches) been applied?
- [x] Is there an [emulator](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Emulating-Devices) for the device?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [x] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)? There is a script called `check_opi_format.py` to help with this.

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- [ ] If there are multiple _0n IOCs, do they run correctly?

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
