### PR TITLE
Ticket2221 make autotune interesting

### DIFF
--- a/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
+++ b/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
@@ -571,7 +571,7 @@ record(ai, "$(P)AUTOTUNE") {
 
 record(ao, "$(P)AUTOTUNE:SP") {
     info(INTEREST, "MEDIUM")
-    field(DESC, "D Setpoint")
+    field(DESC, "Autotune Setpoint")
     field(DTYP, "stream")
     field(OUT, "@eurotherm2k.proto write($(P),AT,$(GAD),$(LAD)) $(PORT)")
     field(SIML, "$(Q)SIM")

--- a/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
+++ b/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
@@ -559,6 +559,7 @@ record(ao, "$(P)D:SP") {
 alias("$(P)D", "$(P)D:SP:RBV")
 
 record(ai, "$(P)AUTOTUNE") {
+    info(INTEREST, "MEDIUM")
     field(DESC, "Autotune Readback")
     field(DTYP, "stream")
     field(SCAN, "Passive")
@@ -569,6 +570,7 @@ record(ai, "$(P)AUTOTUNE") {
 }
 
 record(ao, "$(P)AUTOTUNE:SP") {
+    info(INTEREST, "MEDIUM")
     field(DESC, "D Setpoint")
     field(DTYP, "stream")
     field(OUT, "@eurotherm2k.proto write($(P),AT,$(GAD),$(LAD)) $(PORT)")

--- a/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
+++ b/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
@@ -570,7 +570,6 @@ record(ai, "$(P)AUTOTUNE") {
 }
 
 record(ao, "$(P)AUTOTUNE:SP") {
-    info(INTEREST, "MEDIUM")
     field(DESC, "Autotune Setpoint")
     field(DTYP, "stream")
     field(OUT, "@eurotherm2k.proto write($(P),AT,$(GAD),$(LAD)) $(PORT)")


### PR DESCRIPTION
### Description of work

Adds autotune as an "interesting" field (useful because Polaris has a block looking at autotune)

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2221

### Acceptance criteria

- [ ] From the GUI a block can be added looking at the autotune property of a eurotherm

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Are the PVs named according to the [naming standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
- [ ] Have suitable [disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records) been added?
- [ ] Have suitable [simulation records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation) been added?
- [ ] Have the [finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches) been applied?
- [ ] Is there an [emulator](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Emulating-Devices) for the device?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)? There is a script called `check_opi_format.py` to help with this.

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- [x] If there are multiple _0n IOCs, do they run correctly?

### Final steps

- [x] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
