### PR TITLE
Ticket2219 hrpd jaws commissioning

### DIFF
--- a/LINMOT/LINMOT-IOC-01App/Db/motor.substitutions
+++ b/LINMOT/LINMOT-IOC-01App/Db/motor.substitutions
@@ -1,6 +1,9 @@
-file $(MOTOR)/db/linmot_motor.db {
-
+file $(MOTOR)/db/motor.db {
 pattern {P,    M,         DTYP,      DESC,   EGU,  DIR,  VELO,  VBAS, ACCL, BDST, BVEL, BACC,    MRES,    ERES, UEIP, PREC, DHLM, DLLM, INIT, C, S, OFF }
-{"\$(P)", "\$(M)", "LinMot", "\$(NAME) (LINMOT)",    "degree",  "Pos",  "\$(VELO)",   "\$(VBAS)",  "\$(ACCL)",    0,    1,   0,   "\$(MRES)",   "\$(ERES)", "\$(UEIP)",    3,   "\$(DHLM)",   "\$(DLLM)",  "", "\$(C)", "\$(S)", "\$(OFF)"}
+{"\$(P)", "\$(M)", "LinMot", "\$(NAME) (LINMOT)",    "degree",  "Pos",  "\$(VELO)",   "\$(VBAS)",  "\$(ACCL)",    0,    1,   0,   "\$(MRES)",   "\$(ERES)", "\$(UEIP)",    3,   "\$(DHLM)",   "\$(DLLM)",  "", "\$(C)", "\$(S)"}
+}
 
+file $(MOTOR)/db/linmot_extra.db {
+pattern {P, M, OFF}
+{"\$(P)", "\$(M)", "\$(OFF)"}
 }

--- a/LINMOT/LINMOT-IOC-01App/Db/motor.substitutions
+++ b/LINMOT/LINMOT-IOC-01App/Db/motor.substitutions
@@ -1,6 +1,6 @@
-file $(MOTOR)/motorApp/Db/motor.db {
+file $(MOTOR)/db/linmot_motor.db {
 
-pattern {P,    M,         DTYP,      DESC,   EGU,  DIR,  VELO,  VBAS, ACCL, BDST, BVEL, BACC,    MRES,    ERES, UEIP, PREC, DHLM, DLLM, INIT, C, S }
-{"\$(P)", "\$(M)", "LinMot", "\$(NAME) (LINMOT)",    "degree",  "Pos",  "\$(VELO)",   "\$(VBAS)",  "\$(ACCL)",    0,    1,   0,   "\$(MRES)",   "\$(ERES)", "\$(UEIP)",    3,   "\$(DHLM)",   "\$(DLLM)",  "", "\$(C)", "\$(S)"}
+pattern {P,    M,         DTYP,      DESC,   EGU,  DIR,  VELO,  VBAS, ACCL, BDST, BVEL, BACC,    MRES,    ERES, UEIP, PREC, DHLM, DLLM, INIT, C, S, OFF }
+{"\$(P)", "\$(M)", "LinMot", "\$(NAME) (LINMOT)",    "degree",  "Pos",  "\$(VELO)",   "\$(VBAS)",  "\$(ACCL)",    0,    1,   0,   "\$(MRES)",   "\$(ERES)", "\$(UEIP)",    3,   "\$(DHLM)",   "\$(DLLM)",  "", "\$(C)", "\$(S)", "\$(OFF)"}
 
 }

--- a/LINMOT/LINMOT-IOC-01App/Db/motor.substitutions
+++ b/LINMOT/LINMOT-IOC-01App/Db/motor.substitutions
@@ -1,6 +1,6 @@
 file $(MOTOR)/db/motor.db {
 pattern {P,    M,         DTYP,      DESC,   EGU,  DIR,  VELO,  VBAS, ACCL, BDST, BVEL, BACC,    MRES,    ERES, UEIP, PREC, DHLM, DLLM, INIT, C, S, OFF }
-{"\$(P)", "\$(M)", "LinMot", "\$(NAME) (LINMOT)",    "degree",  "Pos",  "\$(VELO)",   "\$(VBAS)",  "\$(ACCL)",    0,    1,   0,   "\$(MRES)",   "\$(ERES)", "\$(UEIP)",    3,   "\$(DHLM)",   "\$(DLLM)",  "", "\$(C)", "\$(S)"}
+{"\$(P)", "\$(M)", "LinMot", "\$(NAME) (LINMOT)",    "\$(EGU)",  "Pos",  "\$(VELO)",   "\$(VBAS)",  "\$(ACCL)",    0,    1,   0,   "\$(MRES)",   "\$(ERES)", "\$(UEIP)",    3,   "\$(DHLM)",   "\$(DLLM)",  "", "\$(C)", "\$(S)"}
 }
 
 file $(MOTOR)/db/linmot_extra.db {

--- a/LINMOT/LINMOT-IOC-01App/Db/motorSim.substitutions
+++ b/LINMOT/LINMOT-IOC-01App/Db/motorSim.substitutions
@@ -1,11 +1,11 @@
-#file $(MOTOR)/motorApp/Db/motor.db {
+#file $(MOTOR)/db/motor.db {
 #
 #pattern {P,    M,         DTYP,      DESC,   EGU,  DIR,  VELO,  VBAS, ACCL, BDST, BVEL, BACC,    MRES,    ERES, UEIP, PREC, DHLM, DLLM, INIT, C, S, MOTORSIM }
 #{"\$(P)", "\$(M)", "Motor Simulation", "\$(NAME) (LINMOT)",    "degree",  "Pos",  "\$(VELO)",   1,  "\$(ACCL)",    0,    1,   0,   "\$(MRES)",   "\$(ERES)", "\$(UEIP)",    3,   "\$(DHLM)",   "\$(DLLM)",  "", "\$(C)", "\$(S)", "motorSim" }
 #
 #}
 
-file $(MOTOR)/motorApp/Db/asyn_motor.db {
+file $(MOTOR)/db/asyn_motor.db {
 
 pattern {P,    M,         DTYP,      DESC,   EGU,  DIR,  VELO,  VBAS, ACCL, BDST, BVEL, BACC,    MRES,    ERES, UEIP, PREC, DHLM, DLLM, INIT, C, S, MOTORSIM, PORT, ADDR }
 {"\$(P)", "\$(M)", "asynMotor", "\$(NAME) (LINMOT)",    "degree",  "Pos",  "\$(VELO)",   1,  "\$(ACCL)",    0,    1,   0,   "\$(MRES)",   "\$(ERES)", "\$(UEIP)",    3,   "\$(DHLM)",   "\$(DLLM)",  "", "\$(C)", "\$(S)", "motorSim", "motorSim", "0" }

--- a/LINMOT/LINMOT-IOC-01App/Db/motorSim.substitutions
+++ b/LINMOT/LINMOT-IOC-01App/Db/motorSim.substitutions
@@ -8,6 +8,6 @@
 file $(MOTOR)/db/asyn_motor.db {
 
 pattern {P,    M,         DTYP,      DESC,   EGU,  DIR,  VELO,  VBAS, ACCL, BDST, BVEL, BACC,    MRES,    ERES, UEIP, PREC, DHLM, DLLM, INIT, C, S, MOTORSIM, PORT, ADDR }
-{"\$(P)", "\$(M)", "asynMotor", "\$(NAME) (LINMOT)",    "degree",  "Pos",  "\$(VELO)",   1,  "\$(ACCL)",    0,    1,   0,   "\$(MRES)",   "\$(ERES)", "\$(UEIP)",    3,   "\$(DHLM)",   "\$(DLLM)",  "", "\$(C)", "\$(S)", "motorSim", "motorSim", "0" }
+{"\$(P)", "\$(M)", "asynMotor", "\$(NAME) (LINMOT)",    "\$(EGU)",  "Pos",  "\$(VELO)",   1,  "\$(ACCL)",    0,    1,   0,   "\$(MRES)",   "\$(ERES)", "\$(UEIP)",    3,   "\$(DHLM)",   "\$(DLLM)",  "", "\$(C)", "\$(S)", "motorSim", "motorSim", "0" }
 
 }

--- a/LINMOT/iocBoot/iocLINMOT-IOC-01/config.xml
+++ b/LINMOT/iocBoot/iocLINMOT-IOC-01/config.xml
@@ -9,44 +9,44 @@
 <macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM port" />
 
 <macro name="AXIS1" pattern="^(yes|no)$" description="Motor is attached to axis 1 (default: no)" />
-<macro name="OFST1" pattern="[1-9][0-9]*$" description="Motor offset in mm (default: 0)"/>
-<macro name="MRES1" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in mm/steps (default: 0.01)"/>
-<macro name="VELO1" pattern="[0-9]*\.?[0-9]*$" description="Motor speed in mm/s (default: 1)"/>
+<macro name="OFST1" pattern="[1-9][0-9]*$" description="Offset in length units (default: 0)"/>
+<macro name="MRES1" pattern="[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
+<macro name="VELO1" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
 
 <macro name="AXIS2" pattern="^(yes|no)$" description="Motor is attached to axis 2 (default: no)" />
-<macro name="OFST2" pattern="[1-9][0-9]*$" description="Motor offset in mm (default: 0)"/>
-<macro name="MRES2" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in mm/steps (default: 0.01)"/>
-<macro name="VELO2" pattern="[0-9]*\.?[0-9]*$" description="Motor speed in mm/s (default: 1)"/>
+<macro name="OFST2" pattern="[1-9][0-9]*$" description="Offset in length units (default: 0)"/>
+<macro name="MRES2" pattern="[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
+<macro name="VELO2" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
 
 <macro name="AXIS3" pattern="^(yes|no)$" description="Motor is attached to axis 3 (default: no)" />
-<macro name="OFST3" pattern="[1-9][0-9]*$" description="Motor offset in mm (default: 0)"/>
-<macro name="MRES3" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in mm/steps (default: 0.01)"/>
-<macro name="VELO3" pattern="[0-9]*\.?[0-9]*$" description="Motor speed in mm/s (default: 1)"/>
+<macro name="OFST3" pattern="[1-9][0-9]*$" description="Offset in length units (default: 0)"/>
+<macro name="MRES3" pattern="[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
+<macro name="VELO3" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
 
 <macro name="AXIS4" pattern="^(yes|no)$" description="Motor is attached to axis 4 (default: no)" />
-<macro name="OFST4" pattern="[1-9][0-9]*$" description="Motor offset in mm (default: 0)"/>
-<macro name="MRES4" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in mm/steps (default: 0.01)"/>
-<macro name="VELO4" pattern="[0-9]*\.?[0-9]*$" description="Motor speed in mm/s (default: 1)"/>
+<macro name="OFST4" pattern="[1-9][0-9]*$" description="Offset in length units (default: 0)"/>
+<macro name="MRES4" pattern="[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
+<macro name="VELO4" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
 
 <macro name="AXIS5" pattern="^(yes|no)$" description="Motor is attached to axis 5 (default: no)" />
-<macro name="OFST5" pattern="[1-9][0-9]*$" description="Motor offset in mm (default: 0)"/>
-<macro name="MRES5" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in mm/steps (default: 0.01)"/>
-<macro name="VELO5" pattern="[0-9]*\.?[0-9]*$" description="Motor speed in mm/s (default: 1)"/>
+<macro name="OFST5" pattern="[1-9][0-9]*$" description="Offset in length units (default: 0)"/>
+<macro name="MRES5" pattern="[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
+<macro name="VELO5" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
 
 <macro name="AXIS6" pattern="^(yes|no)$" description="Motor is attached to axis 6 (default: no)" />
-<macro name="OFST6" pattern="[1-9][0-9]*$" description="Motor offset in mm (default: 0)"/>
-<macro name="MRES6" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in mm/steps (default: 0.01)"/>
-<macro name="VELO6" pattern="[0-9]*\.?[0-9]*$" description="Motor speed in mm/s (default: 1)"/>
+<macro name="OFST6" pattern="[1-9][0-9]*$" description="Offset in length units (default: 0)"/>
+<macro name="MRES6" pattern="[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
+<macro name="VELO6" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
 
 <macro name="AXIS7" pattern="^(yes|no)$" description="Motor is attached to axis 7 (default: no)" />
-<macro name="OFST7" pattern="[1-9][0-9]*$" description="Motor offset in mm (default: 0)"/>
-<macro name="MRES7" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in mm/steps (default: 0.01)"/>
-<macro name="VELO7" pattern="[0-9]*\.?[0-9]*$" description="Motor speed in mm/s (default: 1)"/>
+<macro name="OFST7" pattern="[1-9][0-9]*$" description="Offset in length units (default: 0)"/>
+<macro name="MRES7" pattern="[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
+<macro name="VELO7" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
 
 <macro name="AXIS8" pattern="^(yes|no)$" description="Motor is attached to axis 8 (default: no)" />
-<macro name="OFST8" pattern="[1-9][0-9]*$" description="Motor offset in mm (default: 0)"/>
-<macro name="MRES8" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in mm/steps (default: 0.01)"/>
-<macro name="VELO8" pattern="[0-9]*\.?[0-9]*$" description="Motor speed in mm/s (default: 1)"/>
+<macro name="OFST8" pattern="[1-9][0-9]*$" description="Offset in length units (default: 0)"/>
+<macro name="MRES8" pattern="[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
+<macro name="VELO8" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
 
 </macros>
 <pvsets>

--- a/LINMOT/iocBoot/iocLINMOT-IOC-01/config.xml
+++ b/LINMOT/iocBoot/iocLINMOT-IOC-01/config.xml
@@ -9,41 +9,49 @@
 <macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM port" />
 
 <macro name="AXIS1" pattern="^(yes|no)$" description="Motor is attached to axis 1 (default: no)" />
+<macro name="EGU1" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="OFST1" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
 <macro name="MRES1" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
 <macro name="VELO1" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
 
 <macro name="AXIS2" pattern="^(yes|no)$" description="Motor is attached to axis 2 (default: no)" />
+<macro name="EGU2" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="OFST2" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
 <macro name="MRES2" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
 <macro name="VELO2" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
 
 <macro name="AXIS3" pattern="^(yes|no)$" description="Motor is attached to axis 3 (default: no)" />
+<macro name="EGU3" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="OFST3" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
 <macro name="MRES3" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
 <macro name="VELO3" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
 
 <macro name="AXIS4" pattern="^(yes|no)$" description="Motor is attached to axis 4 (default: no)" />
+<macro name="EGU4" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="OFST4" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
 <macro name="MRES4" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
 <macro name="VELO4" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
 
 <macro name="AXIS5" pattern="^(yes|no)$" description="Motor is attached to axis 5 (default: no)" />
+<macro name="EGU5" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="OFST5" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
 <macro name="MRES5" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
 <macro name="VELO5" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
 
 <macro name="AXIS6" pattern="^(yes|no)$" description="Motor is attached to axis 6 (default: no)" />
+<macro name="EGU6" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="OFST6" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
 <macro name="MRES6" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
 <macro name="VELO6" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
 
 <macro name="AXIS7" pattern="^(yes|no)$" description="Motor is attached to axis 7 (default: no)" />
+<macro name="EGU7" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="OFST7" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
 <macro name="MRES7" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
 <macro name="VELO7" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
 
 <macro name="AXIS8" pattern="^(yes|no)$" description="Motor is attached to axis 8 (default: no)" />
+<macro name="EGU8" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="OFST8" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
 <macro name="MRES8" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
 <macro name="VELO8" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>

--- a/LINMOT/iocBoot/iocLINMOT-IOC-01/config.xml
+++ b/LINMOT/iocBoot/iocLINMOT-IOC-01/config.xml
@@ -9,43 +9,43 @@
 <macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM port" />
 
 <macro name="AXIS1" pattern="^(yes|no)$" description="Motor is attached to axis 1 (default: no)" />
-<macro name="OFST1" pattern="[1-9][0-9]*$" description="Motor offset in steps (default: 0)"/>
-<macro name="MRES1" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/mm (default: 0.01)"/>
+<macro name="OFST1" pattern="[1-9][0-9]*$" description="Motor offset in mm (default: 0)"/>
+<macro name="MRES1" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in mm/steps (default: 0.01)"/>
 <macro name="VELO1" pattern="[0-9]*\.?[0-9]*$" description="Motor speed in mm/s (default: 1)"/>
 
 <macro name="AXIS2" pattern="^(yes|no)$" description="Motor is attached to axis 2 (default: no)" />
-<macro name="OFST2" pattern="[1-9][0-9]*$" description="Motor offset in steps (default: 0)"/>
-<macro name="MRES2" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/mm (default: 0.01)"/>
+<macro name="OFST2" pattern="[1-9][0-9]*$" description="Motor offset in mm (default: 0)"/>
+<macro name="MRES2" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in mm/steps (default: 0.01)"/>
 <macro name="VELO2" pattern="[0-9]*\.?[0-9]*$" description="Motor speed in mm/s (default: 1)"/>
 
 <macro name="AXIS3" pattern="^(yes|no)$" description="Motor is attached to axis 3 (default: no)" />
-<macro name="OFST3" pattern="[1-9][0-9]*$" description="Motor offset in steps (default: 0)"/>
-<macro name="MRES3" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/mm (default: 0.01)"/>
+<macro name="OFST3" pattern="[1-9][0-9]*$" description="Motor offset in mm (default: 0)"/>
+<macro name="MRES3" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in mm/steps (default: 0.01)"/>
 <macro name="VELO3" pattern="[0-9]*\.?[0-9]*$" description="Motor speed in mm/s (default: 1)"/>
 
 <macro name="AXIS4" pattern="^(yes|no)$" description="Motor is attached to axis 4 (default: no)" />
-<macro name="OFST4" pattern="[1-9][0-9]*$" description="Motor offset in steps (default: 0)"/>
-<macro name="MRES4" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/mm (default: 0.01)"/>
+<macro name="OFST4" pattern="[1-9][0-9]*$" description="Motor offset in mm (default: 0)"/>
+<macro name="MRES4" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in mm/steps (default: 0.01)"/>
 <macro name="VELO4" pattern="[0-9]*\.?[0-9]*$" description="Motor speed in mm/s (default: 1)"/>
 
 <macro name="AXIS5" pattern="^(yes|no)$" description="Motor is attached to axis 5 (default: no)" />
-<macro name="OFST5" pattern="[1-9][0-9]*$" description="Motor offset in steps (default: 0)"/>
-<macro name="MRES5" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/mm (default: 0.01)"/>
+<macro name="OFST5" pattern="[1-9][0-9]*$" description="Motor offset in mm (default: 0)"/>
+<macro name="MRES5" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in mm/steps (default: 0.01)"/>
 <macro name="VELO5" pattern="[0-9]*\.?[0-9]*$" description="Motor speed in mm/s (default: 1)"/>
 
 <macro name="AXIS6" pattern="^(yes|no)$" description="Motor is attached to axis 6 (default: no)" />
-<macro name="OFST6" pattern="[1-9][0-9]*$" description="Motor offset in steps (default: 0)"/>
-<macro name="MRES6" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/mm (default: 0.01)"/>
+<macro name="OFST6" pattern="[1-9][0-9]*$" description="Motor offset in mm (default: 0)"/>
+<macro name="MRES6" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in mm/steps (default: 0.01)"/>
 <macro name="VELO6" pattern="[0-9]*\.?[0-9]*$" description="Motor speed in mm/s (default: 1)"/>
 
 <macro name="AXIS7" pattern="^(yes|no)$" description="Motor is attached to axis 7 (default: no)" />
-<macro name="OFST7" pattern="[1-9][0-9]*$" description="Motor offset in steps (default: 0)"/>
-<macro name="MRES7" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/mm (default: 0.01)"/>
+<macro name="OFST7" pattern="[1-9][0-9]*$" description="Motor offset in mm (default: 0)"/>
+<macro name="MRES7" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in mm/steps (default: 0.01)"/>
 <macro name="VELO7" pattern="[0-9]*\.?[0-9]*$" description="Motor speed in mm/s (default: 1)"/>
 
 <macro name="AXIS8" pattern="^(yes|no)$" description="Motor is attached to axis 8 (default: no)" />
-<macro name="OFST8" pattern="[1-9][0-9]*$" description="Motor offset in steps (default: 0)"/>
-<macro name="MRES8" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/mm (default: 0.01)"/>
+<macro name="OFST8" pattern="[1-9][0-9]*$" description="Motor offset in mm (default: 0)"/>
+<macro name="MRES8" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in mm/steps (default: 0.01)"/>
 <macro name="VELO8" pattern="[0-9]*\.?[0-9]*$" description="Motor speed in mm/s (default: 1)"/>
 
 </macros>

--- a/LINMOT/iocBoot/iocLINMOT-IOC-01/config.xml
+++ b/LINMOT/iocBoot/iocLINMOT-IOC-01/config.xml
@@ -9,52 +9,44 @@
 <macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM port" />
 
 <macro name="AXIS1" pattern="^(yes|no)$" description="Motor is attached to axis 1 (default: no)" />
-<macro name="EGU1" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
-<macro name="OFST1" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
-<macro name="MRES1" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
-<macro name="VELO1" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
+<macro name="OFST1" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)"/>
+<macro name="MRES1" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)"/>
+<macro name="VELO1" pattern="[0-9]*\.?[0-9]*$" description="Speed in mm/s (default: 10)"/>
 
 <macro name="AXIS2" pattern="^(yes|no)$" description="Motor is attached to axis 2 (default: no)" />
-<macro name="EGU2" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
-<macro name="OFST2" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
-<macro name="MRES2" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
-<macro name="VELO2" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
+<macro name="OFST2" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)"/>
+<macro name="MRES2" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)"/>
+<macro name="VELO2" pattern="[0-9]*\.?[0-9]*$" description="Speed in mm/s (default: 10)"/>
 
 <macro name="AXIS3" pattern="^(yes|no)$" description="Motor is attached to axis 3 (default: no)" />
-<macro name="EGU3" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
-<macro name="OFST3" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
-<macro name="MRES3" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
-<macro name="VELO3" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
+<macro name="OFST3" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)"/>
+<macro name="MRES3" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)"/>
+<macro name="VELO3" pattern="[0-9]*\.?[0-9]*$" description="Speed in mm/s (default: 10)"/>
 
 <macro name="AXIS4" pattern="^(yes|no)$" description="Motor is attached to axis 4 (default: no)" />
-<macro name="EGU4" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
-<macro name="OFST4" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
-<macro name="MRES4" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
-<macro name="VELO4" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
+<macro name="OFST4" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)"/>
+<macro name="MRES4" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)"/>
+<macro name="VELO4" pattern="[0-9]*\.?[0-9]*$" description="Speed in mm/s (default: 10)"/>
 
 <macro name="AXIS5" pattern="^(yes|no)$" description="Motor is attached to axis 5 (default: no)" />
-<macro name="EGU5" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
-<macro name="OFST5" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
-<macro name="MRES5" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
-<macro name="VELO5" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
+<macro name="OFST5" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)"/>
+<macro name="MRES5" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)"/>
+<macro name="VELO5" pattern="[0-9]*\.?[0-9]*$" description="Speed in mm/s (default: 10)"/>
 
 <macro name="AXIS6" pattern="^(yes|no)$" description="Motor is attached to axis 6 (default: no)" />
-<macro name="EGU6" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
-<macro name="OFST6" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
-<macro name="MRES6" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
-<macro name="VELO6" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
+<macro name="OFST6" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)"/>
+<macro name="MRES6" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)"/>
+<macro name="VELO6" pattern="[0-9]*\.?[0-9]*$" description="Speed in mm/s (default: 10)"/>
 
 <macro name="AXIS7" pattern="^(yes|no)$" description="Motor is attached to axis 7 (default: no)" />
-<macro name="EGU7" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
-<macro name="OFST7" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
-<macro name="MRES7" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
-<macro name="VELO7" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
+<macro name="OFST7" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)"/>
+<macro name="MRES7" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)"/>
+<macro name="VELO7" pattern="[0-9]*\.?[0-9]*$" description="Speed in mm/s (default: 10)"/>
 
 <macro name="AXIS8" pattern="^(yes|no)$" description="Motor is attached to axis 8 (default: no)" />
-<macro name="EGU8" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
-<macro name="OFST8" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
-<macro name="MRES8" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
-<macro name="VELO8" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
+<macro name="OFST8" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)"/>
+<macro name="MRES8" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)"/>
+<macro name="VELO8" pattern="[0-9]*\.?[0-9]*$" description="Speed in mm/s (default: 10)"/>
 
 </macros>
 <pvsets>

--- a/LINMOT/iocBoot/iocLINMOT-IOC-01/config.xml
+++ b/LINMOT/iocBoot/iocLINMOT-IOC-01/config.xml
@@ -9,43 +9,43 @@
 <macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM port" />
 
 <macro name="AXIS1" pattern="^(yes|no)$" description="Motor is attached to axis 1 (default: no)" />
-<macro name="OFST1" pattern="[1-9][0-9]*$" description="Offset in length units (default: 0)"/>
-<macro name="MRES1" pattern="[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
+<macro name="OFST1" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
+<macro name="MRES1" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
 <macro name="VELO1" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
 
 <macro name="AXIS2" pattern="^(yes|no)$" description="Motor is attached to axis 2 (default: no)" />
-<macro name="OFST2" pattern="[1-9][0-9]*$" description="Offset in length units (default: 0)"/>
-<macro name="MRES2" pattern="[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
+<macro name="OFST2" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
+<macro name="MRES2" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
 <macro name="VELO2" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
 
 <macro name="AXIS3" pattern="^(yes|no)$" description="Motor is attached to axis 3 (default: no)" />
-<macro name="OFST3" pattern="[1-9][0-9]*$" description="Offset in length units (default: 0)"/>
-<macro name="MRES3" pattern="[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
+<macro name="OFST3" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
+<macro name="MRES3" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
 <macro name="VELO3" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
 
 <macro name="AXIS4" pattern="^(yes|no)$" description="Motor is attached to axis 4 (default: no)" />
-<macro name="OFST4" pattern="[1-9][0-9]*$" description="Offset in length units (default: 0)"/>
-<macro name="MRES4" pattern="[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
+<macro name="OFST4" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
+<macro name="MRES4" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
 <macro name="VELO4" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
 
 <macro name="AXIS5" pattern="^(yes|no)$" description="Motor is attached to axis 5 (default: no)" />
-<macro name="OFST5" pattern="[1-9][0-9]*$" description="Offset in length units (default: 0)"/>
-<macro name="MRES5" pattern="[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
+<macro name="OFST5" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
+<macro name="MRES5" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
 <macro name="VELO5" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
 
 <macro name="AXIS6" pattern="^(yes|no)$" description="Motor is attached to axis 6 (default: no)" />
-<macro name="OFST6" pattern="[1-9][0-9]*$" description="Offset in length units (default: 0)"/>
-<macro name="MRES6" pattern="[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
+<macro name="OFST6" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
+<macro name="MRES6" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
 <macro name="VELO6" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
 
 <macro name="AXIS7" pattern="^(yes|no)$" description="Motor is attached to axis 7 (default: no)" />
-<macro name="OFST7" pattern="[1-9][0-9]*$" description="Offset in length units (default: 0)"/>
-<macro name="MRES7" pattern="[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
+<macro name="OFST7" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
+<macro name="MRES7" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
 <macro name="VELO7" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
 
 <macro name="AXIS8" pattern="^(yes|no)$" description="Motor is attached to axis 8 (default: no)" />
-<macro name="OFST8" pattern="[1-9][0-9]*$" description="Offset in length units (default: 0)"/>
-<macro name="MRES8" pattern="[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
+<macro name="OFST8" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in length units (default: 0)"/>
+<macro name="MRES8" pattern="-?[0-9]*\.?[0-9]*$" description="Length units per step (default: 0.01)"/>
 <macro name="VELO8" pattern="[0-9]*\.?[0-9]*$" description="Speed in length units per second (default: 1)"/>
 
 </macros>

--- a/LINMOT/iocBoot/iocLINMOT-IOC-01/st-common.cmd
+++ b/LINMOT/iocBoot/iocLINMOT-IOC-01/st-common.cmd
@@ -61,5 +61,11 @@ iocInit()
 #var motorUtil_debug 1
 motorUtilInit("$(MYPVPREFIX)$(IOCNAME):")
 
+# Save motor positions every 5 seconds
+create_monitor_set("$(IOCNAME)_positions.req", 5, "P=$(MYPVPREFIX)MOT:")
+
+# Save motor settings every 30 seconds
+create_monitor_set("$(IOCNAME)_settings.req", 30, "P=$(MYPVPREFIX)MOT:")
+
 ##ISIS## Stuff that needs to be done after iocInit is called e.g. sequence programs 
 < $(IOCSTARTUP)/postiocinit.cmd

--- a/LINMOT/iocBoot/iocLINMOT-IOC-01/st-motor.cmd
+++ b/LINMOT/iocBoot/iocLINMOT-IOC-01/st-motor.cmd
@@ -11,7 +11,7 @@ epicsEnvSet("OFSTI",$(OFST$(MN)=0))
 epicsEnvSet("MRESI",$(MRES$(MN)=0.01))
 # LinMots set velocity always in C*mm/s where C is internal to the motor.
 # The motor record adds in a factor of 1/MRES so we need to take that out
-dcalc("VELOI", "$(VELOI)*$(MRESI)", 1, 0)
+dcalc("VELOI", "abs($(VELOI)*$(MRESI))", 1, 0)
 $(IFSIM) epicsEnvSet("ERESI",1)
 $(IFNOTSIM) epicsEnvSet("ERESI",0)
 epicsEnvSet("DHLMI",$(DHLM$(MN)=100))

--- a/LINMOT/iocBoot/iocLINMOT-IOC-01/st-motor.cmd
+++ b/LINMOT/iocBoot/iocLINMOT-IOC-01/st-motor.cmd
@@ -5,10 +5,13 @@ epicsEnvSet("AMOTORPV", "MOT:$(AMOTORNAME)")
 ## Load record instances
 
 # Set motor specific initial conditions
-epicsEnvSet("EGUI",$(EGU$(MN)=))
-epicsEnvSet("VELOI",$(VELO$(MN)=1))
+epicsEnvSet("EGUI",$(UNIT$(MN)=mm))
+epicsEnvSet("VELOI",$(VELO$(MN)=10))
 epicsEnvSet("OFSTI",$(OFST$(MN)=0))
 epicsEnvSet("MRESI",$(MRES$(MN)=0.01))
+# LinMots set velocity always in C*mm/s where C is internal to the motor.
+# The motor record adds in a factor of 1/MRES so we need to take that out
+dcalc("VELOI", "$(VELOI)*$(MRESI)", 1, 0)
 $(IFSIM) epicsEnvSet("ERESI",1)
 $(IFNOTSIM) epicsEnvSet("ERESI",0)
 epicsEnvSet("DHLMI",$(DHLM$(MN)=100))

--- a/LINMOT/iocBoot/iocLINMOT-IOC-01/st-motor.cmd
+++ b/LINMOT/iocBoot/iocLINMOT-IOC-01/st-motor.cmd
@@ -5,6 +5,7 @@ epicsEnvSet("AMOTORPV", "MOT:$(AMOTORNAME)")
 ## Load record instances
 
 # Set motor specific initial conditions
+epicsEnvSet("EGUI",$(EGU$(MN)=))
 epicsEnvSet("VELOI",$(VELO$(MN)=1))
 epicsEnvSet("OFSTI",$(OFST$(MN)=0))
 epicsEnvSet("MRESI",$(MRES$(MN)=0.01))

--- a/LINMOT/iocBoot/iocLINMOT-IOC-01/st-motor.cmd
+++ b/LINMOT/iocBoot/iocLINMOT-IOC-01/st-motor.cmd
@@ -30,7 +30,7 @@ dbLoadRecords("$(ASYN)/db/asynRecord.db", "P=$(MYPVPREFIX),R=$(AMOTORPV):ASYN,PO
 # Set the VBAS, the base speed, to 0.0 as it has no effect (that I know of) on the motor except that the acceleration won't be set
 # on an absolute move unless the speed and base speed are different
 #
-dbLoadRecords("$(TOP)/db/motor$(SIMSFX=).db", "P=$(MYPVPREFIX),M=$(AMOTORPV),VELO=$(VELOI),VBAS=0.0,ACCL=$(ACCLI),MRES=$(MRESI),ERES=$(ERESI),DHLM=$(DHLMI),DLLM=$(DLLMI),NAME=$(AMOTORNAME),S=$(SN),C=0,UEIP=0,OFF=$(OFSTI)") 
+dbLoadRecords("$(TOP)/db/motor$(SIMSFX=).db", "P=$(MYPVPREFIX),M=$(AMOTORPV),VELO=$(VELOI),VBAS=0.0,ACCL=$(ACCLI),MRES=$(MRESI),ERES=$(ERESI),DHLM=$(DHLMI),DLLM=$(DLLMI),NAME=$(AMOTORNAME),S=$(SN),C=0,UEIP=0,OFF=$(OFSTI),EGU=$(EGUI)") 
 dbLoadRecords("$(MOTOR)/db/motorStatus.db", "P=$(MYPVPREFIX),M=$(AMOTORPV)") 
 dbLoadRecords("$(AXIS)/db/axis.db", "P=$(MYPVPREFIX),AXIS=$(IOCNAME):AXIS$(MN),mAXIS=$(AMOTORPV)") 
 

--- a/LINMOT/iocBoot/iocLINMOT-IOC-01/st-motor.cmd
+++ b/LINMOT/iocBoot/iocLINMOT-IOC-01/st-motor.cmd
@@ -6,8 +6,8 @@ epicsEnvSet("AMOTORPV", "MOT:$(AMOTORNAME)")
 
 # Set motor specific initial conditions
 epicsEnvSet("VELOI",$(VELO$(MN)=1))
-epicsEnvSet("MRESI",$(MSTP$(MN)=0.01))
 epicsEnvSet("OFSTI",$(OFST$(MN)=0))
+epicsEnvSet("MRESI",$(MRES$(MN)=0.01))
 $(IFSIM) epicsEnvSet("ERESI",1)
 $(IFNOTSIM) epicsEnvSet("ERESI",0)
 epicsEnvSet("DHLMI",$(DHLM$(MN)=100))
@@ -26,6 +26,7 @@ dbLoadRecords("$(ASYN)/db/asynRecord.db", "P=$(MYPVPREFIX),R=$(AMOTORPV):ASYN,PO
 # Set the VBAS, the base speed, to 0.0 as it has no effect (that I know of) on the motor except that the acceleration won't be set
 # on an absolute move unless the speed and base speed are different
 #
-dbLoadRecords("$(TOP)/db/motor$(SIMSFX=).db", "P=$(MYPVPREFIX),M=$(AMOTORPV),VELO=$(VELOI),VBAS=0.0,ACCL=$(ACCLI),MRES=$(MRESI),ERES=$(ERESI),DHLM=$(DHLMI),DLLM=$(DLLMI),NAME=$(AMOTORNAME),S=$(SN),C=0,UEIP=0") 
+dbLoadRecords("$(TOP)/db/motor$(SIMSFX=).db", "P=$(MYPVPREFIX),M=$(AMOTORPV),VELO=$(VELOI),VBAS=0.0,ACCL=$(ACCLI),MRES=$(MRESI),ERES=$(ERESI),DHLM=$(DHLMI),DLLM=$(DLLMI),NAME=$(AMOTORNAME),S=$(SN),C=0,UEIP=0,OFF=$(OFSTI)") 
 dbLoadRecords("$(MOTOR)/db/motorStatus.db", "P=$(MYPVPREFIX),M=$(AMOTORPV)") 
 dbLoadRecords("$(AXIS)/db/axis.db", "P=$(MYPVPREFIX),AXIS=$(IOCNAME):AXIS$(MN),mAXIS=$(AMOTORPV)") 
+

--- a/MCLEN/MCLEN-IOC-01App/Db/motor.substitutions
+++ b/MCLEN/MCLEN-IOC-01App/Db/motor.substitutions
@@ -1,6 +1,6 @@
 file $(MOTOR)/motorApp/Db/motor.db {
 
 pattern {P,    M,         DTYP,      DESC,   EGU,  DIR,  VELO,  VBAS, ACCL, BDST, BVEL, BACC,    MRES,    ERES, UEIP, PREC, DHLM, DLLM, INIT, C, S }
-{"\$(P)", "\$(M)", "Mclennan PM304", "\$(NAME) (MCLEN)",    "degree",  "Pos",  "\$(VELO)",   "\$(VBAS)",  "\$(ACCL)",    0,    1,   0,   "\$(MRES)",   "\$(ERES)", "\$(UEIP)",    3,   "\$(DHLM)",   "\$(DLLM)",  "", "\$(C)", "\$(S)"}
+{"\$(P)", "\$(M)", "Mclennan PM304", "\$(NAME) (MCLEN)",    "\$(EGU)",  "Pos",  "\$(VELO)",   "\$(VBAS)",  "\$(ACCL)",    0,    1,   0,   "\$(MRES)",   "\$(ERES)", "\$(UEIP)",    3,   "\$(DHLM)",   "\$(DLLM)",  "", "\$(C)", "\$(S)"}
 
 }

--- a/MCLEN/MCLEN-IOC-01App/Db/motorSim.substitutions
+++ b/MCLEN/MCLEN-IOC-01App/Db/motorSim.substitutions
@@ -8,6 +8,6 @@
 file $(MOTOR)/motorApp/Db/asyn_motor.db {
 
 pattern {P,    M,         DTYP,      DESC,   EGU,  DIR,  VELO,  VBAS, ACCL, BDST, BVEL, BACC,    MRES,    ERES, UEIP, PREC, DHLM, DLLM, INIT, C, S, MOTORSIM, PORT, ADDR }
-{"\$(P)", "\$(M)", "asynMotor", "\$(NAME) (MCLEN)",    "degree",  "Pos",  "\$(VELO)",   1,  "\$(ACCL)",    0,    1,   0,   "\$(MRES)",   "\$(ERES)", "\$(UEIP)",    3,   "\$(DHLM)",   "\$(DLLM)",  "", "\$(C)", "\$(S)", "motorSim", "motorSim", "0" }
+{"\$(P)", "\$(M)", "asynMotor", "\$(NAME) (MCLEN)",    "\$(EGU)",  "Pos",  "\$(VELO)",   1,  "\$(ACCL)",    0,    1,   0,   "\$(MRES)",   "\$(ERES)", "\$(UEIP)",    3,   "\$(DHLM)",   "\$(DLLM)",  "", "\$(C)", "\$(S)", "motorSim", "motorSim", "0" }
 
 }

--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/config.xml
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/config.xml
@@ -13,6 +13,7 @@
 <macro name="STOP" pattern="^[0-2]$" description="Stop bits (default: 1)" />
 
 <macro name="AXIS1" pattern="^(yes|no)$" description="Motor is attached to axis 1 (default: no)" />
+<macro name="EGU1" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="VELO1" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
 <macro name="ACCL1" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
 <macro name="MSTP1" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />
@@ -23,6 +24,7 @@
 <macro name="HOME1" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
 
 <macro name="AXIS2" pattern="^(yes|no)$" description="Motor is attached to axis 2 (default: no)" />
+<macro name="EGU2" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="VELO2" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
 <macro name="ACCL2" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
 <macro name="MSTP2" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />
@@ -33,6 +35,7 @@
 <macro name="HOME2" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
 
 <macro name="AXIS3" pattern="^(yes|no)$" description="Motor is attached to axis 3 (default: no)" />
+<macro name="EGU3" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="VELO3" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
 <macro name="ACCL3" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
 <macro name="MSTP3" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />
@@ -43,6 +46,7 @@
 <macro name="HOME3" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
 
 <macro name="AXIS4" pattern="^(yes|no)$" description="Motor is attached to axis 4 (default: no)" />
+<macro name="EGU4" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="VELO4" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
 <macro name="ACCL4" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
 <macro name="MSTP4" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />
@@ -53,6 +57,7 @@
 <macro name="HOME4" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
 
 <macro name="AXIS5" pattern="^(yes|no)$" description="Motor is attached to axis 5 (default: no)" />
+<macro name="EGU5" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="VELO5" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
 <macro name="ACCL5" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
 <macro name="MSTP5" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />
@@ -63,6 +68,7 @@
 <macro name="HOME5" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
 
 <macro name="AXIS6" pattern="^(yes|no)$" description="Motor is attached to axis 6 (default: no)" />
+<macro name="EGU6" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="VELO6" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
 <macro name="ACCL6" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
 <macro name="MSTP6" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />
@@ -73,6 +79,7 @@
 <macro name="HOME6" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
 
 <macro name="AXIS7" pattern="^(yes|no)$" description="Motor is attached to axis 7 (default: no)" />
+<macro name="EGU7" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="VELO7" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
 <macro name="ACCL7" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
 <macro name="MSTP7" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />
@@ -83,6 +90,7 @@
 <macro name="HOME7" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
 
 <macro name="AXIS8" pattern="^(yes|no)$" description="Motor is attached to axis 8 (default: no)" />
+<macro name="EGU8" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="VELO8" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
 <macro name="ACCL8" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
 <macro name="MSTP8" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />

--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/config.xml
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/config.xml
@@ -13,7 +13,7 @@
 <macro name="STOP" pattern="^[0-2]$" description="Stop bits (default: 1)" />
 
 <macro name="AXIS1" pattern="^(yes|no)$" description="Motor is attached to axis 1 (default: no)" />
-<macro name="EGU1" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
+<macro name="UNIT1" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="VELO1" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
 <macro name="ACCL1" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
 <macro name="MSTP1" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />
@@ -24,7 +24,7 @@
 <macro name="HOME1" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
 
 <macro name="AXIS2" pattern="^(yes|no)$" description="Motor is attached to axis 2 (default: no)" />
-<macro name="EGU2" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
+<macro name="UNIT2" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="VELO2" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
 <macro name="ACCL2" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
 <macro name="MSTP2" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />
@@ -35,7 +35,7 @@
 <macro name="HOME2" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
 
 <macro name="AXIS3" pattern="^(yes|no)$" description="Motor is attached to axis 3 (default: no)" />
-<macro name="EGU3" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
+<macro name="UNIT3" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="VELO3" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
 <macro name="ACCL3" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
 <macro name="MSTP3" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />
@@ -46,7 +46,7 @@
 <macro name="HOME3" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
 
 <macro name="AXIS4" pattern="^(yes|no)$" description="Motor is attached to axis 4 (default: no)" />
-<macro name="EGU4" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
+<macro name="UNIT4" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="VELO4" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
 <macro name="ACCL4" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
 <macro name="MSTP4" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />
@@ -57,7 +57,7 @@
 <macro name="HOME4" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
 
 <macro name="AXIS5" pattern="^(yes|no)$" description="Motor is attached to axis 5 (default: no)" />
-<macro name="EGU5" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
+<macro name="UNIT5" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="VELO5" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
 <macro name="ACCL5" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
 <macro name="MSTP5" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />
@@ -68,7 +68,7 @@
 <macro name="HOME5" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
 
 <macro name="AXIS6" pattern="^(yes|no)$" description="Motor is attached to axis 6 (default: no)" />
-<macro name="EGU6" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
+<macro name="UNIT6" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="VELO6" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
 <macro name="ACCL6" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
 <macro name="MSTP6" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />
@@ -79,7 +79,7 @@
 <macro name="HOME6" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
 
 <macro name="AXIS7" pattern="^(yes|no)$" description="Motor is attached to axis 7 (default: no)" />
-<macro name="EGU7" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
+<macro name="UNIT7" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="VELO7" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
 <macro name="ACCL7" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
 <macro name="MSTP7" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />
@@ -90,7 +90,7 @@
 <macro name="HOME7" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
 
 <macro name="AXIS8" pattern="^(yes|no)$" description="Motor is attached to axis 8 (default: no)" />
-<macro name="EGU8" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
+<macro name="UNIT8" pattern="[A-Za-z]*$" description="Units (default: blank)"/>
 <macro name="VELO8" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
 <macro name="ACCL8" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
 <macro name="MSTP8" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />

--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/st-motor.cmd
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/st-motor.cmd
@@ -5,6 +5,7 @@ epicsEnvSet("AMOTORPV", "MOT:$(AMOTORNAME)")
 ## Load record instances
 
 # Set motor specific initial conditions
+epicsEnvSet("EGUI",$(EGU$(MN)=))
 epicsEnvSet("VELOI",$(VELO$(MN)=1))
 epicsEnvSet("ACCLI",$(ACCL$(MN)=1))
 epicsEnvSet("MSTPI",$(MSTP$(MN)=4000))
@@ -28,7 +29,7 @@ dbLoadRecords("$(ASYN)/db/asynRecord.db", "P=$(MYPVPREFIX),R=$(AMOTORPV):ASYN,PO
 # Set the VBAS, the base speed, to 0.0 as it has no effect (that I know of) on the McLennan except that the acceleration won't be set
 # on an absolute move unless the speed and base speed are different
 #
-dbLoadRecords("$(TOP)/db/motor$(SIMSFX=).db", "P=$(MYPVPREFIX),M=$(AMOTORPV),VELO=$(VELOI),VBAS=0.0,ACCL=$(ACCLI),MRES=$(MRESI),ERES=$(ERESI),DHLM=$(DHLMI),DLLM=$(DLLMI),NAME=$(AMOTORNAME),S=$(SN),C=0,UEIP=1") 
+dbLoadRecords("$(TOP)/db/motor$(SIMSFX=).db", "P=$(MYPVPREFIX),M=$(AMOTORPV),VELO=$(VELOI),VBAS=0.0,ACCL=$(ACCLI),MRES=$(MRESI),ERES=$(ERESI),DHLM=$(DHLMI),DLLM=$(DLLMI),NAME=$(AMOTORNAME),S=$(SN),C=0,UEIP=1,EGU=$(EGUI)") 
 dbLoadRecords("$(MOTOR)/db/motorStatus.db", "P=$(MYPVPREFIX),M=$(AMOTORPV)") 
 dbLoadRecords("$(AXIS)/db/axis.db", "P=$(MYPVPREFIX),AXIS=$(IOCNAME):AXIS$(MN),mAXIS=$(AMOTORPV)") 
 

--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/st-motor.cmd
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/st-motor.cmd
@@ -5,7 +5,7 @@ epicsEnvSet("AMOTORPV", "MOT:$(AMOTORNAME)")
 ## Load record instances
 
 # Set motor specific initial conditions
-epicsEnvSet("EGUI",$(EGU$(MN)=))
+epicsEnvSet("EGUI",$(UNIT$(MN)=))
 epicsEnvSet("VELOI",$(VELO$(MN)=1))
 epicsEnvSet("ACCLI",$(ACCL$(MN)=1))
 epicsEnvSet("MSTPI",$(MSTP$(MN)=4000))


### PR DESCRIPTION
### Description of work

There were a few errors in the initial LinMot. The offsets and motor resolution weren't being propagated to the motor.

It is helpful to know that the motor reports its position in steps so the position given to the user is:

```
position = resolution*motor_position + offset
```

This can be used to confirm that the reported position is correct as the offset and resolution are varied. Assume you have a configuration where:

```
r_old : old resolution
r_new : new resolution
o_old : old offset
o_new : new offset
p_old : old position
p_new : new position
```

When the configuration is changed from the old to the new macros then the new position should be:

```
p_new = r_new*(p_old - o_old)/r_old + o_new
```

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2219

### Acceptance criteria

- [x] Check that the macros appear in the GUI and the descriptions make sense
- [x] Start the motor with clear offset, velocity and resolution macros. Check in the more details panel that the values are correct (0 offset, 1 velocity, 0.01 resolution)
- [x] Change the offset, velocity and resolution via macros. Check that the responses from the motor are appropriate. This is best done changing 1 macro at a time as they are dependent.
    - Speed should increase linearly with VELO
    - Changing the offset should change the reported position by the offset amount (assuming constant resolution)
    - Changing the resolution will change the resolution in the more details panel. The reported speed will be unchanged but will physically vary inversely with the resolution. Similarly, the reported position will vary inversely with the motor resolution (assuming 0 offset).

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Are the PVs named according to the [naming standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
- [x] Have suitable [disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records) been added?
- [x] Have suitable [simulation records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation) been added?
- [x] Have the [finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches) been applied?
- [x] Is there an [emulator](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Emulating-Devices) for the device?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [x] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)? There is a script called `check_opi_format.py` to help with this.

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- [x] If there are multiple _0n IOCs, do they run correctly?

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
