### PR TITLE
Ticket2290 add name macro for motors

### DIFF
--- a/LINMOT/iocBoot/iocLINMOT-IOC-01/config.xml
+++ b/LINMOT/iocBoot/iocLINMOT-IOC-01/config.xml
@@ -9,44 +9,49 @@
 <macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM port" />
 
 <macro name="AXIS1" pattern="^(yes|no)$" description="Motor is attached to axis 1 (default: no)" />
-<macro name="OFST1" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)"/>
-<macro name="MRES1" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)"/>
-<macro name="VELO1" pattern="[0-9]*\.?[0-9]*$" description="Speed in mm/s (default: 10)"/>
-
 <macro name="AXIS2" pattern="^(yes|no)$" description="Motor is attached to axis 2 (default: no)" />
-<macro name="OFST2" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)"/>
-<macro name="MRES2" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)"/>
-<macro name="VELO2" pattern="[0-9]*\.?[0-9]*$" description="Speed in mm/s (default: 10)"/>
-
 <macro name="AXIS3" pattern="^(yes|no)$" description="Motor is attached to axis 3 (default: no)" />
-<macro name="OFST3" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)"/>
-<macro name="MRES3" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)"/>
-<macro name="VELO3" pattern="[0-9]*\.?[0-9]*$" description="Speed in mm/s (default: 10)"/>
-
 <macro name="AXIS4" pattern="^(yes|no)$" description="Motor is attached to axis 4 (default: no)" />
-<macro name="OFST4" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)"/>
-<macro name="MRES4" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)"/>
-<macro name="VELO4" pattern="[0-9]*\.?[0-9]*$" description="Speed in mm/s (default: 10)"/>
-
 <macro name="AXIS5" pattern="^(yes|no)$" description="Motor is attached to axis 5 (default: no)" />
-<macro name="OFST5" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)"/>
-<macro name="MRES5" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)"/>
-<macro name="VELO5" pattern="[0-9]*\.?[0-9]*$" description="Speed in mm/s (default: 10)"/>
-
 <macro name="AXIS6" pattern="^(yes|no)$" description="Motor is attached to axis 6 (default: no)" />
-<macro name="OFST6" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)"/>
-<macro name="MRES6" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)"/>
-<macro name="VELO6" pattern="[0-9]*\.?[0-9]*$" description="Speed in mm/s (default: 10)"/>
-
 <macro name="AXIS7" pattern="^(yes|no)$" description="Motor is attached to axis 7 (default: no)" />
-<macro name="OFST7" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)"/>
-<macro name="MRES7" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)"/>
-<macro name="VELO7" pattern="[0-9]*\.?[0-9]*$" description="Speed in mm/s (default: 10)"/>
-
 <macro name="AXIS8" pattern="^(yes|no)$" description="Motor is attached to axis 8 (default: no)" />
+
+<macro name="OFST1" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)"/>
+<macro name="OFST2" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)"/>
+<macro name="OFST3" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)"/>
+<macro name="OFST4" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)"/>
+<macro name="OFST5" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)"/>
+<macro name="OFST6" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)"/>
+<macro name="OFST7" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)"/>
 <macro name="OFST8" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)"/>
+
+<macro name="MRES1" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)"/>
+<macro name="MRES2" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)"/>
+<macro name="MRES3" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)"/>
+<macro name="MRES4" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)"/>
+<macro name="MRES5" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)"/>
+<macro name="MRES6" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)"/>
+<macro name="MRES7" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)"/>
 <macro name="MRES8" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)"/>
+
+<macro name="VELO1" pattern="[0-9]*\.?[0-9]*$" description="Speed in mm/s (default: 10)"/>
+<macro name="VELO2" pattern="[0-9]*\.?[0-9]*$" description="Speed in mm/s (default: 10)"/>
+<macro name="VELO3" pattern="[0-9]*\.?[0-9]*$" description="Speed in mm/s (default: 10)"/>
+<macro name="VELO4" pattern="[0-9]*\.?[0-9]*$" description="Speed in mm/s (default: 10)"/>
+<macro name="VELO5" pattern="[0-9]*\.?[0-9]*$" description="Speed in mm/s (default: 10)"/>
+<macro name="VELO6" pattern="[0-9]*\.?[0-9]*$" description="Speed in mm/s (default: 10)"/>
+<macro name="VELO7" pattern="[0-9]*\.?[0-9]*$" description="Speed in mm/s (default: 10)"/>
 <macro name="VELO8" pattern="[0-9]*\.?[0-9]*$" description="Speed in mm/s (default: 10)"/>
+
+<macro name="NAME1" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" />
+<macro name="NAME2" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" />
+<macro name="NAME3" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" />
+<macro name="NAME4" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" />
+<macro name="NAME5" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" />
+<macro name="NAME6" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" />
+<macro name="NAME7" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" />
+<macro name="NAME8" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" />
 
 </macros>
 <pvsets>

--- a/LINMOT/iocBoot/iocLINMOT-IOC-01/st-motor.cmd
+++ b/LINMOT/iocBoot/iocLINMOT-IOC-01/st-motor.cmd
@@ -17,7 +17,7 @@ $(IFNOTSIM) epicsEnvSet("ERESI",0)
 epicsEnvSet("DHLMI",$(DHLM$(MN)=100))
 epicsEnvSet("DLLMI",$(DLLM$(MN)=0))
 epicsEnvSet("ACCLI",$(ACCL$(MN)=1))
-epicsEnvSet("NAMEI",$(NAME$(MN)=$(AMOTORNAME)))
+epicsEnvSet("NAMEI","$(NAME$(MN)=$(AMOTORNAME))")
 
 # The signal number is the axis-1
 calc("SN", "$(MN)-1", 2, 2)

--- a/LINMOT/iocBoot/iocLINMOT-IOC-01/st-motor.cmd
+++ b/LINMOT/iocBoot/iocLINMOT-IOC-01/st-motor.cmd
@@ -17,6 +17,7 @@ $(IFNOTSIM) epicsEnvSet("ERESI",0)
 epicsEnvSet("DHLMI",$(DHLM$(MN)=100))
 epicsEnvSet("DLLMI",$(DLLM$(MN)=0))
 epicsEnvSet("ACCLI",$(ACCL$(MN)=1))
+epicsEnvSet("NAMEI",$(NAME$(MN)=$(AMOTORNAME)))
 
 # The signal number is the axis-1
 calc("SN", "$(MN)-1", 2, 2)
@@ -30,7 +31,7 @@ dbLoadRecords("$(ASYN)/db/asynRecord.db", "P=$(MYPVPREFIX),R=$(AMOTORPV):ASYN,PO
 # Set the VBAS, the base speed, to 0.0 as it has no effect (that I know of) on the motor except that the acceleration won't be set
 # on an absolute move unless the speed and base speed are different
 #
-dbLoadRecords("$(TOP)/db/motor$(SIMSFX=).db", "P=$(MYPVPREFIX),M=$(AMOTORPV),VELO=$(VELOI),VBAS=0.0,ACCL=$(ACCLI),MRES=$(MRESI),ERES=$(ERESI),DHLM=$(DHLMI),DLLM=$(DLLMI),NAME=$(AMOTORNAME),S=$(SN),C=0,UEIP=0,OFF=$(OFSTI),EGU=$(EGUI)") 
+dbLoadRecords("$(TOP)/db/motor$(SIMSFX=).db", "P=$(MYPVPREFIX),M=$(AMOTORPV),VELO=$(VELOI),VBAS=0.0,ACCL=$(ACCLI),MRES=$(MRESI),ERES=$(ERESI),DHLM=$(DHLMI),DLLM=$(DLLMI),NAME=$(NAMEI),S=$(SN),C=0,UEIP=0,OFF=$(OFSTI),EGU=$(EGUI)") 
 dbLoadRecords("$(MOTOR)/db/motorStatus.db", "P=$(MYPVPREFIX),M=$(AMOTORPV)") 
 dbLoadRecords("$(AXIS)/db/axis.db", "P=$(MYPVPREFIX),AXIS=$(IOCNAME):AXIS$(MN),mAXIS=$(AMOTORPV)") 
 

--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/config.xml
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/config.xml
@@ -21,68 +21,68 @@
 <macro name="AXIS7" pattern="^(yes|no)$" description="Motor is attached to axis 7 (default: no)" />
 <macro name="AXIS8" pattern="^(yes|no)$" description="Motor is attached to axis 8 (default: no)" />
 
-<macro name="UNIT1" pattern="[A-Za-z]*$" description="Units (default: mm)"/>
-<macro name="UNIT2" pattern="[A-Za-z]*$" description="Units (default: mm)"/>
-<macro name="UNIT3" pattern="[A-Za-z]*$" description="Units (default: mm)"/>
-<macro name="UNIT4" pattern="[A-Za-z]*$" description="Units (default: mm)"/>
-<macro name="UNIT5" pattern="[A-Za-z]*$" description="Units (default: mm)"/>
-<macro name="UNIT6" pattern="[A-Za-z]*$" description="Units (default: mm)"/>
-<macro name="UNIT7" pattern="[A-Za-z]*$" description="Units (default: mm)"/>
-<macro name="UNIT8" pattern="[A-Za-z]*$" description="Units (default: mm)"/>
+<macro name="UNIT1" pattern="^[A-Za-z]*$" description="Units (default: mm)"/>
+<macro name="UNIT2" pattern="^[A-Za-z]*$" description="Units (default: mm)"/>
+<macro name="UNIT3" pattern="^[A-Za-z]*$" description="Units (default: mm)"/>
+<macro name="UNIT4" pattern="^[A-Za-z]*$" description="Units (default: mm)"/>
+<macro name="UNIT5" pattern="^[A-Za-z]*$" description="Units (default: mm)"/>
+<macro name="UNIT6" pattern="^[A-Za-z]*$" description="Units (default: mm)"/>
+<macro name="UNIT7" pattern="^[A-Za-z]*$" description="Units (default: mm)"/>
+<macro name="UNIT8" pattern="^[A-Za-z]*$" description="Units (default: mm)"/>
 
-<macro name="VELO1" pattern="[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
-<macro name="VELO2" pattern="[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
-<macro name="VELO3" pattern="[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
-<macro name="VELO4" pattern="[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
-<macro name="VELO5" pattern="[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
-<macro name="VELO6" pattern="[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
-<macro name="VELO7" pattern="[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
-<macro name="VELO8" pattern="[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
+<macro name="VELO1" pattern="^[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
+<macro name="VELO2" pattern="^[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
+<macro name="VELO3" pattern="^[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
+<macro name="VELO4" pattern="^[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
+<macro name="VELO5" pattern="^[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
+<macro name="VELO6" pattern="^[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
+<macro name="VELO7" pattern="^[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
+<macro name="VELO8" pattern="^[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
 
-<macro name="ACCL1" pattern="[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
-<macro name="ACCL2" pattern="[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
-<macro name="ACCL3" pattern="[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
-<macro name="ACCL4" pattern="[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
-<macro name="ACCL5" pattern="[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
-<macro name="ACCL6" pattern="[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
-<macro name="ACCL7" pattern="[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
-<macro name="ACCL8" pattern="[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
+<macro name="ACCL1" pattern="^[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
+<macro name="ACCL2" pattern="^[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
+<macro name="ACCL3" pattern="^[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
+<macro name="ACCL4" pattern="^[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
+<macro name="ACCL5" pattern="^[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
+<macro name="ACCL6" pattern="^[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
+<macro name="ACCL7" pattern="^[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
+<macro name="ACCL8" pattern="^[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
 
-<macro name="MSTP1" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
-<macro name="MSTP2" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
-<macro name="MSTP3" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
-<macro name="MSTP4" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
-<macro name="MSTP5" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
-<macro name="MSTP6" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
-<macro name="MSTP7" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
-<macro name="MSTP8" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
+<macro name="MSTP1" pattern="^[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
+<macro name="MSTP2" pattern="^[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
+<macro name="MSTP3" pattern="^[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
+<macro name="MSTP4" pattern="^[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
+<macro name="MSTP5" pattern="^[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
+<macro name="MSTP6" pattern="^[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
+<macro name="MSTP7" pattern="^[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
+<macro name="MSTP8" pattern="^[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
 
-<macro name="ERES1" pattern="-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
-<macro name="ERES2" pattern="-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
-<macro name="ERES3" pattern="-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
-<macro name="ERES4" pattern="-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
-<macro name="ERES5" pattern="-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
-<macro name="ERES6" pattern="-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
-<macro name="ERES7" pattern="-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
-<macro name="ERES8" pattern="-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
+<macro name="ERES1" pattern="^-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
+<macro name="ERES2" pattern="^-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
+<macro name="ERES3" pattern="^-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
+<macro name="ERES4" pattern="^-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
+<macro name="ERES5" pattern="^-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
+<macro name="ERES6" pattern="^-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
+<macro name="ERES7" pattern="^-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
+<macro name="ERES8" pattern="^-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
 
-<macro name="DHLM1" pattern="-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
-<macro name="DHLM2" pattern="-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
-<macro name="DHLM3" pattern="-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
-<macro name="DHLM4" pattern="-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
-<macro name="DHLM5" pattern="-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
-<macro name="DHLM6" pattern="-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
-<macro name="DHLM7" pattern="-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
-<macro name="DHLM8" pattern="-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
+<macro name="DHLM1" pattern="^-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
+<macro name="DHLM2" pattern="^-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
+<macro name="DHLM3" pattern="^-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
+<macro name="DHLM4" pattern="^-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
+<macro name="DHLM5" pattern="^-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
+<macro name="DHLM6" pattern="^-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
+<macro name="DHLM7" pattern="^-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
+<macro name="DHLM8" pattern="^-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
 
-<macro name="DLLM1" pattern="-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
-<macro name="DLLM2" pattern="-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
-<macro name="DLLM3" pattern="-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
-<macro name="DLLM4" pattern="-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
-<macro name="DLLM5" pattern="-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
-<macro name="DLLM6" pattern="-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
-<macro name="DLLM7" pattern="-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
-<macro name="DLLM8" pattern="-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
+<macro name="DLLM1" pattern="^-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
+<macro name="DLLM2" pattern="^-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
+<macro name="DLLM3" pattern="^-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
+<macro name="DLLM4" pattern="^-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
+<macro name="DLLM5" pattern="^-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
+<macro name="DLLM6" pattern="^-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
+<macro name="DLLM7" pattern="^-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
+<macro name="DLLM8" pattern="^-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
 
 <macro name="CMOD1" pattern="^(OPEN|CLOSED)$" description="Loop control mode (default: CLOSED)" />
 <macro name="CMOD2" pattern="^(OPEN|CLOSED)$" description="Loop control mode (default: CLOSED)" />

--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/config.xml
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/config.xml
@@ -13,92 +13,103 @@
 <macro name="STOP" pattern="^[0-2]$" description="Stop bits (default: 1)" />
 
 <macro name="AXIS1" pattern="^(yes|no)$" description="Motor is attached to axis 1 (default: no)" />
-<macro name="UNIT1" pattern="[A-Za-z]*$" description="Units (default: mm)"/>
-<macro name="VELO1" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
-<macro name="ACCL1" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
-<macro name="MSTP1" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />
-<macro name="ERES1" pattern="-?[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
-<macro name="DHLM1" pattern="-?[0-9]*\.?[0-9]*$" description="position upper limit (default: 200)" />
-<macro name="DLLM1" pattern="-?[0-9]*\.?[0-9]*$" description="position lower limit (default: -200)" />
-<macro name="MODE1" pattern="^(OPEN|CLOSED)$" description="motor control mode (default: CLOSED)" />
-<macro name="HOME1" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
-
 <macro name="AXIS2" pattern="^(yes|no)$" description="Motor is attached to axis 2 (default: no)" />
-<macro name="UNIT2" pattern="[A-Za-z]*$" description="Units (default: mm)"/>
-<macro name="VELO2" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
-<macro name="ACCL2" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
-<macro name="MSTP2" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />
-<macro name="ERES2" pattern="-?[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
-<macro name="DHLM2" pattern="-?[0-9]*\.?[0-9]*$" description="position upper limit (default: 200)" />
-<macro name="DLLM2" pattern="-?[0-9]*\.?[0-9]*$" description="position lower limit (default: -200)" />
-<macro name="MODE2" pattern="^(OPEN|CLOSED)$" description="motor control mode (default: CLOSED)" />
-<macro name="HOME2" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
-
 <macro name="AXIS3" pattern="^(yes|no)$" description="Motor is attached to axis 3 (default: no)" />
-<macro name="UNIT3" pattern="[A-Za-z]*$" description="Units (default: mm)"/>
-<macro name="VELO3" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
-<macro name="ACCL3" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
-<macro name="MSTP3" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />
-<macro name="ERES3" pattern="-?[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
-<macro name="DHLM3" pattern="-?[0-9]*\.?[0-9]*$" description="position upper limit (default: 200)" />
-<macro name="DLLM3" pattern="-?[0-9]*\.?[0-9]*$" description="position lower limit (default: -200)" />
-<macro name="MODE3" pattern="^(OPEN|CLOSED)$" description="motor control mode (default: CLOSED)" />
-<macro name="HOME3" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
-
 <macro name="AXIS4" pattern="^(yes|no)$" description="Motor is attached to axis 4 (default: no)" />
-<macro name="UNIT4" pattern="[A-Za-z]*$" description="Units (default: mm)"/>
-<macro name="VELO4" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
-<macro name="ACCL4" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
-<macro name="MSTP4" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />
-<macro name="ERES4" pattern="-?[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
-<macro name="DHLM4" pattern="-?[0-9]*\.?[0-9]*$" description="position upper limit (default: 200)" />
-<macro name="DLLM4" pattern="-?[0-9]*\.?[0-9]*$" description="position lower limit (default: -200)" />
-<macro name="MODE4" pattern="^(OPEN|CLOSED)$" description="motor control mode (default: CLOSED)" />
-<macro name="HOME4" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
-
 <macro name="AXIS5" pattern="^(yes|no)$" description="Motor is attached to axis 5 (default: no)" />
-<macro name="UNIT5" pattern="[A-Za-z]*$" description="Units (default: mm)"/>
-<macro name="VELO5" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
-<macro name="ACCL5" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
-<macro name="MSTP5" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />
-<macro name="ERES5" pattern="-?[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
-<macro name="DHLM5" pattern="-?[0-9]*\.?[0-9]*$" description="position upper limit (default: 200)" />
-<macro name="DLLM5" pattern="-?[0-9]*\.?[0-9]*$" description="position lower limit (default: -200)" />
-<macro name="MODE5" pattern="^(OPEN|CLOSED)$" description="motor control mode (default: CLOSED)" />
-<macro name="HOME5" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
-
 <macro name="AXIS6" pattern="^(yes|no)$" description="Motor is attached to axis 6 (default: no)" />
-<macro name="UNIT6" pattern="[A-Za-z]*$" description="Units (default: mm)"/>
-<macro name="VELO6" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
-<macro name="ACCL6" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
-<macro name="MSTP6" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />
-<macro name="ERES6" pattern="-?[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
-<macro name="DHLM6" pattern="-?[0-9]*\.?[0-9]*$" description="position upper limit (default: 200)" />
-<macro name="DLLM6" pattern="-?[0-9]*\.?[0-9]*$" description="position lower limit (default: -200)" />
-<macro name="MODE6" pattern="^(OPEN|CLOSED)$" description="motor control mode (default: CLOSED)" />
-<macro name="HOME6" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
-
 <macro name="AXIS7" pattern="^(yes|no)$" description="Motor is attached to axis 7 (default: no)" />
-<macro name="UNIT7" pattern="[A-Za-z]*$" description="Units (default: mm)"/>
-<macro name="VELO7" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
-<macro name="ACCL7" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
-<macro name="MSTP7" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />
-<macro name="ERES7" pattern="-?[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
-<macro name="DHLM7" pattern="-?[0-9]*\.?[0-9]*$" description="position upper limit (default: 200)" />
-<macro name="DLLM7" pattern="-?[0-9]*\.?[0-9]*$" description="position lower limit (default: -200)" />
-<macro name="MODE7" pattern="^(OPEN|CLOSED)$" description="motor control mode (default: CLOSED)" />
-<macro name="HOME7" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
-
 <macro name="AXIS8" pattern="^(yes|no)$" description="Motor is attached to axis 8 (default: no)" />
+
+<macro name="UNIT1" pattern="[A-Za-z]*$" description="Units (default: mm)"/>
+<macro name="UNIT2" pattern="[A-Za-z]*$" description="Units (default: mm)"/>
+<macro name="UNIT3" pattern="[A-Za-z]*$" description="Units (default: mm)"/>
+<macro name="UNIT4" pattern="[A-Za-z]*$" description="Units (default: mm)"/>
+<macro name="UNIT5" pattern="[A-Za-z]*$" description="Units (default: mm)"/>
+<macro name="UNIT6" pattern="[A-Za-z]*$" description="Units (default: mm)"/>
+<macro name="UNIT7" pattern="[A-Za-z]*$" description="Units (default: mm)"/>
 <macro name="UNIT8" pattern="[A-Za-z]*$" description="Units (default: mm)"/>
-<macro name="VELO8" pattern="[0-9]*\.?[0-9]*$" description="velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
-<macro name="ACCL8" pattern="[0-9]*\.?[0-9]*$" description="seconds to max speed (default: 1)" />
-<macro name="MSTP8" pattern="[0-9]*\.?[0-9]*$" description="motor resolution in steps/unit (default: 4000)" />
-<macro name="ERES8" pattern="-?[0-9]+/[0-9]+$" description="encoder ratio (default: 400/4096)" />
-<macro name="DHLM8" pattern="-?[0-9]*\.?[0-9]*$" description="position upper limit (default: 200)" />
-<macro name="DLLM8" pattern="-?[0-9]*\.?[0-9]*$" description="position lower limit (default: -200)" />
-<macro name="MODE8" pattern="^(OPEN|CLOSED)$" description="motor control mode (default: CLOSED)" />
+
+<macro name="VELO1" pattern="[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
+<macro name="VELO2" pattern="[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
+<macro name="VELO3" pattern="[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
+<macro name="VELO4" pattern="[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
+<macro name="VELO5" pattern="[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
+<macro name="VELO6" pattern="[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
+<macro name="VELO7" pattern="[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
+<macro name="VELO8" pattern="[0-9]*\.?[0-9]*$" description="Velocity, units/s, where length units are defined in the corresponding MSTP macro (default: 1)" />
+
+<macro name="ACCL1" pattern="[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
+<macro name="ACCL2" pattern="[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
+<macro name="ACCL3" pattern="[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
+<macro name="ACCL4" pattern="[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
+<macro name="ACCL5" pattern="[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
+<macro name="ACCL6" pattern="[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
+<macro name="ACCL7" pattern="[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
+<macro name="ACCL8" pattern="[0-9]*\.?[0-9]*$" description="Seconds to max speed (default: 1)" />
+
+<macro name="MSTP1" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
+<macro name="MSTP2" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
+<macro name="MSTP3" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
+<macro name="MSTP4" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
+<macro name="MSTP5" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
+<macro name="MSTP6" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
+<macro name="MSTP7" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
+<macro name="MSTP8" pattern="[0-9]*\.?[0-9]*$" description="Motor resolution in steps/unit (default: 4000)" />
+
+<macro name="ERES1" pattern="-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
+<macro name="ERES2" pattern="-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
+<macro name="ERES3" pattern="-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
+<macro name="ERES4" pattern="-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
+<macro name="ERES5" pattern="-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
+<macro name="ERES6" pattern="-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
+<macro name="ERES7" pattern="-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
+<macro name="ERES8" pattern="-?[0-9]+/[0-9]+$" description="Encoder ratio (default: 400/4096)" />
+
+<macro name="DHLM1" pattern="-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
+<macro name="DHLM2" pattern="-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
+<macro name="DHLM3" pattern="-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
+<macro name="DHLM4" pattern="-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
+<macro name="DHLM5" pattern="-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
+<macro name="DHLM6" pattern="-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
+<macro name="DHLM7" pattern="-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
+<macro name="DHLM8" pattern="-?[0-9]*\.?[0-9]*$" description="Position upper limit (default: 200)" />
+
+<macro name="DLLM1" pattern="-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
+<macro name="DLLM2" pattern="-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
+<macro name="DLLM3" pattern="-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
+<macro name="DLLM4" pattern="-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
+<macro name="DLLM5" pattern="-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
+<macro name="DLLM6" pattern="-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
+<macro name="DLLM7" pattern="-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
+<macro name="DLLM8" pattern="-?[0-9]*\.?[0-9]*$" description="Position lower limit (default: -200)" />
+
+<macro name="CMOD1" pattern="^(OPEN|CLOSED)$" description="Loop control mode (default: CLOSED)" />
+<macro name="CMOD2" pattern="^(OPEN|CLOSED)$" description="Loop control mode (default: CLOSED)" />
+<macro name="CMOD3" pattern="^(OPEN|CLOSED)$" description="Loop control mode (default: CLOSED)" />
+<macro name="CMOD4" pattern="^(OPEN|CLOSED)$" description="Loop control mode (default: CLOSED)" />
+<macro name="CMOD5" pattern="^(OPEN|CLOSED)$" description="Loop control mode (default: CLOSED)" />
+<macro name="CMOD6" pattern="^(OPEN|CLOSED)$" description="Loop control mode (default: CLOSED)" />
+<macro name="CMOD7" pattern="^(OPEN|CLOSED)$" description="Loop control mode (default: CLOSED)" />
+<macro name="CMOD8" pattern="^(OPEN|CLOSED)$" description="Loop control mode (default: CLOSED)" />
+
+<macro name="HOME1" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
+<macro name="HOME2" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
+<macro name="HOME3" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
+<macro name="HOME4" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
+<macro name="HOME5" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
+<macro name="HOME6" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
+<macro name="HOME7" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
 <macro name="HOME8" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
+
+<macro name="NAME1" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" />
+<macro name="NAME2" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" />
+<macro name="NAME3" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" />
+<macro name="NAME4" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" />
+<macro name="NAME5" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" />
+<macro name="NAME6" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" />
+<macro name="NAME7" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" />
+<macro name="NAME8" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" />
 
 </macros>
 <pvsets>

--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/st-motor.cmd
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/st-motor.cmd
@@ -15,7 +15,7 @@ $(IFSIM) epicsEnvSet("ERESI",1)
 $(IFNOTSIM) epicsEnvSet("ERESI",0)
 epicsEnvSet("DHLMI",$(DHLM$(MN)=200))
 epicsEnvSet("DLLMI",$(DLLM$(MN)=-200))
-epicsEnvSet("NAMEI",$(NAME$(MN)=$(AMOTORNAME)))
+epicsEnvSet("NAMEI","$(NAME$(MN)=$(AMOTORNAME))")
 
 # The signal number is the axis-1
 calc("SN", "$(MN)-1", 2, 2)

--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/st-motor.cmd
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/st-motor.cmd
@@ -15,6 +15,7 @@ $(IFSIM) epicsEnvSet("ERESI",1)
 $(IFNOTSIM) epicsEnvSet("ERESI",0)
 epicsEnvSet("DHLMI",$(DHLM$(MN)=200))
 epicsEnvSet("DLLMI",$(DLLM$(MN)=-200))
+epicsEnvSet("NAMEI",$(NAME$(MN)=$(AMOTORNAME)))
 
 # The signal number is the axis-1
 calc("SN", "$(MN)-1", 2, 2)
@@ -29,7 +30,7 @@ dbLoadRecords("$(ASYN)/db/asynRecord.db", "P=$(MYPVPREFIX),R=$(AMOTORPV):ASYN,PO
 # Set the VBAS, the base speed, to 0.0 as it has no effect (that I know of) on the McLennan except that the acceleration won't be set
 # on an absolute move unless the speed and base speed are different
 #
-dbLoadRecords("$(TOP)/db/motor$(SIMSFX=).db", "P=$(MYPVPREFIX),M=$(AMOTORPV),VELO=$(VELOI),VBAS=0.0,ACCL=$(ACCLI),MRES=$(MRESI),ERES=$(ERESI),DHLM=$(DHLMI),DLLM=$(DLLMI),NAME=$(AMOTORNAME),S=$(SN),C=0,UEIP=1,EGU=$(EGUI)") 
+dbLoadRecords("$(TOP)/db/motor$(SIMSFX=).db", "P=$(MYPVPREFIX),M=$(AMOTORPV),VELO=$(VELOI),VBAS=0.0,ACCL=$(ACCLI),MRES=$(MRESI),ERES=$(ERESI),DHLM=$(DHLMI),DLLM=$(DLLMI),NAME=$(NAMEI),S=$(SN),C=0,UEIP=1,EGU=$(EGUI)")
 dbLoadRecords("$(MOTOR)/db/motorStatus.db", "P=$(MYPVPREFIX),M=$(AMOTORPV)") 
 dbLoadRecords("$(AXIS)/db/axis.db", "P=$(MYPVPREFIX),AXIS=$(IOCNAME):AXIS$(MN),mAXIS=$(AMOTORPV)") 
 


### PR DESCRIPTION
### Description of work

I've added the `NAMEn` macros for LinMots and McLennans so they can have a custom, recognisable name

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2290

### Acceptance criteria

- Add a McLennan IOC to a configuration (set in DEVSIM mode)
- Give the IOC a `NAMEn` macro for an active axis
- Verify the name appears in the Name panel of the motor OPI
- Do the same for LinMots

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Are the PVs named according to the [naming standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
- [ ] Have suitable [disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records) been added?
- [ ] Have suitable [simulation records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation) been added?
- [ ] Have the [finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches) been applied?
- [ ] Is there an [emulator](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Emulating-Devices) for the device?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)? There is a script called `check_opi_format.py` to help with this.

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- [ ] If there are multiple _0n IOCs, do they run correctly?
- [x] Ensure that the log files do not contain undefined macros, ie serach for `macLib: macro` full text is `macLib: macro XXXXX is undefined (expanding string XXXX)`

### Final steps

- [x] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
