### PR TITLE
Add some missing descriptions. Fix spelling of carousel

### DIFF
--- a/ROTSC/ROTSC-IOC-01App/Db/HRPD_specific.db
+++ b/ROTSC/ROTSC-IOC-01App/Db/HRPD_specific.db
@@ -49,6 +49,7 @@ record(scalcout, "$(P)CALC_MTR_1_ENB")
 
 record(bo, "$(P)MTR_1_ENABLED")
 {
+    field(DESC, "Whether motor 1 is enabled")
 	field(ONAM, "ENABLED")
 	field(ZNAM, "DISABLED")
 	info(INTEREST, "MEDIUM")
@@ -64,6 +65,7 @@ record(scalcout, "$(P)CALC_MTR_0_ENB")
 
 record(bo, "$(P)MTR_0_ENABLED")
 {
+    field(DESC, "Whether motor 0 is enabled")
 	field(ONAM, "ENABLED")
 	field(ZNAM, "DISABLED")
 	info(INTEREST, "MEDIUM")
@@ -79,6 +81,7 @@ record(scalcout, "$(P)CALC_MTR_1_DIRECTION")
 
 record(bo, "$(P)MOTOR_1_DIRECTION")
 {
+	field(DESC, "The direction motor 1 is set to rotate")
 	field(ONAM, "RAISE")
 	field(ZNAM, "LOWER")
 	info(INTEREST, "MEDIUM")
@@ -94,6 +97,7 @@ record(scalcout, "$(P)CALC_MTR_1_STATUS")
 
 record(bo, "$(P)MOTOR_1_STATUS")
 {
+	field(DESC, "The status of motor 1")
 	field(ONAM, "ERROR")
 	field(ZNAM, "WORKING")
 	info(INTEREST, "MEDIUM")
@@ -109,6 +113,7 @@ record(scalcout, "$(P)CALC_MTR_0_STATUS")
 
 record(bo, "$(P)MOTOR_0_STATUS")
 {
+	field(DESC, "The status of motor 0")
 	field(ONAM, "ERROR")
 	field(ZNAM, "WORKING")
 	info(INTEREST, "MEDIUM")
@@ -124,7 +129,7 @@ record(scalcout, "$(P)CALC_MTR_0_DIRECTION")
 
 record(bo, "$(P)MOTOR_0_DIRECTION")
 {
-	field(DESC, "The direction it is set to rotate")
+	field(DESC, "The direction motor 0 is set to rotate")
 	field(ONAM, "BACKWARD")
 	field(ZNAM, "FORWARD")
 	info(INTEREST, "MEDIUM")

--- a/ROTSC/ROTSC-IOC-01App/Db/error_calculator.db
+++ b/ROTSC/ROTSC-IOC-01App/Db/error_calculator.db
@@ -7,6 +7,8 @@ record(ai, "$(P)$(ERR)_NUMBER")
 
 record(mbbi, "$(P)$(ERR)_LOWER")
 {
+	field(DESC, "Dictionary of error numbers")	
+	
 	field(DTYP, "Raw Soft Channel")
 	field(INP, "$(P)$(ERR)_NUMBER CP")
 	
@@ -32,6 +34,8 @@ record(mbbi, "$(P)$(ERR)_LOWER")
 
 record(mbbi, "$(P)$(ERR)_UPPER")
 {
+	field(DESC, "Dictionary of error numbers")	
+	
 	field(DTYP, "Raw Soft Channel")
 	field(INP, "$(P)$(ERR)_NUMBER CP")
 
@@ -58,6 +62,7 @@ record(mbbi, "$(P)$(ERR)_UPPER")
 
 record(scalcout, "$(P)$(ERR)_STRING")
 {
+	field(DESC, "Device error as text")	
 	field(SVAL, "")
 	field(INPA, "$(P)$(ERR)_NUMBER CP")
 	field(INAA, "$(P)$(ERR)_LOWER CP")

--- a/ROTSC/ROTSC-IOC-01App/Db/rotating_sample_changer.db
+++ b/ROTSC/ROTSC-IOC-01App/Db/rotating_sample_changer.db
@@ -141,6 +141,7 @@ record(scalcout, "$(P)CALC_CAR_AT_POS_1")
 
 record(bo, "$(P)CAROUSEL_AT_POS_1")
 {
+	field(DESC, "Is the carousel at position 1")
 	field(ONAM, "AT POSITION 1")
 	field(ZNAM, "OFF POSITION 1")
 	info(INTEREST, "MEDIUM")
@@ -157,6 +158,7 @@ record(scalcout, "$(P)CALC_SAMPLE_ARM_UP")
 
 record(bo, "$(P)SAMPLE_ARM_UP")
 {
+	field(DESC, "Whether the sample arm is up")	
 	field(ONAM, "UP")
 	field(ZNAM, "NOT UP")
 }
@@ -172,6 +174,7 @@ record(scalcout, "$(P)CALC_SAMPLE_ARM_DOWN")
 
 record(bo, "$(P)SAMPLE_ARM_DOWN")
 {
+	field(DESC, "Whether the sample arm is down")	
 	field(ONAM, "DOWN")
 	field(ZNAM, "NOT DOWN")
 	info(INTEREST, "MEDIUM")
@@ -331,6 +334,7 @@ record(ao, "$(P)MOVE_TO_POSN")
 
 record(calc, "$(P)CALC_MOVE_FINISHED")
 {
+	field(DESC, "Calculate if the device has finished moving")	
 	field(SCAN, "Passive")
 	field(INPA, "$(P)MOTOR_0_ACTIVE CP")
 	field(INPB, "$(P)MOTOR_1_ACTIVE CP")
@@ -340,6 +344,7 @@ record(calc, "$(P)CALC_MOVE_FINISHED")
 
 record(calc, "$(P)IS_INITIALISED")
 {
+	field(DESC, "Calculate if the device has been initialised")	
 	field(INPA, "$(P)POSN.VAL CP")
 	field(CALC, "A>0")
 	info(INTEREST, "MEDIUM")
@@ -347,6 +352,7 @@ record(calc, "$(P)IS_INITIALISED")
 
 record(calcout, "$(P)CALC_STATUS_STRING")
 {
+	field(DESC, "A text representation of the device status")	
 	field(INPA, "$(P)IS_INITIALISED CP")
 	field(INPB, "$(P)CALC_MOVE_FINISHED CP")
 	field(CALC, "(!A)?0:B?1:2")

--- a/ROTSC/ROTSC-IOC-01App/Db/rotating_sample_changer.db
+++ b/ROTSC/ROTSC-IOC-01App/Db/rotating_sample_changer.db
@@ -124,7 +124,7 @@ record(scalcout, "$(P)CALC_CAR_AT_IDX")
 
 record(bo, "$(P)CAROUSEL_AT_IDX")
 {
-	field(DESC, "If the carousel has reached the index posn")
+	field(DESC, "The carousel has reached the index?")
 	field(ONAM, "AT INDEX")
 	field(ZNAM, "OFF INDEX")
 	info(INTEREST, "MEDIUM")
@@ -334,7 +334,7 @@ record(ao, "$(P)MOVE_TO_POSN")
 
 record(calc, "$(P)CALC_MOVE_FINISHED")
 {
-	field(DESC, "Calculate if the device has finished moving")	
+	field(DESC, "Has the device has finished moving")	
 	field(SCAN, "Passive")
 	field(INPA, "$(P)MOTOR_0_ACTIVE CP")
 	field(INPB, "$(P)MOTOR_1_ACTIVE CP")
@@ -344,7 +344,7 @@ record(calc, "$(P)CALC_MOVE_FINISHED")
 
 record(calc, "$(P)IS_INITIALISED")
 {
-	field(DESC, "Calculate if the device has been initialised")	
+	field(DESC, "Has the device has been initialised")	
 	field(INPA, "$(P)POSN.VAL CP")
 	field(CALC, "A>0")
 	info(INTEREST, "MEDIUM")
@@ -352,7 +352,7 @@ record(calc, "$(P)IS_INITIALISED")
 
 record(calcout, "$(P)CALC_STATUS_STRING")
 {
-	field(DESC, "A text representation of the device status")	
+	field(DESC, "Make text version of status")	
 	field(INPA, "$(P)IS_INITIALISED CP")
 	field(INPB, "$(P)CALC_MOVE_FINISHED CP")
 	field(CALC, "(!A)?0:B?1:2")
@@ -361,6 +361,7 @@ record(calcout, "$(P)CALC_STATUS_STRING")
 
 record(mbbi, "$(P)STATUS_STRING")
 {
+	field(DESC, "Text version of the device status")	
 	field(ZRVL, "0")
 	field(ZRST, "Uninitialised")
 	field(ONVL, "1")

--- a/ROTSC/ROTSC-IOC-01App/Db/rotating_sample_changer.db
+++ b/ROTSC/ROTSC-IOC-01App/Db/rotating_sample_changer.db
@@ -350,18 +350,18 @@ record(calc, "$(P)IS_INITIALISED")
 	info(INTEREST, "MEDIUM")
 }
 
-record(calcout, "$(P)CALC_STATUS_STRING")
+record(calcout, "$(P)CALC_STAT")
 {
 	field(DESC, "Make text version of status")	
 	field(INPA, "$(P)IS_INITIALISED CP")
 	field(INPB, "$(P)CALC_MOVE_FINISHED CP")
 	field(CALC, "(!A)?0:B?1:2")
-	field(OUT, "$(P)STATUS_STRING PP")
+	field(OUT, "$(P)STAT PP")
 }
 
-record(mbbi, "$(P)STATUS_STRING")
+record(mbbi, "$(P)STAT")
 {
-	field(DESC, "Text version of the device status")	
+	field(DESC, "Device status")	
 	field(ZRVL, "0")
 	field(ZRST, "Uninitialised")
 	field(ONVL, "1")

--- a/ROTSC/ROTSC-IOC-01App/Db/rotating_sample_changer.db
+++ b/ROTSC/ROTSC-IOC-01App/Db/rotating_sample_changer.db
@@ -118,12 +118,13 @@ record(scalcout, "$(P)CALC_CAR_AT_IDX")
     field(CALC, "AA[2+BB,2+BB]")
     field(INAA, "$(P)RAW_STATUS PP MS")
 	field(INBB, "$(P)CALC_STATUS_OFFSET")
-    field(OUT, "$(P)CARROUSEL_AT_IDX PP MS")
+    field(OUT, "$(P)CAROUSEL_AT_IDX PP MS")
 	field(IVOA, "Don't drive outputs")
 }
 
-record(bo, "$(P)CARROUSEL_AT_IDX")
+record(bo, "$(P)CAROUSEL_AT_IDX")
 {
+	field(DESC, "If the carousel has reached the index posn")
 	field(ONAM, "AT INDEX")
 	field(ZNAM, "OFF INDEX")
 	info(INTEREST, "MEDIUM")
@@ -134,11 +135,11 @@ record(scalcout, "$(P)CALC_CAR_AT_POS_1")
     field(CALC, "AA[3+BB,3+BB]")
     field(INAA, "$(P)RAW_STATUS PP MS")
 	field(INBB, "$(P)CALC_STATUS_OFFSET")
-    field(OUT, "$(P)CARROUSEL_AT_POS_1 PP MS")
+    field(OUT, "$(P)CAROUSEL_AT_POS_1 PP MS")
 	field(IVOA, "Don't drive outputs")
 }
 
-record(bo, "$(P)CARROUSEL_AT_POS_1")
+record(bo, "$(P)CAROUSEL_AT_POS_1")
 {
 	field(ONAM, "AT POSITION 1")
 	field(ZNAM, "OFF POSITION 1")


### PR DESCRIPTION
### Description of work

I've added some missing description fields to the rotating sample changer PVs. I also changed 'CARROUSEL' to 'CAROUSEL', the former being the French spelling, the latter being the English. There is a corresponding PR for the GUI.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2412

### Acceptance criteria

- [ ] EPICS builds go green
- [ ] Descriptions appropriate to PVs
- [ ] Rotating sample changer still works with the corrected PV spelling

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Are the PVs named according to the [naming standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
- [ ] Have suitable [disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records) been added?
- [ ] Have suitable [simulation records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation) been added?
- [ ] Have the [finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches) been applied?
- [ ] Is there an [emulator](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Emulating-Devices) for the device?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)? There is a script called `check_opi_format.py` to help with this.

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.
- [ ] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- [ ] If there are multiple _0n IOCs, do they run correctly?
- [ ] Ensure that the log files do not contain undefined macros, ie serach for `macLib: macro` full text is `macLib: macro XXXXX is undefined (expanding string XXXX)`

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
