### PR TITLE
Update PV names to have :SP records for settable values

### DIFF
--- a/ROTSC/ROTSC-IOC-01App/Db/HRPD_specific.db
+++ b/ROTSC/ROTSC-IOC-01App/Db/HRPD_specific.db
@@ -135,7 +135,7 @@ record(bo, "$(P)MOTOR_0_DIRECTION")
 	info(INTEREST, "MEDIUM")
 }
 
-record(ao, "$(P)MOVE_TO_POSN:NO_LOWER")
+record(ao, "$(P)POSN:NO_LOWER:SP")
 {
 	field(DTYP, "stream")
 	field(DESC, "Move to the given position")
@@ -144,7 +144,7 @@ record(ao, "$(P)MOVE_TO_POSN:NO_LOWER")
 	info(INTEREST, "MEDIUM")
 	field(EGU, "")
     field(SIML, "$(P)SIM")
-    field(SIOL, "$(P)SIM:MOVE_TO_POSN:NO_LOWER")
+    field(SIOL, "$(P)SIM:POSN:NO_LOWER:SP")
     field(SDIS, "$(P)DISABLE")
 }
 
@@ -156,7 +156,7 @@ record(ai, "$(P)SIM:GET_VR_MAG")
     field(DTYP, "Soft Channel")
 }
 
-record(ao, "$(P)SIM:MOVE_TO_POSN:NO_LOWER")
+record(ao, "$(P)SIM:POSN:NO_LOWER:SP")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")

--- a/ROTSC/ROTSC-IOC-01App/Db/rotating_sample_changer.db
+++ b/ROTSC/ROTSC-IOC-01App/Db/rotating_sample_changer.db
@@ -84,7 +84,7 @@ record(ai, "$(P)POSN")
 	info(archive, "VAL")
 	field(EGU, "") # Fixed positions of 1-20
 	field(SIML, "$(P)SIM")
-    field(SIOL, "$(P)SIM:MOVE_TO_POSN")
+    field(SIOL, "$(P)SIM:POSN:SP")
 	field(SDIS, "$(P)DISABLE")
 }
 
@@ -318,7 +318,7 @@ record(bo, "$(P)RETRIEVE_DROPPED")
     field(SDIS, "$(P)DISABLE")
 }
 
-record(ao, "$(P)MOVE_TO_POSN")
+record(ao, "$(P)POSN:SP")
 {	
 	field(SCAN, "Passive")
 	field(DTYP, "stream")
@@ -328,7 +328,7 @@ record(ao, "$(P)MOVE_TO_POSN")
 	info(INTEREST, "HIGH")
 	field(EGU, "")
     field(SIML, "$(P)SIM")
-    field(SIOL, "$(P)SIM:MOVE_TO_POSN")
+    field(SIOL, "$(P)SIM:POSN:SP")
     field(SDIS, "$(P)DISABLE")
 }
 
@@ -385,7 +385,7 @@ record(bo, "$(P)SIM:RESET_1")
     field(DTYP, "Soft Channel")
 }
 
-record(ao, "$(P)SIM:MOVE_TO_POSN")
+record(ao, "$(P)SIM:POSN:SP")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")


### PR DESCRIPTION
### Description of work

Update the rotating sample changer PVs to end with SP so that they don't throw errors when set using a block.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2314

### Acceptance criteria

- [ ] Rotating sample changer works as before
- [ ] Can use cset on a block pointing at the new PVs without getting an error
- [ ] Release notes contain appropriate instructions on how to update the blocks on instruments

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Are the PVs named according to the [naming standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
- [ ] Have suitable [disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records) been added?
- [ ] Have suitable [simulation records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation) been added?
- [ ] Have the [finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches) been applied?
- [ ] Is there an [emulator](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Emulating-Devices) for the device?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)? There is a script called `check_opi_format.py` to help with this.

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.
- [ ] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- [ ] If there are multiple _0n IOCs, do they run correctly?
- [ ] Ensure that the log files do not contain undefined macros, ie serach for `macLib: macro` full text is `macLib: macro XXXXX is undefined (expanding string XXXX)`

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
