### PR TITLE
Eurotherm ramp rate units

### DIFF
--- a/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
+++ b/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
@@ -114,6 +114,7 @@ record(ao, "$(P)RATE:SP")
    field(DTYP, "asynFloat64")
    field(OUT, "@asyn($(READ),0,1)RATE")
    field(EGU, "K/min")
+   info(INTEREST, "MEDIUM")
 }
 
 record(ai, "$(P)RATE")
@@ -123,6 +124,7 @@ record(ai, "$(P)RATE")
    field(INP, "@asyn($(READ),0,1)RATE")
    field(EGU, "K/min")
    field(SCAN, "I/O Intr")
+   info(INTEREST, "MEDIUM")
 }
 
 record(bi, "$(P)RAMPING")

--- a/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
+++ b/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
@@ -113,7 +113,7 @@ record(ao, "$(P)RATE:SP")
    field(DESC, "Rate the ramp increases/decreases")
    field(DTYP, "asynFloat64")
    field(OUT, "@asyn($(READ),0,1)RATE")
-   field(EGU, "K/s")
+   field(EGU, "K/min")
 }
 
 record(ai, "$(P)RATE")
@@ -121,7 +121,7 @@ record(ai, "$(P)RATE")
    field(DESC, "Rate the ramp increases/decreases")
    field(DTYP, "asynFloat64")
    field(INP, "@asyn($(READ),0,1)RATE")
-   field(EGU, "K/s")
+   field(EGU, "K/min")
    field(SCAN, "I/O Intr")
 }
 

--- a/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
+++ b/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
@@ -87,6 +87,7 @@ record(stringout, "$(P)RAMP_FILE:SP")
    field(SCAN, "I/O Intr")
 }
 
+# This set point is passed to the ReadASCII ramp, which decides what value to pass on to the device.
 record(ao, "$(P)TEMP:SP")
 {
    field(DESC, "Temperature setpoint")
@@ -98,6 +99,7 @@ record(ao, "$(P)TEMP:SP")
    info(archive, "VAL")
 }
 
+# This set point is read back from the ReadASCII ramp to say where it is ramping to
 record(ao, "$(P)TEMP:SP:RBV")
 {
    field(DESC, "Temperature setpoint readback")
@@ -135,6 +137,7 @@ record(bi, "$(P)RAMPING")
    field(SCAN, "I/O Intr")   
 }
 
+# This is the value that is being sent to the ReadASCII ramp to tell it at what temperature we currently are
 record(ao, "$(P)CURRENT_TEMP")
 {
     field(DESC, "The current temperature of the sensor")
@@ -222,7 +225,7 @@ record(ai, "$(P)OUT_MAX")
 
 ###########
 
-#Pass on PID ramp
+#Pass on PID ramp from ReadASCII to the device
 record(ao, "$(P)RAMP_SP")
 {
     field(DTYP, "Soft Channel")

--- a/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-common.cmd
+++ b/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-common.cmd
@@ -8,11 +8,20 @@ epicsEnvSet "RAMP_PAT" ".*"
 
 < $(IOCSTARTUP)/init.cmd
 
-drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
-asynSetOption("L0", -1, "baud", "$(BAUD=9600)")
-asynSetOption("L0", -1, "bits", "$(BITS=7)")
-asynSetOption("L0", -1, "parity", "$(PARITY=even)")
-asynSetOption("L0", -1, "stop", "$(STOP=1)")
+# For dev sim devices
+$(IFDEVSIM) drvAsynIPPortConfigure("L0", "localhost:$(EMULATOR_PORT=)")
+
+$(IFNOTDEVSIM) $(IFNOTRECSIM) drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "baud", "$(BAUD=9600)")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "bits", "$(BITS=7)")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "parity", "$(PARITY=even)")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "$(STOP=1)")
+
+asynSetTraceMask("L0",-1,0x9) 
+asynSetTraceIOMask("L0",-1,0x2)
+
+asynOctetSetInputEos( "L0", -1, "\r\n")
+asynOctetSetOutputEos("L0", -1, "\r\n")
 
 < $(IOCSTARTUP)/dbload.cmd
 

--- a/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-common.cmd
+++ b/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-common.cmd
@@ -3,8 +3,10 @@ epicsEnvSet "STREAM_PROTOCOL_PATH" "$(EUROTHERM2K)/data"
 epicsEnvSet "CALIB_BASE_DIR" "C:/Instrument/Settings/config/common"
 epicsEnvSet "SENS_DIR" "temp_sensors"
 epicsEnvSet "SENS_PAT" "^C.*"
-epicsEnvSet "RAMP_DIR" "ramps"
+epicsEnvSet "RAMP_DIR" "$(CALIB_BASE_DIR)/ramps"
 epicsEnvSet "RAMP_PAT" ".*"
+
+$(IFDEVSIM) epicsEnvSet "RAMP_DIR" "$(READASCII)/example_settings"
 
 < $(IOCSTARTUP)/init.cmd
 
@@ -17,11 +19,7 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "bits", "$(BITS=7)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "parity", "$(PARITY=even)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "$(STOP=1)")
 
-asynSetTraceMask("L0",-1,0x9) 
-asynSetTraceIOMask("L0",-1,0x2)
-
-asynOctetSetInputEos( "L0", -1, "\r\n")
-asynOctetSetOutputEos("L0", -1, "\r\n")
+$(IFDEVSIM) asynOctetSetOutputEos("L0", -1, "\r\n")
 
 < $(IOCSTARTUP)/dbload.cmd
 

--- a/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-euro.cmd
+++ b/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-euro.cmd
@@ -7,12 +7,12 @@ calc("GAD", "$(ADDR_$(EURO_NUM)=0)/10%10",1,1)
 
 ## Load FileList
 ## A seperate instance must be created for each Eurothrm
-$(IFACTIVE) FileListConfigure("RAMPFILELIST$(EURO_NUM)", "$(CALIB_BASE_DIR)/$(RAMP_DIR)", $(RAMP_PAT)) 
+$(IFACTIVE) FileListConfigure("RAMPFILELIST$(EURO_NUM)", "$(RAMP_DIR)", $(RAMP_PAT)) 
 $(IFACTIVE) FileListConfigure("SENSORFILELIST$(EURO_NUM)", "$(CALIB_BASE_DIR)/$(SENS_DIR)", "$(SENS_PAT)", 1) 
 
 ## Load ReadASCII
 ## A seperate instance must be created for each Eurothrm
-$(IFACTIVE) ReadASCIIConfigure("READASCII$(EURO_NUM)", "$(CALIB_BASE_DIR)/$(RAMP_DIR)")
+$(IFACTIVE) ReadASCIIConfigure("READASCII$(EURO_NUM)", "$(RAMP_DIR)")
 
 ## Load record instances
 ## The timing for record reads is controlled in st-timing.cmd


### PR DESCRIPTION
### Description of work
This changes the eurotherm ramping units for K/s to K/min
This also brings the eurotherm under test.

### To test
 - Check that you can run the device emulator
 - Check that the tests pass

Other PRs:

Original issue is: https://github.com/ISISComputingGroup/IBEX/issues/2465

### Acceptance criteria
 - [ ]  Tests pass

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Are the PVs named according to the [naming standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
- [ ] Have suitable [disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records) been added?
- [ ] Have suitable [simulation records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation) been added?
- [ ] Have the [finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches) been applied?
- [ ] Is there an [emulator](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Emulating-Devices) for the device?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)? There is a script called `check_opi_format.py` to help with this.

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.
- [ ] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- [ ] If there are multiple _0n IOCs, do they run correctly?
- [ ] Ensure that the log files do not contain undefined macros, ie serach for `macLib: macro` full text is `macLib: macro XXXXX is undefined (expanding string XXXX)`

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
