### PR TITLE
Ticket 2592: Inverted the DFKPS power PV

### DIFF
--- a/DFKPS/DFKPS-IOC-01App/Db/DFKPS_8800_status.db
+++ b/DFKPS/DFKPS-IOC-01App/Db/DFKPS_8800_status.db
@@ -91,7 +91,7 @@ record(seq, "$(P)PROCALL2")
     field(LNK5, "$(P)ILK:REGSUP")
     field(LNK6, "$(P)ILK:IGBT")
     field(LNK7, "$(P)ILK:OVERC")
-    field(LNK8, "$(P)POWER PP")
+    field(LNK8, "$(P)CALCPOWER.A PP")
     field(LNK9, "$(P)CALCNEUT.A")
     field(LNKA, "$(P)CALCNEUT.B")
     field(FLNK, "$(P)CALCNEUT")
@@ -316,11 +316,18 @@ record(bi, "$(P)ILK:NEUTRAL")
     info(INTEREST, "HIGH")
 }
 
+record(calcout, "$(P)CALCPOWER")
+{
+    field(DESC, "Invert the power bit")
+	field(CALC, "!A")
+	field(OUT, "$(P)POWER PP")
+}
+
 record(bi, "$(P)POWER")
 {
     field(DESC, "Power")
-    field(ZNAM, "On")
-    field(ONAM, "Off")
+    field(ZNAM, "Off")
+    field(ONAM, "On")
     info(INTEREST, "HIGH")
     info(archive, "VAL")
 }
@@ -352,6 +359,10 @@ record(bo, "$(P)START")
 }
 
 record(bo, "$(P)SIM:START"){
+    field(DTYP, "Soft Channel")
+}
+
+record(ai, "$(P)SIM:STATUS"){
     field(DTYP, "Soft Channel")
 }
 


### PR DESCRIPTION
### Description of work

As per https://github.com/ISISComputingGroup/IBEX/issues/2592 the power PV for the Danfysik 8800 was being set to 1 when off and 0 when on. This wasn't normally an issue as the ONAM/ZNAM were also swapped. 

### To test

* Start DFKPS as a 8800 model and in recsim
* Open the muon front end opi
* Confirm that the power pv and LED on the OPI match
* caput %MYPVPREFIX%DFKPS_01:SIM:STATUS 2
* Confirm that power pv changes
* Confirm that the power pv and LED on the OPI match

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Are the PVs named according to the [naming standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
- [ ] Have suitable [disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records) been added?
- [ ] Have suitable [simulation records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation) been added?
- [ ] Have the [finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches) been applied?
- [ ] Is there an [emulator](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Emulating-Devices) for the device?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)? There is a script called `check_opi_format.py` to help with this.

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- [x] If there are multiple _0n IOCs, do they run correctly?
- [ ] Ensure that the log files do not contain undefined macros, ie serach for `macLib: macro` full text is `macLib: macro XXXXX is undefined (expanding string XXXX)`

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
