### PR TITLE
Fixes to reproduce the working hotfix on ZOOM

### DIFF
--- a/FINS/FINS-IOC-01App/Db/zoom-vacuum-base.template
+++ b/FINS/FINS-IOC-01App/Db/zoom-vacuum-base.template
@@ -37,7 +37,13 @@ record(bo, "$(P)$(Q)DAE:RESET:SP")
     field(ZNAM, "RESET")
     field(ONAM, "RESET")
     field(DESC, "Reset the DAE")
-    field(FLNK, "$(P)$(Q)DAE:RESET:RAW:SP")
+    field(FLNK, "$(P)$(Q)DAE:RESET:RAW:VAL")
+}
+
+record(longout, "$(P)$(Q)DAE:RESET:RAW:VAL")
+{
+	field(VAL, "1")
+	field(OUT, "$(P)$(Q)DAE:RESET:RAW:SP PP")
 }
 
 record(longout, "$(P)$(Q)DAE:RESET:RAW:SP")

--- a/FINS/FINS-IOC-01App/Db/zoom-vacuum-commands.template
+++ b/FINS/FINS-IOC-01App/Db/zoom-vacuum-commands.template
@@ -59,7 +59,7 @@ record(bo, "$(P)$(Q)$(NAME):$(ZPV)")
     field(ONAM, "$(ZPV)")
     field(DTYP, "Soft Channel")
     field(DESC, "$(ZDESC)")
-    field(FLNK, "$(P)$(Q)$(NAME):$(ZPV):RAW:SP")
+    field(FLNK, "$(P)$(Q)$(NAME):$(ZPV):RAW:VAL")
 }
 
 record(bo, "$(P)$(Q)$(NAME):$(OPV)")
@@ -68,7 +68,19 @@ record(bo, "$(P)$(Q)$(NAME):$(OPV)")
     field(ONAM, "$(OPV)")
     field(DTYP, "Soft Channel")
     field(DESC, "$(ODESC)")
-    field(FLNK, "$(P)$(Q)$(NAME):$(OPV):RAW:SP")
+    field(FLNK, "$(P)$(Q)$(NAME):$(OPV):RAW:VAL")
+}
+
+record(longout, "$(P)$(Q)$(NAME):$(ZPV):RAW:VAL")
+{
+	field(VAL, "1")
+	field(OUT, "$(P)$(Q)$(NAME):$(ZPV):RAW:SP PP")
+}
+
+record(longout, "$(P)$(Q)$(NAME):$(OPV):RAW:VAL")
+{
+	field(VAL, "1")
+	field(OUT, "$(P)$(Q)$(NAME):$(OPV):RAW:SP PP")
 }
 
 record(longout, "$(P)$(Q)$(NAME):$(ZPV):RAW:SP")


### PR DESCRIPTION
### Description of work

Altered the files so that they will generate a db file matching one created for a hotfix.
The main item is an addition of a longout that is forward linked to from certain items such as the monitor insert and extract records which in turn writes a value of 1, always 1, to the PLC

### To test

Relates to https://github.com/ISISComputingGroup/IBEX/issues/2665
To test, re-make the FINS IOC and check that appropriate records are created. If in doubt as to what those records should be either look at the db file on ZOOM, or ask Kathryn for a copy of it.

### Acceptance criteria

The interim records are in place so that ZOOM will be able to function should the system be upgraded.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [ ] Are the PVs named according to the [naming standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
- [ ] Have suitable [disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records) been added?
- [ ] Have suitable [simulation records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation) been added?
- [ ] Have the [finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches) been applied?
- [ ] Is there an [emulator](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Emulating-Devices) for the device?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)? There is a script called `check_opi_format.py` to help with this.

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.
- [ ] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- [ ] If there are multiple _0n IOCs, do they run correctly?
- [ ] Ensure that the log files do not contain undefined macros, ie serach for `macLib: macro` full text is `macLib: macro XXXXX is undefined (expanding string XXXX)`

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
