### PR TITLE
Put terminator in st-common.cmd.

### DIFF
--- a/KHLY2400/iocBoot/iocKHLY2400-IOC-01/config.xml
+++ b/KHLY2400/iocBoot/iocKHLY2400-IOC-01/config.xml
@@ -8,6 +8,8 @@
 <macro name="BITS" pattern="^[0-9]$" description="Serial communication number of bits, defaults to 8." />
 <macro name="PARITY" pattern="^(even)|(odd)|(none)$" description="Serial communication parity, defaults to none." />
 <macro name="STOP" pattern="^[0-9]$" description="Serial communication stop bit, defaults to 1." />
+<macro name="OEOS" pattern="^.*$" description="Serial communication output terminator, defaults to \r\n." />
+<macro name="IEOS" pattern="^.*$" description="Serial communication input terminator, defaults to \r\n." />
 </macros>
 </config_part>
 </ioc_config>

--- a/KHLY2400/iocBoot/iocKHLY2400-IOC-01/st-common.cmd
+++ b/KHLY2400/iocBoot/iocKHLY2400-IOC-01/st-common.cmd
@@ -7,7 +7,7 @@ epicsEnvSet "DEVICE" "L0"
 ## For emulator use:
 $(IFDEVSIM) freeIPPort("FREEPORT")  
 $(IFDEVSIM) epicsEnvShow("FREEPORT") 
-$(IFDEVSIM) drvAsynIPPortConfigure("$(DEVICE)", "localhost:57677")
+$(IFDEVSIM) drvAsynIPPortConfigure("$(DEVICE)", "localhost:$(FREEPORT=0)")
 
 $(IFNOTDEVSIM) drvAsynSerialPortConfigure("$(DEVICE)", "$(PORT)", 0, 0, 0, 0)
 $(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "baud", "$(BAUD=19200)")

--- a/KHLY2400/iocBoot/iocKHLY2400-IOC-01/st-common.cmd
+++ b/KHLY2400/iocBoot/iocKHLY2400-IOC-01/st-common.cmd
@@ -14,8 +14,8 @@ $(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "baud", "$(BAUD=19200)")
 $(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "bits", "$(BITS=8)")
 $(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "parity", "$(PARITY=none)")
 $(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)")
-asynOctetSetInputEos("$(DEVICE)", -1, "$(OEOS=\\r\\n)")
-asynOctetSetOutputEos("$(DEVICE)", -1, "$(IEOS=\\r\\n)")
+asynOctetSetInputEos("$(DEVICE)", -1, "$(IEOS=\\r\\n)")
+asynOctetSetOutputEos("$(DEVICE)", -1, "$(OEOS=\\r\\n)")
 
 ## Load record instances
 

--- a/KHLY2400/iocBoot/iocKHLY2400-IOC-01/st-common.cmd
+++ b/KHLY2400/iocBoot/iocKHLY2400-IOC-01/st-common.cmd
@@ -7,15 +7,15 @@ epicsEnvSet "DEVICE" "L0"
 ## For emulator use:
 $(IFDEVSIM) freeIPPort("FREEPORT")  
 $(IFDEVSIM) epicsEnvShow("FREEPORT") 
-$(IFDEVSIM) drvAsynIPPortConfigure("$(DEVICE)", "localhost:$(FREEPORT=0)")
+$(IFDEVSIM) drvAsynIPPortConfigure("$(DEVICE)", "localhost:57677")
 
 $(IFNOTDEVSIM) drvAsynSerialPortConfigure("$(DEVICE)", "$(PORT)", 0, 0, 0, 0)
 $(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "baud", "$(BAUD=19200)")
 $(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "bits", "$(BITS=8)")
 $(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "parity", "$(PARITY=none)")
 $(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)")
-$(IFNOTDEVSIM) asynOctetSetInputEos("$(DEVICE)", -1, "$(OEOS=\r)")
-$(IFNOTDEVSIM) asynOctetSetOutputEos("$(DEVICE)", -1, "$(IEOS=\r)")
+asynOctetSetInputEos("$(DEVICE)", -1, "$(OEOS=\\r\\n)")
+asynOctetSetOutputEos("$(DEVICE)", -1, "$(IEOS=\\r\\n)")
 
 ## Load record instances
 


### PR DESCRIPTION
### Description of work

Makes the terminator on the Keithley 2400 configurable.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2695

Needs the PR at https://github.com/ISISComputingGroup/EPICS-Keithley2400/pull/1

### Acceptance criteria

- [x] By default the terminator is still `\r\n` (as before, and as the emulator expects)
- [x] In the GUI, set up the keithley macros with `IEOS=\\r\\n` and `OEOS=\\r\\n` (note, the double slash is unfortunately needed because of macro escaping)
  * [x] Verify that the IOC and the emulator still talk correctly. You should see constant messages of the form `2017-10-27 17:05:08,470 INFO lewis.Keithley2400StreamInterface.StreamHandler: Processing request :OUTP? using command ^\:OUTP\?$` in the lewis log and no errors in the IOC log.

Now modify the terminators in `C:\Instrument\Apps\EPICS\support\DeviceEmulator\master\lewis_emulators\keithley_2400\interfaces\stream_interface.py` to be `\r`.

- [x] In the GUI, set up the keithley macros with `IEOS=\\r` and `OEOS=\\r`
  * [x] Verify that the IOC and the emulator still talk correctly, as above.

- [ ] There is an appropriate note at https://github.com/ISISComputingGroup/IBEX/wiki/Maintenance-Day to update Polaris' configuration.

Useful command to launch the emulator: `C:\Instrument\Apps\Python\python.exe C:\Instrument\Apps\Python\Scripts\lewis.exe -r 127.0.0.1:10000 -p stream -a C:\Instrument\Apps\EPICS\support\DeviceEmulator\master -k lewis_emulators keithley_2400 -p "stream: {bind_address: localhost, port: 57677}"`

---

#### Code Review

- [ ] **Pertitent information and a copy of the manual has been stored in the [wiki](IOCs)**
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [x] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [x] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
