### PR TITLE
Ticket2693 keithley crash

### DIFF
--- a/KHLY2400/KHLY2400-IOC-01App/Db/KHLY2400.db
+++ b/KHLY2400/KHLY2400-IOC-01App/Db/KHLY2400.db
@@ -131,9 +131,9 @@ record(seq, "$(P)_READ_POWER") {
 	field(DLY2, "0")
 	field(DLY3, "0")
 	
-	field(LNK1, "$(P)V.PROC")
-	field(LNK2, "$(P)I.PROC")
-	field(LNK3, "$(P)R.PROC")
+	field(LNK1, "$(P)V:RAW.PROC")
+	field(LNK2, "$(P)I:RAW.PROC")
+	field(LNK3, "$(P)R:RAW.PROC")
 	
 	field(SELM, "All")
 }
@@ -142,54 +142,103 @@ record(seq, "$(P)_READ_POWER") {
 #### Current, Voltage, Resistance ####
 ######################################
 
-record(ai, "$(P)I")
+record(ai, "$(P)I:RAW")
 {
-    field(DESC, "Current")
     field(DTYP, "stream")
-    field(EGU, "A")
-	field(PREC, "5")
     field(INP, "@Keithley2400.proto get_I $(PORT)")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:I")
     field(SDIS, "$(P)DISABLE")
-    info(archive, "VAL")
-    info(INTEREST, "HIGH")
 }
 
 record(ai, "$(P)SIM:I")
 {
+	field(LOPR, "-1000000000")
+	field(HOPR, "1000000000")
 }
 
-record(ai, "$(P)V")
+record(calcout, "$(P)I:CALC")
 {
-    field(DESC, "Voltage")
-    field(DTYP, "stream")
-    field(EGU, "V")
+	field(INPA, "$(P)I:RAW CP MS")
+	# The reason this is done is to filter out the 10**38 "Nan" 
+	# value that the device gives when sensor disconnected.
+	field(CALC, "A>10**20?Nan:A")
+}
+
+record(ai, "$(P)I")
+{
+	field(DESC, "Current")
+    field(EGU, "A")
 	field(PREC, "5")
+	field(INP, "$(P)I:CALC CP MS")
+	info(archive, "VAL")
+    info(INTEREST, "HIGH")
+	field(LOPR, "-1000000000")
+	field(HOPR, "1000000000")
+}
+
+record(ai, "$(P)V:RAW")
+{
+    field(DTYP, "stream")
     field(INP, "@Keithley2400.proto get_V $(PORT)")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:V")
     field(SDIS, "$(P)DISABLE")
-    info(archive, "VAL")
-    info(INTEREST, "HIGH")
 }
 
 record(ai, "$(P)SIM:V")
 {
+	field(LOPR, "-1000000000")
+	field(HOPR, "1000000000")
 }
 
-record(ai, "$(P)R")
+record(calcout, "$(P)V:CALC")
 {
-    field(DESC, "Resistance")
-    field(DTYP, "stream")
-    field(EGU, "ohm")
+	field(INPA, "$(P)V:RAW CP MS")
+	# The reason this is done is to filter out the 10**38 "Nan" 
+	# value that the device gives when sensor disconnected.
+	field(CALC, "A>10**20?Nan:A")
+}
+
+record(ai, "$(P)V")
+{
+	field(DESC, "Voltage")
+    field(EGU, "V")
 	field(PREC, "5")
+	field(INP, "$(P)V:CALC CP MS")
+	info(archive, "VAL")
+    info(INTEREST, "HIGH")
+	field(LOPR, "-1000000000")
+	field(HOPR, "1000000000")
+}
+
+record(ai, "$(P)R:RAW")
+{
+    field(DTYP, "stream")
     field(INP, "@Keithley2400.proto get_R $(PORT)")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:R")
     field(SDIS, "$(P)DISABLE")
-    info(archive, "VAL")
+}
+
+record(calcout, "$(P)R:CALC")
+{
+	field(INPA, "$(P)R:RAW CP MS")
+	# The reason this is done is to filter out the 10**38 "Nan" 
+	# value that the device gives when sensor disconnected.
+	field(CALC, "A>10**20?Nan:A")
+}
+
+record(ai, "$(P)R")
+{
+	field(DESC, "Resistance")
+    field(EGU, "ohm")
+	field(PREC, "5")
+	field(INP, "$(P)V:CALC CP MS")
+	info(archive, "VAL")
     info(INTEREST, "HIGH")
+	field(LOPR, "-1000000000")
+	field(HOPR, "1000000000")
 }
 
 record(ai, "$(P)SIM:R")

--- a/KHLY2400/KHLY2400-IOC-01App/Db/KHLY2400.db
+++ b/KHLY2400/KHLY2400-IOC-01App/Db/KHLY2400.db
@@ -153,8 +153,6 @@ record(ai, "$(P)I:RAW")
 
 record(ai, "$(P)SIM:I")
 {
-	field(LOPR, "-1000000000")
-	field(HOPR, "1000000000")
 }
 
 record(calcout, "$(P)I:CALC")
@@ -173,8 +171,6 @@ record(ai, "$(P)I")
 	field(INP, "$(P)I:CALC CP MS")
 	info(archive, "VAL")
     info(INTEREST, "HIGH")
-	field(LOPR, "-1000000000")
-	field(HOPR, "1000000000")
 }
 
 record(ai, "$(P)V:RAW")
@@ -188,8 +184,6 @@ record(ai, "$(P)V:RAW")
 
 record(ai, "$(P)SIM:V")
 {
-	field(LOPR, "-1000000000")
-	field(HOPR, "1000000000")
 }
 
 record(calcout, "$(P)V:CALC")
@@ -208,8 +202,6 @@ record(ai, "$(P)V")
 	field(INP, "$(P)V:CALC CP MS")
 	info(archive, "VAL")
     info(INTEREST, "HIGH")
-	field(LOPR, "-1000000000")
-	field(HOPR, "1000000000")
 }
 
 record(ai, "$(P)R:RAW")
@@ -237,8 +229,6 @@ record(ai, "$(P)R")
 	field(INP, "$(P)V:CALC CP MS")
 	info(archive, "VAL")
     info(INTEREST, "HIGH")
-	field(LOPR, "-1000000000")
-	field(HOPR, "1000000000")
 }
 
 record(ai, "$(P)SIM:R")

--- a/KHLY2400/iocBoot/iocKHLY2400-IOC-01/st-common.cmd
+++ b/KHLY2400/iocBoot/iocKHLY2400-IOC-01/st-common.cmd
@@ -7,15 +7,15 @@ epicsEnvSet "DEVICE" "L0"
 ## For emulator use:
 $(IFDEVSIM) freeIPPort("FREEPORT")  
 $(IFDEVSIM) epicsEnvShow("FREEPORT") 
-$(IFDEVSIM) drvAsynIPPortConfigure("$(DEVICE)", "localhost:$(FREEPORT=0)")
+$(IFDEVSIM) drvAsynIPPortConfigure("$(DEVICE)", "localhost:57677")
 
 $(IFNOTDEVSIM) drvAsynSerialPortConfigure("$(DEVICE)", "$(PORT)", 0, 0, 0, 0)
 $(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "baud", "$(BAUD=19200)")
 $(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "bits", "$(BITS=8)")
 $(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "parity", "$(PARITY=none)")
 $(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)")
-$(IFNOTDEVSIM) asynOctetSetInputEos("$(DEVICE)", -1, "$(OEOS=\r)")
-$(IFNOTDEVSIM) asynOctetSetOutputEos("$(DEVICE)", -1, "$(IEOS=\r)")
+asynOctetSetInputEos("$(DEVICE)", -1, "$(OEOS=\\r)")
+asynOctetSetOutputEos("$(DEVICE)", -1, "$(IEOS=\\r)")
 
 ## Load record instances
 

--- a/KHLY2400/iocBoot/iocKHLY2400-IOC-01/st-common.cmd
+++ b/KHLY2400/iocBoot/iocKHLY2400-IOC-01/st-common.cmd
@@ -7,15 +7,15 @@ epicsEnvSet "DEVICE" "L0"
 ## For emulator use:
 $(IFDEVSIM) freeIPPort("FREEPORT")  
 $(IFDEVSIM) epicsEnvShow("FREEPORT") 
-$(IFDEVSIM) drvAsynIPPortConfigure("$(DEVICE)", "localhost:57677")
+$(IFDEVSIM) drvAsynIPPortConfigure("$(DEVICE)", "localhost:$(FREEPORT=0)")
 
 $(IFNOTDEVSIM) drvAsynSerialPortConfigure("$(DEVICE)", "$(PORT)", 0, 0, 0, 0)
 $(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "baud", "$(BAUD=19200)")
 $(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "bits", "$(BITS=8)")
 $(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "parity", "$(PARITY=none)")
 $(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)")
-asynOctetSetInputEos("$(DEVICE)", -1, "$(OEOS=\\r)")
-asynOctetSetOutputEos("$(DEVICE)", -1, "$(IEOS=\\r)")
+$(IFNOTDEVSIM) asynOctetSetInputEos("$(DEVICE)", -1, "$(OEOS=\r)")
+$(IFNOTDEVSIM) asynOctetSetOutputEos("$(DEVICE)", -1, "$(IEOS=\r)")
 
 ## Load record instances
 


### PR DESCRIPTION
### Description of work

This PR fixes a crash in the ibex gui when the Keithley 2400 had a disconnected sensor.

The sequence of events that caused this crash was:
- Keithley gives a value of `10^38` if a sensor is disconnected
- This was propagated through the IOC
- The OPI graph widget choked when trying to plot such a large value.

I've modified the IOC so that any value above `10^20` is rejected and replaced with `Nan`, which also makes it go into an alarm state. This limit should be comfortably above any value which will realistically be measured, but is also able to be plotted by CSS.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2693

### Acceptance criteria

With a Keithley 2400 in recsim mode:
- [ ] Check that `caput TE:NDW1799:KHLY2400_01:SIM:I 10` comes up with 10 Amps on the OPI
- [ ] Check that `caput %MYPVPREFIX%KHLY2400_01:SIM:I 1.0e+19` comes up with 10^19 Amps on the OPI
- [ ] Check that `caput %MYPVPREFIX%KHLY2400_01:SIM:I 1.0e+38` comes up an alarm on the OPI and the graph widget does not crash

You can also test in devsim mode. This is a bit more fiddly to set up:
- Launch the emulator using `C:\Instrument\Apps\Python\python.exe C:\Instrument\Apps\Python\Scripts\lewis.exe -r 127.0.0.1:10000 -p stream -a C:\Instrument\Apps\EPICS\support\DeviceEmulator\master -k lewis_emulators keithley_2400 -p "stream: {bind_address: localhost, port: 57677}"`
- Modify `st-common.cmd` to point at `localhost:57677` i.e. set line 10 to be `$(IFDEVSIM) drvAsynIPPortConfigure("$(DEVICE)", "localhost:57677")`
- Once you have the IOC and emulator talking use `caput %MYPVPREFIX%KHLY2400_01:OUTPUT:MODE:SP 1` to make the emulator give you values.
- The easiest way I've found to change the data coming back is to change the `INITIAL_CURRENT` and `INITIAL_VOLTAGE` variables at the top of `C:\Instrument\Apps\EPICS\support\DeviceEmulator\master\lewis_emulators\keithley_2400\device.py`

Once you have set up the emulator as above the same tests should work in devsim as recsim.

---

#### Code Review

- [ ] **Pertitent information and a copy of the manual has been stored in the [wiki](IOCs)**
- [x] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [x] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Functional Tests

- IOC responds correctly in:
    - [x] Devsim mode
    - [x] Recsim mode
    - [ ] Real device, if available
- [x] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [x] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [x] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
