### PR TITLE
Ticket2633 mk3 chopper speed crash

### DIFF
--- a/MK3CHOPR/MK3CHOPR-IOC-01App/src/mk3Driver.cpp
+++ b/MK3CHOPR/MK3CHOPR-IOC-01App/src/mk3Driver.cpp
@@ -22,7 +22,7 @@
 
 
 static const char *driverName="mk3Driver";
-static const int BUFFER_SIZE = 50;
+static const int BUFFER_SIZE = 100;
 
 mk3Driver::mk3Driver(const char *portName, const char *configFilePath, int mockChopper) 
    : asynPortDriver(portName, 

--- a/MK3CHOPR/MK3CHOPR-IOC-01App/src/mk3Driver.cpp
+++ b/MK3CHOPR/MK3CHOPR-IOC-01App/src/mk3Driver.cpp
@@ -22,6 +22,7 @@
 
 
 static const char *driverName="mk3Driver";
+static const int BUFFER_SIZE = 50;
 
 mk3Driver::mk3Driver(const char *portName, const char *configFilePath, int mockChopper) 
    : asynPortDriver(portName, 
@@ -191,7 +192,7 @@ asynStatus mk3Driver::readOctet(asynUser *pasynUser, char *value, size_t maxChar
     }
     else if (function == P_ChopperName)
     {
-        const int size = 50;
+        const int size = BUFFER_SIZE;
         char result[size];
         errCode = m_interface->getChopperName(channel, result, size);
         checkErrorCode(errCode);
@@ -354,8 +355,8 @@ void mk3Driver::checkErrorCode(int code)
     // 0 = no error
     if (code != 0)
     {
-        char answer[50];
-        m_interface->checkErrorCode(code, answer, 50);
+        char answer[BUFFER_SIZE];
+        m_interface->checkErrorCode(code, answer, BUFFER_SIZE);
         errlogSevPrintf(errlogMajor, "%s", answer);
         
         // If .net timeout try to re-intialise

--- a/MK3CHOPR/iocBoot/iocMk3CHOPR-IOC-01/st.cmd
+++ b/MK3CHOPR/iocBoot/iocMk3CHOPR-IOC-01/st.cmd
@@ -18,7 +18,9 @@ MK3CHOPR_IOC_01_registerRecordDeviceDriver pdbbase
 < $(IOCSTARTUP)/init.cmd
 
 # Portname, path to config file, use mock (=1 for mock)
-mk3DriverConfigure("MK3", "C:/LabVIEW Modules/Drivers/ISIS MK3 Disc Chopper/MK3_Chopper.config", 0)
+$(IFDEVSIM) epicsEnvSet(useMock, 1)
+$(IFNOTDEVSIM) epicsEnvSet(useMock, 0)
+mk3DriverConfigure("MK3", "C:/LabVIEW Modules/Drivers/ISIS MK3 Disc Chopper/MK3_Chopper.config", $(useMock))
 
 ## Load record instances
 

--- a/MK3CHOPR/iocBoot/iocMk3CHOPR-IOC-01/st.cmd
+++ b/MK3CHOPR/iocBoot/iocMk3CHOPR-IOC-01/st.cmd
@@ -18,9 +18,7 @@ MK3CHOPR_IOC_01_registerRecordDeviceDriver pdbbase
 < $(IOCSTARTUP)/init.cmd
 
 # Portname, path to config file, use mock (=1 for mock)
-$(IFDEVSIM) epicsEnvSet(useMock, 1)
-$(IFNOTDEVSIM) epicsEnvSet(useMock, 0)
-mk3DriverConfigure("MK3", "C:/LabVIEW Modules/Drivers/ISIS MK3 Disc Chopper/MK3_Chopper.config", $(useMock))
+mk3DriverConfigure("MK3", "C:/LabVIEW Modules/Drivers/ISIS MK3 Disc Chopper/MK3_Chopper.config", $(DEVSIM))
 
 ## Load record instances
 


### PR DESCRIPTION
# Description

The current Mk3 chopper crashes on encountering error code 21. I've increased the buffer size in the IOC to cope with bigger messages. There's a corresponding change in the support module to make the copy safer.

I also edited the startup command to use the MockChopper in DevSim mode to avoid having to choose it manually.

# Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2633

# Acceptance criteria

To get error messages emitted by the Mock Chopper, do the following:

- Change the error-code to something positive in MockChopper.cs. For instance `PutNominalPhaseErrorWindow`
- Change the error message in `ResolveErrorCode` in `MockChopper.cs`
- Build the chopper support module and IOC
- Run the IOC in DevSim mode which, with the IOC PR, will instruct it to use the mock chopper
- Perform the operation you set the error code for (e.g. Change the phase error window)
- Note that the IOC returns the error message you set above

To verify the ticket, I expect the following:

- [x] On `master` change the error code and message to something longer than 50 characters (e.g. the error reported in the ticket). Compile and run the IOC (you'll need to set it to use the mock chopper manually without the PRs). When you do the associated operation, it should cause the IOC to crash.

Repeat the operation with the PRs. The buffer size is now 100 characters:

- [x] The IOC does not crash for an error message of fewer than 100 characters. The full error message is reported.
- [x] The IOC does not crash for an error message of greater than 100 characters. The first 99 characters are reported (100th character reserved for null terminator).

#### Code Review

- [ ] **Pertitent information and a copy of the manual has been stored in the [wiki](IOCs)**
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [x] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Functional Tests

- IOC responds correctly in:
    - [x] Devsim mode
    - [x] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [x] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
