### PR TITLE
FLNK does not cause trigger on I/O intr record

### DIFF
--- a/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
+++ b/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
@@ -93,10 +93,17 @@ record(ao, "$(P)TEMP:SP")
    field(DESC, "Temperature setpoint")
    field(DTYP, "asynFloat64")
    field(OUT, "@asyn($(READ),0,1)TGT")
-   field(FLNK, "$(P)OUT_SP")
+   field(FLNK, "$(P)OUT_SP:TRIG")
    field(EGU, "K")
    info(INTEREST, "HIGH")
    info(archive, "VAL")
+}
+
+# Subtly different than FLNK to an I/O intr record. Needs explicit write or does not trigger
+record(calcout, "$(P)OUT_SP:TRIG") {
+   field(INPA, "1")
+   field(CALC, "A")
+   field(OUT, "$(P)OUT_SP.PROC")
 }
 
 # This set point is read back from the ReadASCII ramp to say where it is ramping to

--- a/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
+++ b/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
@@ -93,17 +93,11 @@ record(ao, "$(P)TEMP:SP")
    field(DESC, "Temperature setpoint")
    field(DTYP, "asynFloat64")
    field(OUT, "@asyn($(READ),0,1)TGT")
-   field(FLNK, "$(P)OUT_SP:TRIG")
+   # I/O intr FLNK won't process until we trigger PROC via CA
+   field(FLNK, "$(P)OUT_SP.PROC CA")
    field(EGU, "K")
    info(INTEREST, "HIGH")
    info(archive, "VAL")
-}
-
-# Subtly different than FLNK to an I/O intr record. Needs explicit write or does not trigger
-record(calcout, "$(P)OUT_SP:TRIG") {
-   field(INPA, "1")
-   field(CALC, "A")
-   field(OUT, "$(P)OUT_SP.PROC")
 }
 
 # This set point is read back from the ReadASCII ramp to say where it is ramping to


### PR DESCRIPTION
### Description of work

When the Eurotherm temperature SP is changed, it should update the device SP:RBV even if the SP hasn't changed. This is most evident if the underlying calibration file has been changed.

The issue arises because using a FLNK on a record with I/O intr doesn't cause it to process. Forward linking directly to the PROC field via channel access avoids the issue

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2683

### Acceptance criteria

- [x] Eurotherm starts
- [x] Can set the Eurotherm setpoint
- [x] Eurotherm ramping behaviour is preserved
- [x] The setpoint readback value updates to the set value on the following workflow
    - Set the temperature SP
    - Change the calibration file, so that the SP:RBV changes
    - Set the temperature SP again to the same value as it currently has
    - The SP:RBV changes to match the SP

---

#### Code Review

- [ ] **Pertitent information and a copy of the manual has been stored in the [wiki](IOCs)**
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Functional Tests

- IOC responds correctly in:
    - [x] Devsim mode
    - [x] Recsim mode
    - [x] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
