### PR TITLE
Ticket2758 ieg negative pressure

### DIFF
--- a/IEG/IEG-IOC-01App/Db/ieg.db
+++ b/IEG/IEG-IOC-01App/Db/ieg.db
@@ -259,26 +259,66 @@ record(ai, "$(P)PRES:RAW")
 
 record(calc, "$(P)PRES:CALC")
 {
+    field(DESC, "Device pressure, as calculated")
+	
     field(ASG, "READONLY")
     field(INPA, "$(P)PRES:RAW CP MS")
     # Default to no calibration if macros not set.
     field(CALC, "A*$(CALIBRATION_A)+$(CALIBRATION_B)")
-}
-
-record(ai, "$(P)PRES")
-{
-    field(DESC, "Device pressure")
-    field(INP, "$(P)PRES:CALC CP MS")
-    field(EGU, "mbar")
     
-    field(LOW, "-0.1")
+    field(LOW, "0")
     field(HIGH, "350")
 	field(LSV, "MAJOR")
 	field(HSV, "MAJOR")
+	
+    field(EGU, "mbar")
+}
+
+record(calc, "$(P)PRES:OUT:CALC") {
+    field(DESC, "Restrict calculated pressure to [0,350] mbar")
+	
+    field(ASG, "READONLY")
+    field(INPA, "$(P)PRES:CALC CP MS")
+    # Default to no calibration if macros not set.
+    field(CALC, "MAX(MIN(INPA,350.0),0.0)")	
+    field(EGU, "mbar")
+}
+
+record(ai, "$(P)PRES:OUT")
+{
+    field(DESC, "Device pressure (restricted [0,350] mbar)")
+    field(INP, "$(P)PRES:OUT:CALC CP MS")
+    field(EGU, "mbar")
     
     info(INTEREST, "HIGH")
     info(archive, "VAL")
     info(alarm, "IEG")
+}
+
+# User requirements are uncertain and subject to change.
+# Use the restricted range pressure as the primary output for now.
+# Aliasing makes it easier to change in future if needed
+# If we're concerned about stability in blocks/scripts, use the
+# unaliased PVs
+alias("$(P)PRES:OUT", "$(P)PRES")
+
+record(scalcout, "$(P)PRES:GUI:NMES")
+{
+	field(DESC, "GUI pressure reading when in range")
+    field(INPA, "$(P)PRES CP")
+    field(CALC, "PRINTF('%.2f mbar',A)")
+}
+
+record(scalcout, "$(P)PRES:GUI:LMES")
+{
+	field(DESC, "GUI pressure reading when le 0")
+    field(CALC, "'<= 0 mbar'")
+}
+
+record(scalcout, "$(P)PRES:GUI:HMES")
+{
+	field(DESC, "GUI pressure reading when gt 350")
+    field(CALC, "'> 350 mbar'")
 }
 
 record(scalcout, "$(P)PRES:GUI")
@@ -289,8 +329,10 @@ record(scalcout, "$(P)PRES:GUI")
     field(ASG, "READONLY")
     field(DESC, "GUI pressure reading")
     field(INPA, "$(P)PRES CP MS")
-    field(CALC, "A>350?'> 350 mbar':PRINTF('%.2f mbar',A)")
-    field(EGU, "")
+	field(INAA, "$(P)PRES:GUI:HMES")
+	field(INBB, "$(P)PRES:GUI:LMES")
+	field(INCC, "$(P)PRES:GUI:NMES")
+    field(CALC, "A>350?AA:(A<=0?BB:CC)")
 }
 
 #

--- a/IEG/IEG-IOC-01App/Db/ieg.db
+++ b/IEG/IEG-IOC-01App/Db/ieg.db
@@ -91,16 +91,16 @@ record(seq, "$(P)STATUS:_FANOUT")
     field(LNK4, "$(P)ERROR PP")
 
     field(DOL5, "$(P)STATUS:_RAW.E")
-    field(LNK5, "$(P)PRES:BUFFER:HIGH PP")
+    field(LNK5, "$(P)PRESSURE:BUFFER:HIGH PP")
     
     field(DOL6, "$(P)STATUS:_RAW.F")
-    field(LNK6, "$(P)PRES:LOW PP")
+    field(LNK6, "$(P)PRESSURE:LOW PP")
     
     field(DOL7, "$(P)STATUS:_RAW.G")
-    field(LNK7, "$(P)PRES:HIGH PP")
+    field(LNK7, "$(P)PRESSURE:HIGH PP")
     
     field(DOL8, "$(P)STATUS:_RAW.H")
-    field(LNK8, "$(P)PRES:RAW PP")
+    field(LNK8, "$(P)PRESSURE:RAW PP")
     
     field(SELM, "All")
 }
@@ -214,7 +214,7 @@ record(mbbi, "$(P)ERROR")
     info(archive, "VAL")
 }
 
-record(bi, "$(P)PRES:BUFFER:HIGH")
+record(bi, "$(P)PRESSURE:BUFFER:HIGH")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")
@@ -226,7 +226,7 @@ record(bi, "$(P)PRES:BUFFER:HIGH")
     info(archive, "VAL")
 }
 
-record(bi, "$(P)PRES:HIGH")
+record(bi, "$(P)PRESSURE:HIGH")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")
@@ -238,7 +238,7 @@ record(bi, "$(P)PRES:HIGH")
     info(archive, "VAL")
 }
 
-record(bi, "$(P)PRES:LOW")
+record(bi, "$(P)PRESSURE:LOW")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")
@@ -250,19 +250,19 @@ record(bi, "$(P)PRES:LOW")
     info(archive, "VAL")
 }
 
-record(ai, "$(P)PRES:RAW")
+record(ai, "$(P)PRESSURE:RAW")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")
     field(DESC, "Device pressure")
 }
 
-record(calc, "$(P)PRES:CALC")
+record(calc, "$(P)PRESSURE:CALC")
 {
     field(DESC, "Device pressure, as calculated")
 	
     field(ASG, "READONLY")
-    field(INPA, "$(P)PRES:RAW CP MS")
+    field(INPA, "$(P)PRESSURE:RAW CP MS")
     # Default to no calibration if macros not set.
     field(CALC, "A*$(CALIBRATION_A)+$(CALIBRATION_B)")
     
@@ -274,20 +274,20 @@ record(calc, "$(P)PRES:CALC")
     field(EGU, "mbar")
 }
 
-record(calc, "$(P)PRES:OUT:CALC") {
+record(calc, "$(P)PRESSURE:OUT:CALC") {
     field(DESC, "Restrict calculated pressure to [0,350] mbar")
 	
     field(ASG, "READONLY")
-    field(INPA, "$(P)PRES:CALC CP MS")
+    field(INPA, "$(P)PRESSURE:CALC CP MS")
     # Default to no calibration if macros not set.
     field(CALC, "MAX(MIN(INPA,350.0),0.0)")	
     field(EGU, "mbar")
 }
 
-record(ai, "$(P)PRES:OUT")
+record(ai, "$(P)PRESSURE:OUT")
 {
     field(DESC, "Device pressure (restricted [0,350] mbar)")
-    field(INP, "$(P)PRES:OUT:CALC CP MS")
+    field(INP, "$(P)PRESSURE:OUT:CALC CP MS")
     field(EGU, "mbar")
     
     info(INTEREST, "HIGH")
@@ -300,28 +300,28 @@ record(ai, "$(P)PRES:OUT")
 # Aliasing makes it easier to change in future if needed
 # If we're concerned about stability in blocks/scripts, use the
 # unaliased PVs
-alias("$(P)PRES:OUT", "$(P)PRES")
+alias("$(P)PRESSURE:OUT", "$(P)PRESSURE")
 
-record(scalcout, "$(P)PRES:GUI:NMES")
+record(scalcout, "$(P)PRESSURE:GUI:NMES")
 {
 	field(DESC, "GUI pressure reading when in range")
-    field(INPA, "$(P)PRES CP")
+    field(INPA, "$(P)PRESSURE CP")
     field(CALC, "PRINTF('%.2f mbar',A)")
 }
 
-record(scalcout, "$(P)PRES:GUI:LMES")
+record(scalcout, "$(P)PRESSURE:GUI:LMES")
 {
 	field(DESC, "GUI pressure reading when le 0")
     field(CALC, "'<= 0 mbar'")
 }
 
-record(scalcout, "$(P)PRES:GUI:HMES")
+record(scalcout, "$(P)PRESSURE:GUI:HMES")
 {
 	field(DESC, "GUI pressure reading when gt 350")
     field(CALC, "'> 350 mbar'")
 }
 
-record(scalcout, "$(P)PRES:GUI")
+record(scalcout, "$(P)PRESSURE:GUI")
 {
     # Format the pressure as '> 350 mbar' if pressure 
     # greater than 350, '<= 0 mbar' if pressure less than
@@ -329,10 +329,10 @@ record(scalcout, "$(P)PRES:GUI")
     # This is for use on the OPI, which looks at the OSV field.
     field(ASG, "READONLY")
     field(DESC, "GUI pressure reading")
-    field(INPA, "$(P)PRES CP MS")
-	field(INAA, "$(P)PRES:GUI:HMES")
-	field(INBB, "$(P)PRES:GUI:LMES")
-	field(INCC, "$(P)PRES:GUI:NMES")
+    field(INPA, "$(P)PRESSURE CP MS")
+	field(INAA, "$(P)PRESSURE:GUI:HMES")
+	field(INBB, "$(P)PRESSURE:GUI:LMES")
+	field(INCC, "$(P)PRESSURE:GUI:NMES")
     field(CALC, "A>350?AA:(A<=0?BB:CC)")
 }
 

--- a/IEG/IEG-IOC-01App/Db/ieg.db
+++ b/IEG/IEG-IOC-01App/Db/ieg.db
@@ -58,7 +58,7 @@ record(mbbo, "$(P)MODE:SP")
     field(SDIS, "$(P)DISABLE")
 }
 
-record(ai, $(P)STATUS:_SCAN)
+record(ai, "$(P)STATUS:_SCAN")
 {
     field(INP, "@devieg.proto getStatus($(P)STATUS:_RAW) $(PORT)")
     field(SCAN, "1 second")
@@ -266,8 +266,9 @@ record(calc, "$(P)PRESSURE:CALC")
     # Default to no calibration if macros not set.
     field(CALC, "A*$(CALIBRATION_A)+$(CALIBRATION_B)")
     
-    field(LOW, "0")
-    field(HIGH, "350")
+	# No alarm for limit up to 3dp
+    field(LOW, "-0.0005")
+    field(HIGH, "350.0005")
 	field(LSV, "MAJOR")
 	field(HSV, "MAJOR")
 	
@@ -275,20 +276,21 @@ record(calc, "$(P)PRESSURE:CALC")
 }
 
 record(calc, "$(P)PRESSURE:OUT:CALC") {
-    field(DESC, "Restrict calculated pressure to [0,350] mbar")
+    field(DESC, "Calculate pressure in range 0-350 mbar")
 	
     field(ASG, "READONLY")
     field(INPA, "$(P)PRESSURE:CALC CP MS")
     # Default to no calibration if macros not set.
-    field(CALC, "MAX(MIN(INPA,350.0),0.0)")	
+    field(CALC, "MAX(MIN(A,350.0),0.0)")	
     field(EGU, "mbar")
 }
 
 record(ai, "$(P)PRESSURE:OUT")
 {
-    field(DESC, "Device pressure (restricted [0,350] mbar)")
+    field(DESC, "Device pressure (0-350 mbar)")
     field(INP, "$(P)PRESSURE:OUT:CALC CP MS")
     field(EGU, "mbar")
+	field(PREC, "2")
     
     info(INTEREST, "HIGH")
     info(archive, "VAL")
@@ -305,20 +307,22 @@ alias("$(P)PRESSURE:OUT", "$(P)PRESSURE")
 record(scalcout, "$(P)PRESSURE:GUI:NMES")
 {
 	field(DESC, "GUI pressure reading when in range")
-    field(INPA, "$(P)PRESSURE CP")
+    field(INPA, "$(P)PRESSURE:OUT CP")
     field(CALC, "PRINTF('%.2f mbar',A)")
 }
 
-record(scalcout, "$(P)PRESSURE:GUI:LMES")
+record(stringout, "$(P)PRESSURE:GUI:LMES")
 {
-	field(DESC, "GUI pressure reading when le 0")
-    field(CALC, "'<= 0 mbar'")
+	field(DESC, "GUI pressure reading when lt 0")
+    field(VAL, "<0 mbar")
+	field(PINI, "YES")
 }
 
-record(scalcout, "$(P)PRESSURE:GUI:HMES")
+record(stringout, "$(P)PRESSURE:GUI:HMES")
 {
 	field(DESC, "GUI pressure reading when gt 350")
-    field(CALC, "'> 350 mbar'")
+    field(VAL, ">350 mbar")
+	field(PINI, "YES")
 }
 
 record(scalcout, "$(P)PRESSURE:GUI")
@@ -329,11 +333,11 @@ record(scalcout, "$(P)PRESSURE:GUI")
     # This is for use on the OPI, which looks at the OSV field.
     field(ASG, "READONLY")
     field(DESC, "GUI pressure reading")
-    field(INPA, "$(P)PRESSURE CP MS")
+    field(INPA, "$(P)PRESSURE:CALC CP MS")
 	field(INAA, "$(P)PRESSURE:GUI:HMES")
 	field(INBB, "$(P)PRESSURE:GUI:LMES")
-	field(INCC, "$(P)PRESSURE:GUI:NMES")
-    field(CALC, "A>350?AA:(A<=0?BB:CC)")
+	field(INCC, "$(P)PRESSURE:GUI:NMES.OSV CP")
+    field(CALC, "A>350?AA:(A<0?BB:CC)")
 }
 
 #

--- a/IEG/IEG-IOC-01App/Db/ieg.db
+++ b/IEG/IEG-IOC-01App/Db/ieg.db
@@ -91,16 +91,16 @@ record(seq, "$(P)STATUS:_FANOUT")
     field(LNK4, "$(P)ERROR PP")
 
     field(DOL5, "$(P)STATUS:_RAW.E")
-    field(LNK5, "$(P)PRESSURE:BUFFER:HIGH PP")
+    field(LNK5, "$(P)PRES:BUFFER:HIGH PP")
     
     field(DOL6, "$(P)STATUS:_RAW.F")
-    field(LNK6, "$(P)PRESSURE:LOW PP")
+    field(LNK6, "$(P)PRES:LOW PP")
     
     field(DOL7, "$(P)STATUS:_RAW.G")
-    field(LNK7, "$(P)PRESSURE:HIGH PP")
+    field(LNK7, "$(P)PRES:HIGH PP")
     
     field(DOL8, "$(P)STATUS:_RAW.H")
-    field(LNK8, "$(P)PRESSURE:RAW PP")
+    field(LNK8, "$(P)PRES:RAW PP")
     
     field(SELM, "All")
 }
@@ -214,7 +214,7 @@ record(mbbi, "$(P)ERROR")
     info(archive, "VAL")
 }
 
-record(bi, "$(P)PRESSURE:BUFFER:HIGH")
+record(bi, "$(P)PRES:BUFFER:HIGH")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")
@@ -226,7 +226,7 @@ record(bi, "$(P)PRESSURE:BUFFER:HIGH")
     info(archive, "VAL")
 }
 
-record(bi, "$(P)PRESSURE:HIGH")
+record(bi, "$(P)PRES:HIGH")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")
@@ -238,7 +238,7 @@ record(bi, "$(P)PRESSURE:HIGH")
     info(archive, "VAL")
 }
 
-record(bi, "$(P)PRESSURE:LOW")
+record(bi, "$(P)PRES:LOW")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")
@@ -250,25 +250,25 @@ record(bi, "$(P)PRESSURE:LOW")
     info(archive, "VAL")
 }
 
-record(ai, "$(P)PRESSURE:RAW")
+record(ai, "$(P)PRES:RAW")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")
     field(DESC, "Device pressure")
 }
 
-record(calc, "$(P)PRESSURE:CALC")
+record(calc, "$(P)PRES:CALC")
 {
     field(ASG, "READONLY")
-    field(INPA, "$(P)PRESSURE:RAW CP MS")
+    field(INPA, "$(P)PRES:RAW CP MS")
     # Default to no calibration if macros not set.
     field(CALC, "A*$(CALIBRATION_A)+$(CALIBRATION_B)")
 }
 
-record(ai, "$(P)PRESSURE")
+record(ai, "$(P)PRES")
 {
     field(DESC, "Device pressure")
-    field(INP, "$(P)PRESSURE:CALC CP MS")
+    field(INP, "$(P)PRES:CALC CP MS")
     field(EGU, "mbar")
     
     field(LOW, "-0.1")
@@ -281,14 +281,14 @@ record(ai, "$(P)PRESSURE")
     info(alarm, "IEG")
 }
 
-record(scalcout, "$(P)PRESSURE:GUI")
+record(scalcout, "$(P)PRES:GUI")
 {
     # Format the pressure as '> 350' if pressure 
     # greater than 350 else format to 2 d.p 
     # This is for use on the OPI, which looks at the OSV field.
     field(ASG, "READONLY")
     field(DESC, "GUI pressure reading")
-    field(INPA, "$(P)PRESSURE CP MS")
+    field(INPA, "$(P)PRES CP MS")
     field(CALC, "A>350?'> 350 mbar':PRINTF('%.2f mbar',A)")
     field(EGU, "")
 }

--- a/IEG/IEG-IOC-01App/Db/ieg.db
+++ b/IEG/IEG-IOC-01App/Db/ieg.db
@@ -323,8 +323,9 @@ record(scalcout, "$(P)PRES:GUI:HMES")
 
 record(scalcout, "$(P)PRES:GUI")
 {
-    # Format the pressure as '> 350' if pressure 
-    # greater than 350 else format to 2 d.p 
+    # Format the pressure as '> 350 mbar' if pressure 
+    # greater than 350, '<= 0 mbar' if pressure less than
+    # or equal to 0 else format to 2 d.p.
     # This is for use on the OPI, which looks at the OSV field.
     field(ASG, "READONLY")
     field(DESC, "GUI pressure reading")


### PR DESCRIPTION
### Description of work

As per ticket:

- ~~Rename existing PVs from `PRESSURE` to `PRES` in line with IBEX standards~~
    - My bad, `PRESSURE` is IBEX standard. Confusing because temperature is `TEMP`
- ~~Have a `PRES:RAW` PV with the true calculated value~~
    - `PRESSURE:RAW` already exists. There are now 2 PVs, `PRESSURE:OUT` and `PRESSURE:CALC`. `PRESSURE:OUT` is limited to 0-350 mbar where as `PRESSURE:CALC` is the calculated pressure. I have aliased `PRESSURE` to `PRESSURE:OUT` so that if you want a block that just reports 0-350, you can use the vanilla `PRESSURE` PV.
- `PRES` to be limited to 0-350 mbar with suitable alarms
- `PRES` GUI to have a similar message to "> 350mbar" message for negative pressures
- Adjust labels on GUI
- Remove sample bin pressure from GUI ~~and IOC~~
    - Sample bin pressure from TPG26X IOC
- Adjust Iris configurations to match change to PV names

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2758

### Acceptance criteria

Changes to the IEG pressure have to be made via the Lewis backdoor so you'll need a device emulator running.

- PV exists containing sample pressure in full float range
- PV exists containing sample pressure in range [0,350]
    - Value is the same as previous PV when in range
- All high interest pressure PVs enter an alarm state when value outside of range [0,350]
- The GUI displays the pressure value to 2dp when in range [0,350]
- The GUI displays a suitable message for pressures outside of this range
- The labels on the GUI match the description provided by Matt North (see ticket)
- The Sample bin pressure has been removed from the GUI
- No config changes were needed as `PRESSURE` is the block value they're using and this has been set to alias the [0,350] mbar restricted PV.

---

#### Code Review

- [ ] **Pertitent information and a copy of the manual has been stored in the [wiki](IOCs)**
- [x] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [x] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [x] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Functional Tests

- IOC responds correctly in:
    - [x] Devsim mode
    - [x] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
