### PR TITLE
Fix eurotherm

### DIFF
--- a/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
+++ b/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
@@ -265,8 +265,6 @@ record(calcout, "$(P)RAMPON:RETRIEVE")
    field(INPA, "$(P)RAMPON:CACHE")
    field(CALC, "A")
    field(OUT, "$(P)RAMPON:SP PP")
-   field(ZNAM, "OFF")
-   field(ONAM, "ON")
 }
 
 record(calcout, "$(P)SENSOR_DISCONNECTED")

--- a/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
+++ b/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
@@ -233,14 +233,14 @@ record(ai, "$(P)OUT_MAX")
 
 record(ai, "$(P)NO_SENSOR_VALUE")
 {
-    field(DESC, "The temperature constant indicating a disconnected sensor")
+    field(DESC, "Indicates disconnected sensor")
     field(VAL, 1529)
 }
 
 
 record(calcout, "$(P)SENSOR_CONNECTED")
 {
-   field(DESC, "Check whether the temperature sensor is reconnected")
+   field(DESC, "Check if temp sensor reconnected")
    field(INPA, "$(P)RBV CP")
    field(INPB, "$(P)NO_SENSOR_VALUE")
    field(CALC, "A = B")
@@ -260,7 +260,7 @@ record(bo, "$(P)RAMPON:ENABLE")
 record(calcout, "$(P)RAMPON:RETRIEVE")
 {
    # As calcout to add delay
-   field(DESC, "Retrieves and sets the cached Ramp setting")
+   field(DESC, "Retrieve and set ramp setting")
    field(ODLY, "1")
    field(INPA, "$(P)RAMPON:CACHE")
    field(CALC, "A")
@@ -271,7 +271,7 @@ record(calcout, "$(P)RAMPON:RETRIEVE")
 
 record(calcout, "$(P)SENSOR_DISCONNECTED")
 {
-   field(DESC, "Check whether the temperature sensor is disconnected")
+   field(DESC, "Check temp sensor is disconnected")
    field(INPA, "$(P)RBV CP")
    field(INPB, "$(P)NO_SENSOR_VALUE")
    field(CALC, "A = B")
@@ -658,6 +658,7 @@ record(ai, "$(P)AUTOTUNE") {
     field(SIML, "$(Q)SIM")
     field(SIOL, "$(P)SIM:AUTOTUNE")
     field(SDIS, "$(Q)DISABLE")
+	field(EGU, "")
 }
 
 record(ao, "$(P)AUTOTUNE:SP") {
@@ -668,6 +669,7 @@ record(ao, "$(P)AUTOTUNE:SP") {
     field(SIOL, "$(P)SIM:AUTOTUNE:SP")
     field(SDIS, "$(Q)DISABLE")
 	field(FLNK, "$(P)AUTOTUNE.PROC")
+	field(EGU, "")
 }
 
 alias("$(P)AUTOTUNE", "$(P)AUTOTUNE:SP:RBV")


### PR DESCRIPTION
### Description of work

Fixes syntax errors in eurotherm

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2816

### Acceptance criteria

Eurotherm no longer errors

---

#### Code Review

- [ ] **Pertitent information and a copy of the manual has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)**
- [x] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Functional Tests

- IOC responds correctly in:
    - [x] Devsim mode
    - [x] Recsim mode
    - [ ] Real device, if available
- [x] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [x] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
