### PR TITLE
Ticket2760: Add config arg for resetting after each move

### DIFF
--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/st-common.cmd
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/st-common.cmd
@@ -41,7 +41,7 @@ $(IFNOTSIM) PM304Setup(1,5)
 < st-homing.cmd
 
 # PM304Config(card being configured, asyn port name,  number of axes)
-$(IFNOTSIM) PM304Config(0, "$(ASERIAL)", "$(NAXES=1)", "$(COMBINED_HOMING_MODES=0)")
+$(IFNOTSIM) PM304Config(0, "$(ASERIAL)", "$(NAXES=1)", "$(COMBINED_HOMING_MODES=0)", 1)
 
 iocshCmdLoop("< st-axes.cmd", "MN=\$(I)", "I", 1, 8)
 

--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/st-common.cmd
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/st-common.cmd
@@ -41,7 +41,7 @@ $(IFNOTSIM) PM304Setup(1,5)
 < st-homing.cmd
 
 # PM304Config(card being configured, asyn port name,  number of axes)
-$(IFNOTSIM) PM304Config(0, "$(ASERIAL)", "$(NAXES=1)", "$(COMBINED_HOMING_MODES=0)", 1)
+$(IFNOTSIM) PM304Config(0, "$(ASERIAL)", "$(NAXES=1)", "$(COMBINED_HOMING_MODES=0)")
 
 iocshCmdLoop("< st-axes.cmd", "MN=\$(I)", "I", 1, 8)
 


### PR DESCRIPTION
### Description of work

I've added an argument to PM304Config so that, if set, it sends a reset command before every move. I haven't at the moment made it configurable via a macro because I don't think we will often want to override the default. If we do, perhaps it's the wrong solution.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2760

### Acceptance criteria

- [x] When PM304Config final arg set to 1, reset command is sent on every move
- [ ] When PM304Config final arg set to anything else, reset command is not sent on every move

---

#### Code Review

- [ ] **Pertitent information and a copy of the manual has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)**
- [x] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [x] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [x] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
