### PR TITLE
Added simulation support to no avail

### DIFF
--- a/SKFCHOPPER/iocBoot/iocSKFCHOPPER-IOC-01/st-common.cmd
+++ b/SKFCHOPPER/iocBoot/iocSKFCHOPPER-IOC-01/st-common.cmd
@@ -1,20 +1,21 @@
 ##ISIS## Run IOC initialisation 
 < $(IOCSTARTUP)/init.cmd
 
+## For real device use:
+$(IFNOTRECSIM) drvAsynIPPortConfigure("$(CHOP)","$(IPADDR):$(IPPORT=502)",0,0,1)
+
 #drvAsynIPPortConfigure(const char *portName,
 #                       const char *hostInfo,
 #                       unsigned int priority,
 #                       int noAutoConnect,
 #                       int noProcessEos);
 
-drvAsynIPPortConfigure("$(CHOP)","$(IPADDR):$(IPPORT=502)",0,0,1)
-
 # link type is 0 for tcp, 1 for RTU. 2 for ASCII
 #modbusInterposeConfig(const char *portName,
 #                      modbusLinkType linkType,
 #                      int timeoutMsec, 
 #                      int writeDelayMsec)
-modbusInterposeConfig("$(CHOP)",0,5000,0)
+$(IFNOTRECSIM) modbusInterposeConfig("$(CHOP)",0,5000,0)
 
 # load modbus definitions for use by SKFChopper.db, this used $(CHOP)
 < $(SKFCHOPPER)/data/SKFChopper.cmd
@@ -25,7 +26,7 @@ modbusInterposeConfig("$(CHOP)",0,5000,0)
 < $(IOCSTARTUP)/dbload.cmd
 
 ## Load our record instances
-dbLoadRecords("$(SKFCHOPPER)/db/SKFChopper.db","P=$(MYPVPREFIX)$(IOCNAME):,CHOP=$(CHOP),NAME=$(NAME),OPEN=$(OPEN),CLOSED=$(CLOSED)")
+dbLoadRecords("$(SKFCHOPPER)/db/SKFChopper.db","P=$(MYPVPREFIX)$(IOCNAME):,CHOP=$(CHOP),NAME=$(NAME),OPEN=$(OPEN),CLOSED=$(CLOSED),RECSIM=$(RECSIM)")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd


### PR DESCRIPTION
### Description of work

Modified st-common.cmd to include option for IOC to run in simulation mode.  However, this is currently incompatible with Asyn.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2567

---

#### Code Review

- [ ] **Pertitent information and a copy of the manual has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)**
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
