### PR TITLE
Ticket2760 send mc lennan reset on move

### DIFF
--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/st-motor.cmd
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/st-motor.cmd
@@ -4,6 +4,12 @@ epicsEnvSet("AMOTORPV", "MOT:$(AMOTORNAME)")
 
 ## Load record instances
 
+## Initialise control mode. Defaults to CM14, closed
+$(IFNOTSIM) asynOctetConnect("MKINIT","$(ASERIAL)")
+$(IFNOTSIM) $(IFCMOPEN) asynOctetWrite("MKINIT","$(MN)CM11")
+$(IFNOTSIM) $(IFNOTCMOPEN) asynOctetWrite("MKINIT","$(MN)CM14")
+$(IFNOTSIM) asynOctetWrite("MKINIT","$(MN)ER$(ERES$(MN)=400/4096)")
+
 # Set motor specific initial conditions
 epicsEnvSet("EGUI",$(UNIT$(MN)="mm"))
 epicsEnvSet("VELOI",$(VELO$(MN)=1))

--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/st.cmd
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/st.cmd
@@ -13,6 +13,6 @@ dbLoadDatabase "$(TOP)/dbd/MCLEN-IOC-01.dbd"
 MCLEN_IOC_01_registerRecordDeviceDriver pdbbase
 
 # enable debugging
-var drvPM304Debug 5
+var drvPM304Debug 2
 
 < st-common.cmd


### PR DESCRIPTION
### Description of work

I've set the default output debug level so that not all commands are written to the log. This is more typical of other motors. The current level also ensures that resets (that aren't ignored) do appear in the log where as other commands don't which make them easier to spot.

I've also reinstated the code that sets the motor to closed mode and sets the encoder ratio. I'm surprised its removal hasn't been spotted until now. It's removal seems to have been accidental given the commit history

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2760

### Acceptance criteria

- [x] No alarm triggered or additional log messages generated under normal operation
- [x] Device goes into an alarm state when a reset is requested that triggers an action
- [x] The response to reset commands is stored in the IOC logs

Notably with the reintroduction of the encoder ratio, if you set it to something like -1/1 (remember ERES**3** for the G39 motor) it can easily be put into a tracking abort move just by moving it with this setting.

---

#### Code Review

- [ ] **Pertitent information and a copy of the manual has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)**
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [x] ~Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?~
     - Done on original pass through ticket

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] ~Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section~
    - Already moved during original run through ticket
