### PR TITLE
Add separate level logic

### DIFF
--- a/MERCURY_ITC/MERCURY-IOC-01App/Db/Makefile
+++ b/MERCURY_ITC/MERCURY-IOC-01App/Db/Makefile
@@ -12,6 +12,7 @@ include $(TOP)/configure/CONFIG
 # databases, templates, substitutions like this
 #DB += xxx.db
 DB += $(MERCURY_ITC)/db/MercuryTemp.db
+DB += $(MERCURY_ITC)/db/MercuryLevel.db
 DB += $(MERCURY_ITC)/db/MercuryGlobal.db
 
 #----------------------------------------------------

--- a/MERCURY_ITC/iocBoot/iocMERCURY-IOC-01/config.xml
+++ b/MERCURY_ITC/iocBoot/iocMERCURY-IOC-01/config.xml
@@ -8,6 +8,8 @@
 <macro name="VI_TEMP_2" pattern="^[A-Z0-9]+$" description="Suffix of the vi temperature panel, usually '2' or blank for no controller." />
 <macro name="VI_TEMP_3" pattern="^[A-Z0-9]+$" description="Suffix of the vi temperature panel, usually '3' or blank for no controller." />
 <macro name="VI_TEMP_4" pattern="^[A-Z0-9]+$" description="Suffix of the vi temperature panel, usually '4' or blank for no controller." />
+<macro name="VI_LEVEL_1" pattern="^[A-Z0-9]+$" description="Suffix of the vi level panel, usually '1' or blank for no controller." />
+<macro name="VI_LEVEL_2" pattern="^[A-Z0-9]+$" description="Suffix of the vi level panel, usually '2' or blank for no controller." />
 </macros>
 </config_part>
 </ioc_config>

--- a/MERCURY_ITC/iocBoot/iocMERCURY-IOC-01/st.cmd
+++ b/MERCURY_ITC/iocBoot/iocMERCURY-IOC-01/st.cmd
@@ -54,7 +54,7 @@ epicsEnvSet(LEVEL_NUM,1)
 epicsEnvSet(LEVEL_NUM,2)
 < $(MERCURY_ITC)/iocBoot/iocMercuryiTC/st-level.cmd
 
-dbLoadRecords("db/MercuryGlobal.db", "P=$(MYPVPREFIX)$(IOCNAME):, SIM1=$(SIM1), SIM2=$(SIM2), SIM3=$(SIM3), SIM4=$(SIM4), DISABLE1=$(DISABLE1), DISABLE2=$(DISABLE2), DISABLE3=$(DISABLE3), DISABLE4=$(DISABLE4)")
+dbLoadRecords("db/MercuryGlobal.db", "P=$(MYPVPREFIX)$(IOCNAME):, SIM1=$(SIM1), SIM2=$(SIM2), SIM3=$(SIM3), SIM4=$(SIM4), SIM5=$(SIM5), SIM6=$(SIM6), DISABLE1=$(DISABLE1), DISABLE2=$(DISABLE2), DISABLE3=$(DISABLE3), DISABLE4=$(DISABLE4), DISABLE5=$(DISABLE5), DISABLE6=$(DISABLE6)")
 
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 

--- a/MERCURY_ITC/iocBoot/iocMERCURY-IOC-01/st.cmd
+++ b/MERCURY_ITC/iocBoot/iocMERCURY-IOC-01/st.cmd
@@ -27,10 +27,14 @@ epicsEnvSet(SIM1, " ")
 epicsEnvSet(SIM2, " ")
 epicsEnvSet(SIM3, " ")
 epicsEnvSet(SIM4, " ")
+epicsEnvSet(SIM5, " ")
+epicsEnvSet(SIM6, " ")
 epicsEnvSet(DISABLE1, " ")
 epicsEnvSet(DISABLE2, " ")
 epicsEnvSet(DISABLE3, " ")
 epicsEnvSet(DISABLE4, " ")
+epicsEnvSet(DISABLE5, " ")
+epicsEnvSet(DISABLE6, " ")
 
 epicsEnvSet(TEMP_NUM,1)
 < $(MERCURY_ITC)/iocBoot/iocMercuryiTC/st-temp.cmd
@@ -43,6 +47,12 @@ epicsEnvSet(TEMP_NUM,3)
 
 epicsEnvSet(TEMP_NUM,4)
 < $(MERCURY_ITC)/iocBoot/iocMercuryiTC/st-temp.cmd
+
+epicsEnvSet(LEVEL_NUM,1)
+< $(MERCURY_ITC)/iocBoot/iocMercuryiTC/st-level.cmd
+
+epicsEnvSet(LEVEL_NUM,2)
+< $(MERCURY_ITC)/iocBoot/iocMercuryiTC/st-level.cmd
 
 dbLoadRecords("db/MercuryGlobal.db", "P=$(MYPVPREFIX)$(IOCNAME):, SIM1=$(SIM1), SIM2=$(SIM2), SIM3=$(SIM3), SIM4=$(SIM4), DISABLE1=$(DISABLE1), DISABLE2=$(DISABLE2), DISABLE3=$(DISABLE3), DISABLE4=$(DISABLE4)")
 


### PR DESCRIPTION
### Description of work

Add PVs for Mercury iTC gas levels

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2840

### Acceptance criteria

- PVs exist that match those in the GEM configs
    - [Mercury blocks.txt](https://github.com/ISISComputingGroup/EPICS-ioc/files/1647224/Mercury.blocks.txt)
- IOC communicates effectively with the OPI

---

#### Code Review

- [ ] **Pertitent information and a copy of the manual has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)**
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [x] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [x] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Functional Tests

- IOC responds correctly in:
    - [x] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
