### PR TITLE
More general error handling

### DIFF
--- a/MK3CHOPR/MK3CHOPR-IOC-01App/src/mk3Driver.cpp
+++ b/MK3CHOPR/MK3CHOPR-IOC-01App/src/mk3Driver.cpp
@@ -367,10 +367,10 @@ void mk3Driver::checkErrorCode(int code)
         m_interface->checkErrorCode(code, answer, BUFFER_SIZE);
         errlogSevPrintf(errlogMajor, "%s", answer);
         
-        // If .net timeout try to re-intialise
-        if (code == -3)
+        // If "Chopper connection not initialised", ".net timeout" or "Unknown .NET error" try to re-intialise
+        if (code == -1 || code == -3 || code == -4)
         {
-            errlogSevPrintf(errlogMajor, "%s","Trying to re-establish .NET connection");
+            errlogSevPrintf(errlogMajor, "%s","Trying to re-establish connection");
             m_interface->initialise();
         }
     }


### PR DESCRIPTION
### Description of work

Reinitialize the chopper under more conditions.

This fixes a bug that was seen on IRIS where, if the `initialize()` call fails once after a .NET timeout, the IOC will never try to reconnect again.

Similar issues appear to have occurred in the past on other beamlines, see for example `hrpd\Instrument\var\logs\ioc\MK3CHOPR_01-20171120.log` (I don't think they reported that to us at the time) so this is not a new/recent failure.

I'm not sure how we can test this without a chopper as it needs to be connected to an actual chopper to cause the error.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2943

### Acceptance criteria

- [ ] Error in the original ticket would cause new code to attempt to reinitialize

---

#### Code Review

- [ ] **Pertitent information and a copy of the manual has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)**
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
