### PR TITLE
Ticket2831: Galil checks for incorrectly specified macro before autosaving

### DIFF
--- a/GALIL/iocBoot/iocGALIL-IOC-01/st-common.cmd
+++ b/GALIL/iocBoot/iocGALIL-IOC-01/st-common.cmd
@@ -78,7 +78,7 @@ motorUtilInit("$(MYPVPREFIX)$(IOCNAME):")
 < $(IOCSTARTUP)/postiocinit.cmd
 
 stringiftest("HASMTRCTRL", "$(MTRCTRL=)", 0, 0)
-$(IFNOTHASMTRCTRL) errlogSev("MTRCTRL has not been set", 2)
+$(IFNOTHASMTRCTRL) errlogSev(2, "MTRCTRL has not been set")
 
 # Save motor positions every 5 seconds
 $(IFHASMTRCTRL) $(IFNOTSIM) create_monitor_set("$(IOCNAME)_positions.req", 5, "P=$(MYPVPREFIX)MOT:,CCP=$(MTRCTRL)")

--- a/GALIL/iocBoot/iocGALIL-IOC-01/st-common.cmd
+++ b/GALIL/iocBoot/iocGALIL-IOC-01/st-common.cmd
@@ -19,7 +19,7 @@ set_requestfile_path("${MOTOR}/motorApp/Db", "")
 set_requestfile_path("${TOP}/iocBoot/iocGALIL-IOC-01", "")
 
 # Make sure controller number is 2 digits long
-calc("MTRCTRL", "$(MTRCTRL=01)", 2, 2)
+calc("MTRCTRL", "$(MTRCTRL)", 2, 2)
 
 epicsEnvSet("GALILCONFIG","$(ICPCONFIGROOT)/galil")
 
@@ -77,11 +77,14 @@ motorUtilInit("$(MYPVPREFIX)$(IOCNAME):")
 ##ISIS## Stuff that needs to be done after iocInit is called e.g. sequence programs 
 < $(IOCSTARTUP)/postiocinit.cmd
 
+stringiftest("HASMTRCTRL", "$(MTRCTRL=)", 0, 0)
+$(IFNOTHASMTRCTRL) errlogSev("MTRCTRL has not been set", 2)
+
 # Save motor positions every 5 seconds
-$(IFNOTTESTDEVSIM) create_monitor_set("$(IOCNAME)_positions.req", 5, "P=$(MYPVPREFIX)MOT:,CCP=$(MTRCTRL)")
+$(IFHASMTRCTRL) $(IFNOTSIM) create_monitor_set("$(IOCNAME)_positions.req", 5, "P=$(MYPVPREFIX)MOT:,CCP=$(MTRCTRL)")
 
 # Save motor settings every 30 seconds
-$(IFNOTTESTDEVSIM) create_monitor_set("$(IOCNAME)_settings.req", 30, "P=$(MYPVPREFIX)MOT:,CCP=$(MTRCTRL)")
+$(IFHASMTRCTRL) $(IFNOTSIM) create_monitor_set("$(IOCNAME)_settings.req", 30, "P=$(MYPVPREFIX)MOT:,CCP=$(MTRCTRL)")
 
 ## Start any sequence programs
 #seq sncxxx,"user=icsHost"


### PR DESCRIPTION
### To test

See https://github.com/ISISComputingGroup/IBEX/issues/2831

---

#### Code Review

- [ ] **Pertitent information and a copy of the manual has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)**
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
