### PR TITLE
Ticket2887 display raw field readings

### DIFF
--- a/LKSH460/LKSH460-IOC-01App/Db/lakeshore460.db
+++ b/LKSH460/LKSH460-IOC-01App/Db/lakeshore460.db
@@ -98,9 +98,7 @@ record(mbbo, "$(P)CHANNEL:SP")
     field(SIOL, "$(P)SIM:CHANNEL:SP")	
 }
 
-
 ### SIMULATION RECORDS ###
-
 
 record(stringin, "$(P)SIM:IDN")
 {
@@ -131,4 +129,3 @@ record(bi, "$(P)SIM:UNIT")
 }
 
 alias("$(P)SIM:UNIT","$(P)SIM:UNIT:SP")
-

--- a/LKSH460/LKSH460-IOC-01App/Db/lakeshore460.db
+++ b/LKSH460/LKSH460-IOC-01App/Db/lakeshore460.db
@@ -27,36 +27,11 @@ record(stringin, "$(P)IDN")
     field(PINI, "YES")
 }
 
-record(mbbi, "$(P)UNIT") 
-{
-    field(DESC, "Unit in use - gauss or tesla")
-    field(DTYP, "stream")
-	field(SCAN, "2 second")
-    field(INP,  "@devLakeshore_460.proto getFieldUnits $(PORT)")
-    field(ZRST, "G")
-    field(ONST, "T")	
-    info(INTEREST, "MEDIUM")
-	field(FLNK, "$(P)SOURCE")
-	field(SIML, "$(P)SIM")
-    field(SIOL, "$(P)SIM:UNIT")
-}
-
-record(mbbo, "$(P)UNIT:SP") 
-{
-    field(DESC, "Set Unit, gauss or tesla")
-    field(DTYP, "stream")
-    field(OUT,  "@devLakeshore_460.proto setFieldUnits $(PORT)")
-    field(ZRST, "G")
-    field(ONST, "T")	
-    info(INTEREST, "LOW")
-	field(SIML, "$(P)SIM")
-    field(SIOL, "$(P)SIM:UNIT:SP")
-}
-
 record(mbbi, "$(P)SOURCE")
 {
 	field(DESC, "Vector magnitude source")
 	field(DTYP, "stream")
+	field(SCAN, "2 second")
 	field(INP,  "@devLakeshore_460.proto getSource $(PORT)")
 	field(ONST, "XYZ")
 	field(TWST, "XY")

--- a/LKSH460/LKSH460-IOC-01App/Db/lakeshore460.db
+++ b/LKSH460/LKSH460-IOC-01App/Db/lakeshore460.db
@@ -45,7 +45,7 @@ record(mbbi, "$(P)SOURCE")
 	field(FVVL, "5")
 	info(INTEREST, "HIGH")
 	info(ARCHIVE, "VAL")
-	field(FLNK, "$(P)CHANNEL")
+	field(FLNK, "$(P)UNIT")
 	field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:SOURCE")
 }
@@ -68,6 +68,31 @@ record(mbbo, "$(P)SOURCE:SP")
 	info(INTEREST, "LOW")
 	field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:SOURCE:SP")
+}
+
+record(mbbi, "$(P)UNIT") 
+{
+    field(DESC, "Unit in use - gauss or tesla")
+    field(DTYP, "stream")
+    field(INP,  "@devLakeshore_460.proto getFieldUnits $(PORT)")
+    field(ZRST, "G")
+    field(ONST, "T")	
+    info(INTEREST, "MEDIUM")
+	field(FLNK, "$(P)CHANNEL")
+	field(SIML, "$(P)SIM")
+    field(SIOL, "$(P)SIM:UNIT")
+}
+
+record(mbbo, "$(P)UNIT:SP") 
+{
+    field(DESC, "Set Unit, gauss or tesla")
+    field(DTYP, "stream")
+    field(OUT,  "@devLakeshore_460.proto setFieldUnits $(PORT)")
+    field(ZRST, "G")
+    field(ONST, "T")	
+    info(INTEREST, "LOW")
+	field(SIML, "$(P)SIM")
+    field(SIOL, "$(P)SIM:UNIT:SP")
 }
 
 record(mbbi, "$(P)CHANNEL")

--- a/LKSH460/LKSH460-IOC-01App/Db/lakeshore460_channels.template
+++ b/LKSH460/LKSH460-IOC-01App/Db/lakeshore460_channels.template
@@ -9,10 +9,71 @@ record(ai, "$(P)$(CHANNEL):FIELD:RAW")
 	info(INTEREST, "HIGH")
 	info(ARCHIVE, "VAL")
 	info(ARCHIVE, "EGU")
-	field(FLNK, "$(P)$(CHANNEL):UNIT:MULT")
+	field(PREC, "4")
+	field(FLNK, "$(P)UNIT")
 	field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:$(CHANNEL):FIELD:RAW")
     field(SDIS, "$(P)DISABLE")
+}
+
+record(mbbi, "$(P)UNIT") 
+{
+    field(DESC, "Unit in use - gauss or tesla")
+    field(DTYP, "stream")
+
+    field(INP,  "@devLakeshore_460.proto getFieldUnits $(PORT)")
+    field(ZRST, "G")
+    field(ONST, "T")	
+    info(INTEREST, "MEDIUM")
+	field(FLNK, "$(P)$(CHANNEL):MAXREADING")
+	field(SIML, "$(P)SIM")
+    field(SIOL, "$(P)SIM:UNIT")
+}
+
+record(mbbo, "$(P)UNIT:SP") 
+{
+    field(DESC, "Set Unit, gauss or tesla")
+    field(DTYP, "stream")
+    field(OUT,  "@devLakeshore_460.proto setFieldUnits $(PORT)")
+    field(ZRST, "G")
+    field(ONST, "T")	
+    info(INTEREST, "LOW")
+	field(SIML, "$(P)SIM")
+    field(SIOL, "$(P)SIM:UNIT:SP")
+}
+
+record(ai, "$(P)$(CHANNEL):MAXREADING")
+{
+	field(DESC, "Max reading")
+	field(DTYP, "stream")
+	#field(SCAN, "2 second")
+	field(INP, "@devLakeshore_460.proto getMaxReading($(CHANNEL)) $(PORT)")    
+	info(INTEREST, "HIGH")
+	info(ARCHIVE, "VAL")
+	field(PREC, "4")
+	field(EGU, "")
+    field(SIML, "$(P)SIM")
+    field(SIOL, "$(P)SIM:$(CHANNEL):MAXREADING")
+    field(SDIS, "$(P)DISABLE")
+	field(FLNK, "$(P)$(CHANNEL):RELMODEREADING")
+
+}
+
+record(ai, "$(P)$(CHANNEL):RELMODEREADING")
+{
+	field(DESC, "Relative Mode Reading")
+	#field(SCAN, "2 second")
+	field(DTYP, "stream")
+	field(INP, "@devLakeshore_460.proto getRelModeReading($(CHANNEL)) $(PORT)")    
+	info(INTEREST, "HIGH")
+	info(ARCHIVE, "VAL")
+	field(PREC, "4")
+	field(EGU, "")
+    field(SIML, "$(P)SIM")
+    field(SIOL, "$(P)SIM:$(CHANNEL):RELMODEREADING")
+    field(SDIS, "$(P)DISABLE")
+	field(FLNK, "$(P)$(CHANNEL):UNIT:MULT")
+
 }
 
 record(mbbi, "$(P)$(CHANNEL):UNIT:MULT")
@@ -45,7 +106,7 @@ record(fanout, "$(P)$(CHANNEL):CALC:FAN")
 	field(DESC, "Trigger all readback calculations")
 	field(LNK1, "$(P)$(CHANNEL):FIELD:CALC:GAUSS.PROC")
 	field(LNK2, "$(P)$(CHANNEL):FIELD:CALC:TESLA.PROC")
-	field(LNK3, "$(P)$(CHANNEL):UNIT:CALC.PROC")
+	field(LNK3, "$(P)$(CHANNEL):FIELD:UNIT:CALC.PROC")
 	info(INTEREST, "LOW")	
 }
 
@@ -53,99 +114,45 @@ record(calcout, "$(P)$(CHANNEL):FIELD:CALC:GAUSS")
 {
 	field(DESC, "Calculating gauss with multiplier")
 	field(INPA, "$(P)$(CHANNEL):FIELD:RAW")
-	field(INPB, "$(P)$(CHANNEL):UNIT")
+	field(INPB, "$(P)UNIT")
 	field(INPC, "$(P)$(CHANNEL):CALC:MULT")
-	#field(CALC, "B=0?A*C:A*C*10EXP4")
-	field(CALC, "B=0?A*C:A*C*10")
-	field(OUT, "$(P)$(CHANNEL):FIELD:GAUSS")
+	field(CALC, "B=0?A*C:A*C*10000")
+	field(OUT, "$(P)$(CHANNEL):FIELD:GAUSS PP")
 	info(INTEREST, "LOW")
+	field(EGU, "G")
 }
 
 record(ai, "$(P)$(CHANNEL):FIELD:GAUSS") 
 {
 	field(DESC, "Gauss field reading")
-	field(EGU, "Gauss")
+	field(EGU, "G")
 	info(INTEREST, "HIGH")
 	info(ARCHIVE, "VAL")
+	field(PREC, "4")
 }
 
 record(calcout, "$(P)$(CHANNEL):FIELD:CALC:TESLA")
 {
 	field(DESC, "Calculating tesla value with multiplier")
 	field(INPA, "$(P)$(CHANNEL):FIELD:RAW")
-	field(INPB, "$(P)$(CHANNEL):UNIT")
+	field(INPB, "$(P)UNIT")
 	field(INPC, "$(P)$(CHANNEL):CALC:MULT")
-	#field(CALC, "B=1?A*C:A*C*10EXP-4")
-	field(CALC, "B=1?A*C:A*C*10")
-	field(OUT, "$(P)$(CHANNEL):FIELD:TESLA")
+	field(CALC, "B=1?A*C:A*C*0.0001")
+	field(OUT, "$(P)$(CHANNEL):FIELD:TESLA PP")
 	info(INTEREST, "LOW")
+	field(EGU, "T")
 }
 
 record(ai, "$(P)$(CHANNEL):FIELD:TESLA") 
 {
 	field(DESC, "Tesla field reading")
-	field(EGU, "Tesla")
-	info(INTEREST, "HIGH")
-	info(ARCHIVE, "VAL")
-}
-
-record(ai, "$(P)$(CHANNEL):MAXREADING")
-{
-	field(DESC, "Max reading")
-	field(DTYP, "stream")
-	field(SCAN, "2 second")
-	field(INP, "@devLakeshore_460.proto getMaxReading($(CHANNEL)) $(PORT)")    
+	field(EGU, "T")
 	info(INTEREST, "HIGH")
 	info(ARCHIVE, "VAL")
 	field(PREC, "4")
-	field(EGU, "")
-    field(SIML, "$(P)SIM")
-    field(SIOL, "$(P)SIM:$(CHANNEL):MAXREADING")
-    field(SDIS, "$(P)DISABLE")
 }
 
-record(ai, "$(P)$(CHANNEL):RELMODEREADING")
-{
-	field(DESC, "Relative Mode Reading")
-	field(SCAN, "2 second")
-	field(DTYP, "stream")
-	field(INP, "@devLakeshore_460.proto getRelModeReading($(CHANNEL)) $(PORT)")    
-	info(INTEREST, "HIGH")
-	info(ARCHIVE, "VAL")
-	field(PREC, "4")
-	field(EGU, "")
-    field(SIML, "$(P)SIM")
-    field(SIOL, "$(P)SIM:$(CHANNEL):RELMODEREADING")
-    field(SDIS, "$(P)DISABLE")
-}
 
-record(ai, "$(P)$(CHANNEL):RELMODESET")
-{
-	field(DESC, "return rel mode set point")
-	field(SCAN, "5 second")
-	field(DTYP, "stream")
-	field(INP, "@devLakeshore_460.proto getRelModeSetpoint($(CHANNEL)) $(PORT)")
-	info(INTEREST, "HIGH")	
-	info(ARCHIVE, "VAL")
-	field(EGU, "")
-	field(PREC, "4")
-    field(SIML, "$(P)SIM")
-    field(SIOL, "$(P)SIM:$(CHANNEL):RELMODESET")
-    field(SDIS, "$(P)DISABLE")
-	field(FLNK, "$(P)$(CHANNEL):UNIT:MULT")
-}
-
-record(ao, "$(P)$(CHANNEL):RELMODESET:SP")
-{
-	field(DESC, "set rel mode set point")
-	field(DTYP, "stream")
-	field(OUT, "@devLakeshore_460.proto setRelModeSetpoint($(CHANNEL)) $(PORT)")    
-    field(SIML, "$(P)SIM")
-    field(SIOL, "$(P)SIM:$(CHANNEL):RELMODESET:SP")
-    field(SDIS, "$(P)$(CHANNEL):DISABLE")
-	info(INTEREST, "LOW")	
-	field(EGU, "")
-}
 
 record(bo, "$(P)$(CHANNEL):MAXCLEAR:SP")
 {
@@ -267,7 +274,6 @@ record(mbbi, "$(P)$(CHANNEL):RELMODESET:MULT")
 	field(TWST, " ")
 	field(THST, "k")
 	info(INTEREST, "LOW")
-	field(FLNK, "$(P)$(CHANNEL):MODE")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:$(CHANNEL):RELMODESET:MULT")
     field(SDIS, "$(P)DISABLE")
@@ -291,11 +297,42 @@ record(stringout, "$(P)$(CHANNEL):RELMODESET:UNIT:CALC:STR")
     field(OUT,  "$(P)$(CHANNEL):RELMODESET.EGU PP")
 }
 
+record(ai, "$(P)$(CHANNEL):RELMODESET")
+{
+	field(DESC, "return rel mode set point")
+	field(SCAN, "5 second")
+	field(DTYP, "stream")
+	field(INP, "@devLakeshore_460.proto getRelModeSetpoint($(CHANNEL)) $(PORT)")
+	info(INTEREST, "HIGH")	
+	info(ARCHIVE, "VAL")
+	field(EGU, "")
+	field(PREC, "4")
+    field(SIML, "$(P)SIM")
+    field(SIOL, "$(P)SIM:$(CHANNEL):RELMODESET")
+    field(SDIS, "$(P)DISABLE")
+	#field(FLNK, "$(P)$(CHANNEL):UNIT:MULT")
+	field(FLNK, "$(P)$(CHANNEL):MODE")
+
+}
+
+record(ao, "$(P)$(CHANNEL):RELMODESET:SP")
+{
+	field(DESC, "set rel mode set point")
+	field(DTYP, "stream")
+	field(OUT, "@devLakeshore_460.proto setRelModeSetpoint($(CHANNEL)) $(PORT)")    
+    field(SIML, "$(P)SIM")
+    field(SIOL, "$(P)SIM:$(CHANNEL):RELMODESET:SP")
+    field(SDIS, "$(P)$(CHANNEL):DISABLE")
+	info(INTEREST, "LOW")	
+	field(EGU, "")
+}
+
 record(bi, "$(P)$(CHANNEL):MODE") 
 {
 	field(DESC, "Get the field reading mode")
     field(DTYP, "stream")
-    field(INP,  "@devLakeshore_460.proto getACDCFIELD($(CHANNEL)) $(PORT)")
+	#field(SCAN, "5 second")
+    field(INP,  "@devLakeshore_460.proto getACDCFieldReading($(CHANNEL)) $(PORT)")
     field(ZNAM, "DC")
     field(ONAM, "AC")    
 	info(INTEREST, "HIGH")	
@@ -310,7 +347,7 @@ record(bo, "$(P)$(CHANNEL):MODE:SP")
 {
 	field(DESC, "Set the field reading mode")
     field(DTYP, "stream")
-    field(OUT,  "@devLakeshore_460.proto setACDCFIELD($(CHANNEL)) $(PORT)")
+    field(OUT,  "@devLakeshore_460.proto setACDCFieldReading($(CHANNEL)) $(PORT)")
     field(ZNAM, "DC")
     field(ONAM, "AC")    
     field(SIML, "$(P)SIM")

--- a/LKSH460/LKSH460-IOC-01App/Db/lakeshore460_channels.template
+++ b/LKSH460/LKSH460-IOC-01App/Db/lakeshore460_channels.template
@@ -9,36 +9,11 @@ record(ai, "$(P)$(CHANNEL):FIELD:RAW")
 	info(INTEREST, "HIGH")
 	info(ARCHIVE, "VAL")
 	field(PREC, "4")
-	field(FLNK, "$(P)UNIT")
+	field(FLNK, "$(P)$(CHANNEL):MAXREADING")
 	field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:$(CHANNEL):FIELD:RAW")
     field(SDIS, "$(P)DISABLE")
 	field(EGU, "")
-}
-
-record(mbbi, "$(P)UNIT") 
-{
-    field(DESC, "Unit in use - gauss or tesla")
-    field(DTYP, "stream")
-    field(INP,  "@devLakeshore_460.proto getFieldUnits $(PORT)")
-    field(ZRST, "G")
-    field(ONST, "T")	
-    info(INTEREST, "MEDIUM")
-	field(FLNK, "$(P)$(CHANNEL):MAXREADING")
-	field(SIML, "$(P)SIM")
-    field(SIOL, "$(P)SIM:UNIT")
-}
-
-record(mbbo, "$(P)UNIT:SP") 
-{
-    field(DESC, "Set Unit, gauss or tesla")
-    field(DTYP, "stream")
-    field(OUT,  "@devLakeshore_460.proto setFieldUnits $(PORT)")
-    field(ZRST, "G")
-    field(ONST, "T")	
-    info(INTEREST, "LOW")
-	field(SIML, "$(P)SIM")
-    field(SIOL, "$(P)SIM:UNIT:SP")
 }
 
 record(ai, "$(P)$(CHANNEL):MAXREADING")

--- a/LKSH460/LKSH460-IOC-01App/Db/lakeshore460_channels.template
+++ b/LKSH460/LKSH460-IOC-01App/Db/lakeshore460_channels.template
@@ -8,19 +8,18 @@ record(ai, "$(P)$(CHANNEL):FIELD:RAW")
 	field(INP, "@devLakeshore_460.proto getMagneticFieldReading($(CHANNEL)) $(PORT)")
 	info(INTEREST, "HIGH")
 	info(ARCHIVE, "VAL")
-	info(ARCHIVE, "EGU")
 	field(PREC, "4")
 	field(FLNK, "$(P)UNIT")
 	field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:$(CHANNEL):FIELD:RAW")
     field(SDIS, "$(P)DISABLE")
+	field(EGU, "")
 }
 
 record(mbbi, "$(P)UNIT") 
 {
     field(DESC, "Unit in use - gauss or tesla")
     field(DTYP, "stream")
-
     field(INP,  "@devLakeshore_460.proto getFieldUnits $(PORT)")
     field(ZRST, "G")
     field(ONST, "T")	
@@ -46,7 +45,6 @@ record(ai, "$(P)$(CHANNEL):MAXREADING")
 {
 	field(DESC, "Max reading")
 	field(DTYP, "stream")
-	#field(SCAN, "2 second")
 	field(INP, "@devLakeshore_460.proto getMaxReading($(CHANNEL)) $(PORT)")    
 	info(INTEREST, "HIGH")
 	info(ARCHIVE, "VAL")
@@ -62,7 +60,6 @@ record(ai, "$(P)$(CHANNEL):MAXREADING")
 record(ai, "$(P)$(CHANNEL):RELMODEREADING")
 {
 	field(DESC, "Relative Mode Reading")
-	#field(SCAN, "2 second")
 	field(DTYP, "stream")
 	field(INP, "@devLakeshore_460.proto getRelModeReading($(CHANNEL)) $(PORT)")    
 	info(INTEREST, "HIGH")
@@ -188,8 +185,6 @@ record(stringout, "$(P)$(CHANNEL):FIELD:UNIT:CALC:STR")
     field(OUT,  "$(P)$(CHANNEL):FIELD.EGU PP")
 }
 
-
-
 ## MAX HOLD READING UNITS CALCULATION ###
 
 record(scalcout, "$(P)$(CHANNEL):MAXREADING:UNIT:CALC")
@@ -310,9 +305,7 @@ record(ai, "$(P)$(CHANNEL):RELMODESET")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:$(CHANNEL):RELMODESET")
     field(SDIS, "$(P)DISABLE")
-	#field(FLNK, "$(P)$(CHANNEL):UNIT:MULT")
 	field(FLNK, "$(P)$(CHANNEL):MODE")
-
 }
 
 record(ao, "$(P)$(CHANNEL):RELMODESET:SP")
@@ -331,7 +324,6 @@ record(bi, "$(P)$(CHANNEL):MODE")
 {
 	field(DESC, "Get the field reading mode")
     field(DTYP, "stream")
-	#field(SCAN, "5 second")
     field(INP,  "@devLakeshore_460.proto getACDCFieldReading($(CHANNEL)) $(PORT)")
     field(ZNAM, "DC")
     field(ONAM, "AC")    

--- a/LKSH460/LKSH460-IOC-01App/Db/lakeshore460_channels.template
+++ b/LKSH460/LKSH460-IOC-01App/Db/lakeshore460_channels.template
@@ -1,19 +1,92 @@
 ## Template for x/y/z/vector channel PVs ##
 
-record(ai, "$(P)$(CHANNEL):FIELDREADING")
+record(ai, "$(P)$(CHANNEL):FIELD:RAW")
 {
-	field(DESC, "Field reading")
-    field(DTYP, "stream")
-	field(SCAN, "2 second")
-	field(INP, "@devLakeshore_460.proto getMagneticFieldReading($(CHANNEL)) $(PORT)")    
+	field(DESC, "Magnetic field reading")
+	field(DTYP, "stream")
+	field(SCAN, "1 second")
+	field(INP, "@devLakeshore_460.proto getMagneticFieldReading($(CHANNEL)) $(PORT)")
 	info(INTEREST, "HIGH")
 	info(ARCHIVE, "VAL")
-	field(EGU, "")
-	field(PREC, "4")
-    field(SIML, "$(P)SIM")
-    field(SIOL, "$(P)SIM:$(CHANNEL):FIELDREADING")
+	info(ARCHIVE, "EGU")
+	field(FLNK, "$(P)$(CHANNEL):UNIT:MULT")
+	field(SIML, "$(P)SIM")
+    field(SIOL, "$(P)SIM:$(CHANNEL):FIELD:RAW")
     field(SDIS, "$(P)DISABLE")
-    info(alarm, "Lakeshore460")
+}
+
+record(mbbi, "$(P)$(CHANNEL):UNIT:MULT")
+{
+	field(DESC, "Multiplier for magnetic field reading")
+	field(DTYP, "stream")
+	field(INP, "@devLakeshore_460.proto getFieldUnitsMulti($(CHANNEL)) $(PORT)")
+	field(ZRST, "u")
+	field(ONST, "m")
+	field(TWST, " ")
+	field(THST, "k")
+	info(INTEREST, "LOW")
+	field(FLNK, "$(P)$(CHANNEL):CALC:MULT")
+    field(SIML, "$(P)SIM")
+    field(SIOL, "$(P)SIM:$(CHANNEL):UNIT:MULT")
+    field(SDIS, "$(P)DISABLE")
+}
+
+record(scalcout, "$(P)$(CHANNEL):CALC:MULT")
+{
+	field(DESC, "Alter the multiplier string to a number")
+	field(CALC, "AA='u'?0.000001:AA='m'?0.001:AA='k'?1000:1")
+	field(INAA, "$(P)$(CHANNEL):UNIT:MULT")
+	info(INTEREST, "LOW")
+	field(FLNK, "$(P)$(CHANNEL):CALC:FAN")
+}
+
+record(fanout, "$(P)$(CHANNEL):CALC:FAN")
+{
+	field(DESC, "Trigger all readback calculations")
+	field(LNK1, "$(P)$(CHANNEL):FIELD:CALC:GAUSS.PROC")
+	field(LNK2, "$(P)$(CHANNEL):FIELD:CALC:TESLA.PROC")
+	field(LNK3, "$(P)$(CHANNEL):UNIT:CALC.PROC")
+	info(INTEREST, "LOW")	
+}
+
+record(calcout, "$(P)$(CHANNEL):FIELD:CALC:GAUSS")
+{
+	field(DESC, "Calculating gauss with multiplier")
+	field(INPA, "$(P)$(CHANNEL):FIELD:RAW")
+	field(INPB, "$(P)$(CHANNEL):UNIT")
+	field(INPC, "$(P)$(CHANNEL):CALC:MULT")
+	#field(CALC, "B=0?A*C:A*C*10EXP4")
+	field(CALC, "B=0?A*C:A*C*10")
+	field(OUT, "$(P)$(CHANNEL):FIELD:GAUSS")
+	info(INTEREST, "LOW")
+}
+
+record(ai, "$(P)$(CHANNEL):FIELD:GAUSS") 
+{
+	field(DESC, "Gauss field reading")
+	field(EGU, "Gauss")
+	info(INTEREST, "HIGH")
+	info(ARCHIVE, "VAL")
+}
+
+record(calcout, "$(P)$(CHANNEL):FIELD:CALC:TESLA")
+{
+	field(DESC, "Calculating tesla value with multiplier")
+	field(INPA, "$(P)$(CHANNEL):FIELD:RAW")
+	field(INPB, "$(P)$(CHANNEL):UNIT")
+	field(INPC, "$(P)$(CHANNEL):CALC:MULT")
+	#field(CALC, "B=1?A*C:A*C*10EXP-4")
+	field(CALC, "B=1?A*C:A*C*10")
+	field(OUT, "$(P)$(CHANNEL):FIELD:TESLA")
+	info(INTEREST, "LOW")
+}
+
+record(ai, "$(P)$(CHANNEL):FIELD:TESLA") 
+{
+	field(DESC, "Tesla field reading")
+	field(EGU, "Tesla")
+	info(INTEREST, "HIGH")
+	info(ARCHIVE, "VAL")
 }
 
 record(ai, "$(P)$(CHANNEL):MAXREADING")
@@ -59,7 +132,7 @@ record(ai, "$(P)$(CHANNEL):RELMODESET")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:$(CHANNEL):RELMODESET")
     field(SDIS, "$(P)DISABLE")
-	field(FLNK, "$(P)$(CHANNEL):FIELDREADING:UNIT:MULT")
+	field(FLNK, "$(P)$(CHANNEL):UNIT:MULT")
 }
 
 record(ao, "$(P)$(CHANNEL):RELMODESET:SP")
@@ -90,39 +163,25 @@ alias("$(P)$(CHANNEL):MAXCLEAR:SP","$(P)$(CHANNEL):MAXCLEAR")
 
 ## FIELD READING UNITS CALCULATION ###
 
-record(scalcout, "$(P)$(CHANNEL):FIELDREADING:UNIT:CALC")
+record(scalcout, "$(P)$(CHANNEL):FIELD:UNIT:CALC")
 {
 	field(DESC, "field units concat.")
-	field(INAA, "$(P)$(CHANNEL):FIELDREADING:UNIT:MULT CP MS")
+	field(INAA, "$(P)$(CHANNEL):UNIT:MULT CP MS")
 	field(INBB, "$(P)UNIT CP MS")	
 	field(CALC, "AA+BB")
 	info(INTEREST, "LOW")
 	field(OOPT, "Every Time")
 }
 
-record(stringout, "$(P)$(CHANNEL):FIELDREADING:UNIT:CALC:STR")
+record(stringout, "$(P)$(CHANNEL):FIELD:UNIT:CALC:STR")
 {
     field(DESC, "Push units to field reading")
-    field(DOL, "$(P)$(CHANNEL):FIELDREADING:UNIT:CALC.SVAL CP")
+    field(DOL, "$(P)$(CHANNEL):FIELD:UNIT:CALC.SVAL CP")
 	field(OMSL, "closed_loop")
-    field(OUT,  "$(P)$(CHANNEL):FIELDREADING.EGU PP")
+    field(OUT,  "$(P)$(CHANNEL):FIELD.EGU PP")
 }
 
-record(mbbi, "$(P)$(CHANNEL):FIELDREADING:UNIT:MULT")
-{
-	field(DESC, "Multiplier for field reading")
-	field(DTYP, "stream")
-	field(INP, "@devLakeshore_460.proto getFieldUnitsMulti($(CHANNEL)) $(PORT)")
-	field(ZRST, "u")
-	field(ONST, "m")
-	field(TWST, " ")
-	field(THST, "k")
-	info(INTEREST, "LOW")
-	field(FLNK, "$(P)$(CHANNEL):MAXREADING:UNIT:MULT")
-    field(SIML, "$(P)SIM")
-    field(SIOL, "$(P)SIM:$(CHANNEL):FIELDREADING:UNIT:MULT")
-    field(SDIS, "$(P)DISABLE")
-}
+
 
 ## MAX HOLD READING UNITS CALCULATION ###
 
@@ -236,7 +295,7 @@ record(bi, "$(P)$(CHANNEL):MODE")
 {
 	field(DESC, "Get the field reading mode")
     field(DTYP, "stream")
-    field(INP,  "@devLakeshore_460.proto getACDCFieldReading($(CHANNEL)) $(PORT)")
+    field(INP,  "@devLakeshore_460.proto getACDCFIELD($(CHANNEL)) $(PORT)")
     field(ZNAM, "DC")
     field(ONAM, "AC")    
 	info(INTEREST, "HIGH")	
@@ -251,7 +310,7 @@ record(bo, "$(P)$(CHANNEL):MODE:SP")
 {
 	field(DESC, "Set the field reading mode")
     field(DTYP, "stream")
-    field(OUT,  "@devLakeshore_460.proto setACDCFieldReading($(CHANNEL)) $(PORT)")
+    field(OUT,  "@devLakeshore_460.proto setACDCFIELD($(CHANNEL)) $(PORT)")
     field(ZNAM, "DC")
     field(ONAM, "AC")    
     field(SIML, "$(P)SIM")
@@ -511,7 +570,13 @@ record(bo, "$(P)$(CHANNEL):STATUS:SP")
 
 ### SIMULATION RECORDS ###
 
-record(mbbi, "$(P)$(CHANNEL):SIM:FIELDREADING:UNIT:MULT")
+record(mbbi, "$(P)$(CHANNEL):SIM:UNIT:MULT")
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+}
+
+record(mbbi, "$(P)$(CHANNEL):SIM:FIELD:RAW")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")
@@ -563,7 +628,7 @@ record(mbbi, "$(P)$(CHANNEL):SIM:RANGE")
 
 alias("$(P)$(CHANNEL):SIM:RANGE","$(P)$(CHANNEL):SIM:RANGE:SP")
 
-record(ai, "$(P)$(CHANNEL):SIM:FIELDREADING")
+record(ai, "$(P)$(CHANNEL):SIM:FIELD")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")

--- a/LKSH460/iocBoot/iocLKSH460-IOC-01/st-common.cmd
+++ b/LKSH460/iocBoot/iocLKSH460-IOC-01/st-common.cmd
@@ -13,6 +13,10 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "bits", "$(BITS=7)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "parity", "$(PARITY=even)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "$(STOP=1)")
 
+## Commands for turning on debugging.  Shows traffic on connection.
+#asynSetTraceMask("L0",-1,0x9) 
+#asynSetTraceIOMask("L0",-1,0x2)
+
 ##ISIS## Load common DB records 
 < $(IOCSTARTUP)/dbload.cmd
 


### PR DESCRIPTION
### Description of work

Unit value PVs have been added to the IOC to allow user scientists to log values without them varying if they switch units. 
For example, when logging the raw device reading, if the user changes units the value of the readback will spike dramatically as it changes from Tesla to Gauss.

![lksh_raw](https://user-images.githubusercontent.com/15033982/37100699-8693c6fc-221b-11e8-9c93-07c7e6c5f46d.PNG)

By adding FIELD:TESLA and FIELD:GAUSS PVs, we can maintain the overall log of the readback regardless of which unit we are in. Below, the units are changed from Tesla to Gauss but the RAW:GAUSS value remains unchanged. 
![lsh_gauss](https://user-images.githubusercontent.com/15033982/37100704-88618c6c-221b-11e8-919e-346390a48538.PNG)


### To test

[Ticket 2887](https://github.com/ISISComputingGroup/IBEX/issues/2887)

### Acceptance criteria

See also: [OPI pull request](https://github.com/ISISComputingGroup/ibex_gui/pull/651)
See also: [Test Files pull request](https://github.com/ISISComputingGroup/EPICS-IOC_Test_Framework/pull/62)
---

#### Code Review

- [ ] **Pertitent information and a copy of the manual has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)**
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?


### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
