### PR TITLE
Ticket 2202: Added polling for the mclennan and linmot

### DIFF
--- a/LINMOT/LINMOT-IOC-01App/Db/motor.substitutions
+++ b/LINMOT/LINMOT-IOC-01App/Db/motor.substitutions
@@ -7,3 +7,8 @@ file $(MOTOR)/db/linmot_extra.db {
 pattern {P, M, OFF}
 {"\$(P)", "\$(M)", "\$(OFF)"}
 }
+
+file $(MOTOR)/db/periodic_polling.db {
+pattern {P, M}
+{"\$(P)", "\$(M)"}
+}

--- a/LINMOT/iocBoot/iocLINMOT-IOC-01/st.cmd
+++ b/LINMOT/iocBoot/iocLINMOT-IOC-01/st.cmd
@@ -12,7 +12,7 @@ errlogInit2(65536, 256)
 dbLoadDatabase "$(TOP)/dbd/LINMOT-IOC-01.dbd"
 LINMOT_IOC_01_registerRecordDeviceDriver pdbbase
 
-# enable debugging
-var drvLinMotDebug 5
+# enable debugging by setting >1
+var drvLinMotDebug 0
 
 < st-common.cmd

--- a/MCLEN/MCLEN-IOC-01App/Db/motor.substitutions
+++ b/MCLEN/MCLEN-IOC-01App/Db/motor.substitutions
@@ -4,3 +4,8 @@ pattern {P,    M,         DTYP,      DESC,   EGU,  DIR,  VELO,  VBAS, ACCL, BDST
 {"\$(P)", "\$(M)", "Mclennan PM304", "\$(NAME) (MCLEN)",    "\$(EGU)",  "Pos",  "\$(VELO)",   "\$(VBAS)",  "\$(ACCL)",    0,    1,   0,   "\$(MRES)",   "\$(ERES)", "\$(UEIP)",    3,   "\$(DHLM)",   "\$(DLLM)",  "", "\$(C)", "\$(S)"}
 
 }
+
+file $(MOTOR)/db/periodic_polling.db {
+pattern {P, M}
+{"\$(P)", "\$(M)"}
+}


### PR DESCRIPTION
### Description of work

See https://github.com/ISISComputingGroup/IBEX/issues/2202

### To test

Turn on asyn trace on the linmot and mclennan, confirm that they both poll the motor position every second.

---

#### Code Review

- [ ] **Pertitent information and a copy of the manual has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)**
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [x] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
