### PR TITLE
Add alias for external temp sp

### DIFF
--- a/JULABO/JULABO-IOC-01App/Db/FP50_MH.db
+++ b/JULABO/JULABO-IOC-01App/Db/FP50_MH.db
@@ -142,6 +142,11 @@ record(ai, "$(P)EXTTEMP")
     info(archive, "VAL")
 }
 
+# Julabo only has one setpoint. To enable doing csets on external temperature,
+# alias the setpoint PVs to also apply to exttemp PVs
+alias("$(P)TEMP:SP", "$(P)EXTTEMP:SP")
+alias("$(P)TEMP:SP:RBV", "$(P)EXTTEMP:SP:RBV")
+
 record(ai, "$(P)HIGHLIMIT") 
 {
     field(DESC, "High limit")


### PR DESCRIPTION
### Description of work

Adds aliases pointing from `EXTTEMP:SP` to `TEMP:SP` and the same for set point read backs.

This enables blocks pointing at the external temperature to work with a `cset`.

@John-Holt-Tessella and I had a discussion about different methods of doing this, we felt that creating aliases was the best compromise as it reflects what the device is seeing. We considered other options, such as keeping two setpoints and sending a different one to the device based on the control mode, but this could become confusing for users if they think they have set a setpoint but it was not sent.

I haven't added tests because there is no new functionality - only an extra alias.

Documentation added to https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Julabo

### To test

https://github.com/ISISComputingGroup/IBEX/issues/3074

### Acceptance criteria

- Can do a `cset` on a block pointing at the external temperature, and the setpoint is applied.

---

#### Code Review

- [ ] **Pertitent information and a copy of the manual has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)**
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
