### PR TITLE
Use axis record DB files

### DIFF
--- a/BKHOFF/BKHOFF-IOC-01App/Db/IMAT.substitutions
+++ b/BKHOFF/BKHOFF-IOC-01App/Db/IMAT.substitutions
@@ -18,7 +18,7 @@ file "${EEMCU}/db/EssMCAGmotor.template"
 {
 pattern
 {P,       N,  M,      DTYP,         PORT,     ADDR,  DESC,          EGU, DIR,  VELO, JVEL,  VBAS,  ACCL,  BDST, DLY,  BVEL,  BACC,  MRES, ERES,   PREC,  DLLM,  DHLM,  INIT}
-{"\$(P)",  1,  "\$(M1)",  "asyn",  "\$(PORT)",  1,     "Rotation",  degree,  Pos,  1,   1,    1,     1,     0,    0.3,  1,     1,    1,    1,      3,     -180,   180,    ""}
-{"\$(P)",  2,  "\$(M2)",  "asyn",  "\$(PORT)",  2,     "Z",  mm,  Pos,  2.5,    2.5,     2.5,   1,     0,    0,    1,     1,    1,    1,      3,     -250,       250,    ""}
+{"\$(P)",  1,  "\$(M1)",  "asynAxis",  "\$(PORT)",  1,     "Rotation",  degree,  Pos,  1,   1,    1,     1,     0,    0.3,  1,     1,    1,    1,      3,     -181,   181,    ""}
+{"\$(P)",  2,  "\$(M2)",  "asynAxis",  "\$(PORT)",  2,     "Z",  mm,  Pos,  2.5,    2.5,     2.5,   1,     0,    0,    1,     1,    1,    1,      3,     -160,       300,    ""}
 }
 

--- a/BKHOFF/iocBoot/iocBKHOFF-IOC-01/st-common.cmd
+++ b/BKHOFF/iocBoot/iocBKHOFF-IOC-01/st-common.cmd
@@ -60,10 +60,14 @@ dbLoadRecords("db/IMAT.db","P=$(MYPVPREFIX),PORT=MCU1,M1=MOT:MTR0901,M2=MOT:MTR0
 
 ## motor util package
 ## note: IOC name needs to have been added to _FAN element of this DB file
-dbLoadRecords("$(MOTOR)/db/motorUtil.db","P=$(MYPVPREFIX)$(IOCNAME):,$(IFIOC)= ,PVPREFIX=$(MYPVPREFIX)")
+dbLoadRecords("$(AXISRECORD)/db/axisUtil.db","P=$(MYPVPREFIX)$(IOCNAME):,$(IFIOC)= ,PVPREFIX=$(MYPVPREFIX)")
 
 dbLoadRecords("$(MOTOR)/db/motorStatus.db", "P=$(MYPVPREFIX),M=MOT:MTR0901")
 dbLoadRecords("$(MOTOR)/db/motorStatus.db", "P=$(MYPVPREFIX),M=MOT:MTR0902")
+
+epicsEnvSet("BKHOFFCONFIG","$(ICPCONFIGROOT)/$(IOCNAME)")
+## configure axes
+< $(BKHOFFCONFIG)/axes.cmd
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd
@@ -71,7 +75,7 @@ dbLoadRecords("$(MOTOR)/db/motorStatus.db", "P=$(MYPVPREFIX),M=MOT:MTR0902")
 cd "${TOP}/iocBoot/${IOC}"
 iocInit
 
-motorUtilInit("$(MYPVPREFIX)$(IOCNAME):")
+axisUtilInit("$(MYPVPREFIX)$(IOCNAME):")
 
 ## Start any sequence programs
 #seq sncxxx,"user=faa59Host"


### PR DESCRIPTION
### Description of work

Update BKHOFF Db files for axis record, also adjust high and low limits to reflect current range

### To test

See ISISComputingGroup/IBEX#3037

### Acceptance criteria

These are the current files as being used on IMAT, so already tested there

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
