### PR TITLE
Macro for severity of being on and ramping up or down

### DIFF
--- a/HVCAEN/iocBoot/iocHVCAEN-IOC-01/st.cmd
+++ b/HVCAEN/iocBoot/iocHVCAEN-IOC-01/st.cmd
@@ -26,7 +26,7 @@ CAENx527ConfigureCreate "hv0", "$(HVCAENIP0)"
 
 ## Load our record instances
 #dbLoadRecords("db/xxx.db","user=faa59Host")
-CAENx527DbLoadRecords("P=$(MYPVPREFIX)CAEN")
+CAENx527DbLoadRecords("P=$(MYPVPREFIX)CAEN, ALARM_WHEN_ON=$(ALARM_WHEN_ON=NO_ALARM), ALARM_WHEN_RAMPING=$(ALARM_WHEN_RAMPING=NO_ALARM)")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd

--- a/HVCAEN/iocBoot/iocHVCAENSIM-IOC-01/st.cmd
+++ b/HVCAEN/iocBoot/iocHVCAENSIM-IOC-01/st.cmd
@@ -27,7 +27,7 @@ CAENx527ConfigureCreate "hv0", "127.0.0.1"
 
 ## Load our record instances
 #dbLoadRecords("db/xxx.db","user=faa59Host")
-CAENx527DbLoadRecords("P=$(MYPVPREFIX)CAEN")
+CAENx527DbLoadRecords("P=$(MYPVPREFIX)CAEN, ALARM_WHEN_ON=$(ALARM_WHEN_ON=NO_ALARM), ALARM_WHEN_RAMPING=$(ALARM_WHEN_RAMPING=NO_ALARM)")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd


### PR DESCRIPTION
### Description of work

The severity of being on or ramping up and down has been changed from a minor alarm to a macro, defaulting to no alarm.

See also:
https://github.com/ISISComputingGroup/EPICS-HVCAENx527/pull/2

### To test

https://github.com/ISISComputingGroup/IBEX/issues/3004

### Acceptance criteria

Put the IOC into sim mode.
caput TE:[Host]:CAEN:hv0:0:SIM YES
Change the status, make sure it has the correct severity level when using defaults and also when macro is set.
caput TE:[Host]:CAEN:hv0:0:SIM:0:status 1
caput TE:[Host]:CAEN:hv0:0:SIM:0:status 2
caput TE:[Host]:CAEN:hv0:0:SIM:0:status 3


---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
