### PR TITLE
Add extra MCLEN homing mode

### DIFF
--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/config.xml
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/config.xml
@@ -93,14 +93,14 @@
 <macro name="CMOD7" pattern="^(OPEN|CLOSED)$" description="Loop control mode (default: CLOSED)" />
 <macro name="CMOD8" pattern="^(OPEN|CLOSED)$" description="Loop control mode (default: CLOSED)" />
 
-<macro name="HOME1" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
-<macro name="HOME2" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
-<macro name="HOME3" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
-<macro name="HOME4" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
-<macro name="HOME5" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
-<macro name="HOME6" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
-<macro name="HOME7" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
-<macro name="HOME8" pattern="^([0-2])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero] (default: 1)" />
+<macro name="HOME1" pattern="^([0-3])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero, 3. Constant velocity move and zero] (default: 1)" />
+<macro name="HOME2" pattern="^([0-3])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero, 3. Constant velocity move and zero] (default: 1)" />
+<macro name="HOME3" pattern="^([0-3])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero, 3. Constant velocity move and zero] (default: 1)" />
+<macro name="HOME4" pattern="^([0-3])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero, 3. Constant velocity move and zero] (default: 1)" />
+<macro name="HOME5" pattern="^([0-3])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero, 3. Constant velocity move and zero] (default: 1)" />
+<macro name="HOME6" pattern="^([0-3])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero, 3. Constant velocity move and zero] (default: 1)" />
+<macro name="HOME7" pattern="^([0-3])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero, 3. Constant velocity move and zero] (default: 1)" />
+<macro name="HOME8" pattern="^([0-3])$" description="Homing mode [0: Hardware defined, 1: Constant velocity move, 2: Reverse home and zero, 3. Constant velocity move and zero] (default: 1)" />
 
 <macro name="NAME1" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" />
 <macro name="NAME2" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" />


### PR DESCRIPTION
### Description of work

I've added a new homing mode for McLennan motors: constant velocity move and zero.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/3077

### Acceptance criteria

- Other homing modes unaffected
    - Notably mode 1 is the one most likely to be affected and the only one we can test with the office McLennan
    - Mode 1 should do a jog to the limit. When it gets there the position should not be reset
- There is a new homing mode, identical to mode 1 but which zeroes the position when it reaches its destination,
    - Do a home
    - When the motor reaches the limit, the position should be zeroed
    - Other actions shouldn't cause the position to be zeroed (e.g. a jog)
    - If you ask for the motor to home and then stop it, it may still zero. This is a known issue that we've decided not to action.

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
