### PR TITLE
Ticket3010 extend banner

### DIFF
--- a/INSTETC/INSTETC-IOC-01App/Db/INSTETC.db
+++ b/INSTETC/INSTETC-IOC-01App/Db/INSTETC.db
@@ -127,8 +127,6 @@ record (bo, "$(P)CS:CONTROL:LOCKED")
 	field(DTYP, "Soft Channel")
 	field(ZNAM, "NO")
 	field(ONAM, "YES")
-	field(ZSV, "NO_ALARM")
-    field(OSV, "MAJOR")
 	field(PINI, "YES")
 	field(VAL, "0")
 }
@@ -143,6 +141,8 @@ record (bo, "$(P)CS:MANAGER")
 	field(OMSL, "supervisory")
 	field(ZNAM, "No")
 	field(ONAM, "Yes")
+	field(ZSV, "NO_ALARM")
+    field(OSV, "MAJOR")
 }
 
 # This points to the centrally located shutter status and archives it locally 

--- a/INSTETC/INSTETC-IOC-01App/Db/INSTETC.db
+++ b/INSTETC/INSTETC-IOC-01App/Db/INSTETC.db
@@ -127,6 +127,8 @@ record (bo, "$(P)CS:CONTROL:LOCKED")
 	field(DTYP, "Soft Channel")
 	field(ZNAM, "NO")
 	field(ONAM, "YES")
+	field(ZSV, "NO_ALARM")
+    field(OSV, "MAJOR")
 	field(PINI, "YES")
 	field(VAL, "0")
 }


### PR DESCRIPTION
### Description of work

Add an alarm to the manager mode so that it goes red in the spangle banner when manager mode is on

### To test

https://github.com/ISISComputingGroup/IBEX/issues/3010

### Acceptance criteria

- When Manager mode = No, text appears black in banner
- When Manager mode = Yes, text appears red in banner

Flash reviewed and approved by @John-Holt-Tessella 

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
