### PR TITLE
Remove comms macros from ITC. Values cannot be changed.

### DIFF
--- a/ITC503/iocBoot/iocITC503-IOC-01/config.xml
+++ b/ITC503/iocBoot/iocITC503-IOC-01/config.xml
@@ -5,10 +5,6 @@
 <ioc_details></ioc_details>
 <macros>
 <macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" />
-<macro name="BAUD" pattern="^[0-9]+$" description="Serial communication baud rate, defaults to 9600." />
-<macro name="BITS" pattern="^[0-9]$" description="Serial communication number of bits, defaults to 8." />
-<macro name="PARITY" pattern="^(even)|(odd)|(none)$" description="Serial communication parity, defaults to none." />
-<macro name="STOP" pattern="^[0-9]$" description="Serial communication stop bit, defaults to 1." />
 </macros>
 <pvsets>
 </pvsets>

--- a/ITC503/iocBoot/iocITC503-IOC-01/st.cmd
+++ b/ITC503/iocBoot/iocITC503-IOC-01/st.cmd
@@ -27,10 +27,10 @@ $(IFDEVSIM) drvAsynIPPortConfigure("L0", "localhost:$(EMULATOR_PORT=57677)")
 
 ## For real device use:
 $(IFNOTDEVSIM) $(IFNOTRECSIM) drvAsynSerialPortConfigure("L0", "$(PORT=NO_PORT_MACRO)", 0, 0, 0, 0)
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "baud", "$(BAUD=9600)")
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "bits", "$(BITS=8)")
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "parity", "$(PARITY=none)")
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "$(STOP=2)")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "baud", "9600")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "bits", "8")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "parity", "none")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "2")
 
 ##ISIS## Load common DB records 
 < $(IOCSTARTUP)/dbload.cmd


### PR DESCRIPTION
@GDH-ISIS requested that the comms parameters should not be user-configurable