### PR TITLE
Remove comms macros from ips

### DIFF
--- a/IPS/iocBoot/iocIPS-IOC-01/config.xml
+++ b/IPS/iocBoot/iocIPS-IOC-01/config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<config_part>
+<ioc_desc>Oxford Instruments IPS</ioc_desc>
+<ioc_details></ioc_details>
+<macros>
+<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" />
+</macros>
+<pvsets>
+</pvsets>
+</config_part>
+</ioc_config>

--- a/IPS/iocBoot/iocIPS-IOC-01/st.cmd
+++ b/IPS/iocBoot/iocIPS-IOC-01/st.cmd
@@ -28,10 +28,10 @@ $(IFRECSIM) drvAsynSerialPortConfigure("$(DEVICE)", "$(PORT=NUL)", 0, 1, 0, 0)
 
 ## For real device:
 $(IFNOTDEVSIM) $(IFNOTRECSIM) drvAsynSerialPortConfigure("$(DEVICE)", "$(PORT=NO_PORT_MACRO)", 0, 0, 0, 0)
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "baud", "$(BAUD=9600)")
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "bits", "$(BITS=8)")
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "parity", "$(PARITY=none)")
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=2)")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "baud", "9600")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "bits", "8")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "parity", "none")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "stop", "2")
 
 ## Load record instances
 


### PR DESCRIPTION
@GDH-ISIS requested that the comms macros should not be user-configurable