### PR TITLE
Ticket3225: IOC: Larmor motion  set points

### DIFF
--- a/GALIL/iocBoot/iocGALIL-IOC-01/st-common.cmd
+++ b/GALIL/iocBoot/iocGALIL-IOC-01/st-common.cmd
@@ -1,6 +1,5 @@
 
 ##ISIS## Run IOC initialisation 
-# iocshCmdLoop("epicsEnvSet("IFIOC_GALIL_0\$(I)", "#")", "", "I", 1, 9)
 epicsEnvSet("IFIOC_GALIL_01", "#")
 epicsEnvSet("IFIOC_GALIL_02", "#")
 epicsEnvSet("IFIOC_GALIL_03", "#")

--- a/GALIL/iocBoot/iocGALIL-IOC-01/st-common.cmd
+++ b/GALIL/iocBoot/iocGALIL-IOC-01/st-common.cmd
@@ -1,5 +1,16 @@
 
 ##ISIS## Run IOC initialisation 
+# iocshCmdLoop("epicsEnvSet("IFIOC_GALIL_0\$(I)", "#")", "", "I", 1, 9)
+epicsEnvSet("IFIOC_GALIL_01", "#")
+epicsEnvSet("IFIOC_GALIL_02", "#")
+epicsEnvSet("IFIOC_GALIL_03", "#")
+epicsEnvSet("IFIOC_GALIL_04", "#")
+epicsEnvSet("IFIOC_GALIL_05", "#")
+epicsEnvSet("IFIOC_GALIL_06", "#")
+epicsEnvSet("IFIOC_GALIL_07", "#")
+epicsEnvSet("IFIOC_GALIL_08", "#")
+epicsEnvSet("IFIOC_GALIL_09", "#")
+epicsEnvSet("IFIOC_GALIL_10", "#")
 < $(IOCSTARTUP)/init.cmd
 
 ##ISIS## Load common DB records 


### PR DESCRIPTION
### Description of work

Added env variables to ignore record loads for other GALIL motors.

### To test

[#3225](https://github.com/ISISComputingGroup/IBEX/issues/3225)

### Acceptance criteria

No `maclib` errors occur when running any GALIL motor.

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertinent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [x] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
