### PR TITLE
Ticket3180

### DIFF
--- a/AG3631A/iocBoot/iocAG3631A-IOC-01/st.cmd
+++ b/AG3631A/iocBoot/iocAG3631A-IOC-01/st.cmd
@@ -33,6 +33,14 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "1")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynOctetSetInputEos("L0", -1, "\r\n")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynOctetSetOutputEos("L0", -1, "\r\n")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 ## Load record instances
 
 ##ISIS## Load common DB records 

--- a/AMINT2L/iocBoot/iocAMINT2L-IOC-01/st-common.cmd
+++ b/AMINT2L/iocBoot/iocAMINT2L-IOC-01/st-common.cmd
@@ -16,6 +16,14 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "bits", "$(BITS=8)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "parity", "$(PARITY=none)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "$(STOP=1)")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N") 
+
 ##ISIS## Load common DB records 
 < $(IOCSTARTUP)/dbload.cmd
 

--- a/CCD100/iocBoot/iocCCD100-IOC-01/st-common.cmd
+++ b/CCD100/iocBoot/iocCCD100-IOC-01/st-common.cmd
@@ -17,6 +17,14 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "$(STOP=1)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynOctetSetInputEos("L0", -1, "\r\n")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynOctetSetOutputEos("L0", -1, "\r\n") 
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 ## Load record instances
 
 ##ISIS## Load common DB records 

--- a/CRYVALVE/iocBoot/iocCRYVALVE-IOC-01/st.cmd
+++ b/CRYVALVE/iocBoot/iocCRYVALVE-IOC-01/st.cmd
@@ -29,6 +29,14 @@ $(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)")
 $(IFNOTDEVSIM) asynOctetSetInputEos("$(DEVICE)", -1, "$(OEOS=\r)")
 $(IFNOTDEVSIM) asynOctetSetOutputEos("$(DEVICE)", -1, "$(IEOS=\r)")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 ## Load record instances
 
 ##ISIS## Load common DB records

--- a/CYBAMAN/iocBoot/iocCYBAMAN-IOC-01/st.cmd
+++ b/CYBAMAN/iocBoot/iocCYBAMAN-IOC-01/st.cmd
@@ -36,6 +36,14 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "bits", "$(BITS=8)"
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "parity", "$(PARITY=none)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 ## Load record instances
 
 ##ISIS## Load common DB records 

--- a/DFKPS/iocBoot/iocDFKPS-IOC-01/st-common.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-01/st-common.cmd
@@ -19,6 +19,14 @@ $(IFNOTRECSIM) $(IFNOTDEVSIM) asynSetOption("L0", -1, "bits", "$(BITS=8)")
 $(IFNOTRECSIM) $(IFNOTDEVSIM) asynSetOption("L0", -1, "parity", "$(PARITY="none")")
 $(IFNOTRECSIM) $(IFNOTDEVSIM) asynSetOption("L0", -1, "stop", "$(STOP=2)")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 $(IFNOTRECSIM) asynOctetSetInputEos("L0",0,"$(IEOS=\\n\\r)")
 $(IFNOTRECSIM) asynOctetSetOutputEos("L0",0,"$(OEOS=\\r)")
 

--- a/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-common.cmd
+++ b/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-common.cmd
@@ -18,6 +18,14 @@ $(IFDEVSIM) epicsEnvSet "SENS_DIR" "eurotherm2k/master/example_temp_sensor"
 # For dev sim devices
 $(IFDEVSIM) drvAsynIPPortConfigure("L0", "localhost:$(EMULATOR_PORT=)")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 $(IFNOTDEVSIM) $(IFNOTRECSIM) drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "baud", "$(BAUD=9600)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "bits", "$(BITS=7)")

--- a/GEMORC/iocBoot/iocGEMORC-IOC-01/st.cmd
+++ b/GEMORC/iocBoot/iocGEMORC-IOC-01/st.cmd
@@ -36,6 +36,14 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "bits", "$(BITS=8)"
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "parity", "$(PARITY=none)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 ## Load record instances
 
 ##ISIS## Load common DB records 

--- a/HAMEG8123/iocBoot/iocHAMEG8123-IOC-01/st-common.cmd
+++ b/HAMEG8123/iocBoot/iocHAMEG8123-IOC-01/st-common.cmd
@@ -18,6 +18,14 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "1")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynOctetSetInputEos("L0", -1, "\r")                                            
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynOctetSetOutputEos("L0", -1, "\r")                                           
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 ## Load record instances
 
 ##ISIS## Load common DB records 

--- a/HLG/iocBoot/iocHLG-IOC-01/st-common.cmd
+++ b/HLG/iocBoot/iocHLG-IOC-01/st-common.cmd
@@ -16,6 +16,13 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "bits", "$(BITS=8)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "parity", "$(PARITY=none)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "$(STOP=1)")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
 
 ## Load record instances
 

--- a/IEG/iocBoot/iocIEG-IOC-01/st.cmd
+++ b/IEG/iocBoot/iocIEG-IOC-01/st.cmd
@@ -32,6 +32,14 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "bits", "$(BITS=8)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "parity", "$(PARITY=none)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "$(STOP=1)")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 ## Load record instances
 
 ##ISIS## Load common DB records 

--- a/ILM200/iocBoot/iocILM200-IOC-01/st-common.cmd
+++ b/ILM200/iocBoot/iocILM200-IOC-01/st-common.cmd
@@ -17,6 +17,14 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "bits", "$(BITS=8)"
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "parity", "$(PARITY=none)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=2)")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 ## Load record instances
 
 ##ISIS## Load common DB records 

--- a/IPS/iocBoot/iocIPS-IOC-01/st.cmd
+++ b/IPS/iocBoot/iocIPS-IOC-01/st.cmd
@@ -33,6 +33,14 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "bits", "8")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "parity", "none")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "stop", "2")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 ## Load record instances
 
 ##ISIS## Load common DB records 

--- a/ITC503/iocBoot/iocITC503-IOC-01/st.cmd
+++ b/ITC503/iocBoot/iocITC503-IOC-01/st.cmd
@@ -32,6 +32,14 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "bits", "8")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "parity", "none")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "2")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 ##ISIS## Load common DB records 
 < $(IOCSTARTUP)/dbload.cmd
 

--- a/JULABO/iocBoot/iocJULABO-IOC-01/st-common.cmd
+++ b/JULABO/iocBoot/iocJULABO-IOC-01/st-common.cmd
@@ -15,6 +15,14 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "bits", "7")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "parity", "even")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "1")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 ## Load record instances
 
 ##ISIS## Load common DB records 

--- a/KHLY2400/iocBoot/iocKHLY2400-IOC-01/config.xml
+++ b/KHLY2400/iocBoot/iocKHLY2400-IOC-01/config.xml
@@ -10,8 +10,8 @@
 <macro name="STOP" pattern="^[0-9]$" description="Serial communication stop bit, defaults to 1." />
 <macro name="OEOS" pattern="^.*$" description="Serial communication output terminator, defaults to \\r\\n." />
 <macro name="IEOS" pattern="^.*$" description="Serial communication input terminator, defaults to \\r\\n." />
-<macro name="HARDFLOWCNTL" pattern="Y|N" description="Hardware serial communication flow control (RTS/CTS), defaults to N." />
-<macro name="SOFTFLOWCNTL" pattern="Y|N" description="Sotfware serial communication flow control (XON/XOFF) defaults to N." />
+<macro name="HARDFLOWCNTL" pattern="^Y|N$" description="Hardware serial communication flow control (RTS/CTS), defaults to N." />
+<macro name="SOFTFLOWCNTL" pattern="^Y|N$" description="Sotfware serial communication flow control (XON/XOFF) defaults to N." />
 </macros>
 </config_part>
 </ioc_config>

--- a/KHLY2400/iocBoot/iocKHLY2400-IOC-01/config.xml
+++ b/KHLY2400/iocBoot/iocKHLY2400-IOC-01/config.xml
@@ -10,6 +10,8 @@
 <macro name="STOP" pattern="^[0-9]$" description="Serial communication stop bit, defaults to 1." />
 <macro name="OEOS" pattern="^.*$" description="Serial communication output terminator, defaults to \\r\\n." />
 <macro name="IEOS" pattern="^.*$" description="Serial communication input terminator, defaults to \\r\\n." />
+<macro name="HARDFLOWCNTL" pattern="Y|N" description="Hardware serial communication flow control (RTS/CTS), defaults to N." />
+<macro name="SOFTFLOWCNTL" pattern="Y|N" description="Sotfware serial communication flow control (XON/XOFF) defaults to N." />
 </macros>
 </config_part>
 </ioc_config>

--- a/KHLY2400/iocBoot/iocKHLY2400-IOC-01/st-common.cmd
+++ b/KHLY2400/iocBoot/iocKHLY2400-IOC-01/st-common.cmd
@@ -18,6 +18,20 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)"
 asynOctetSetInputEos("$(DEVICE)", -1, "$(IEOS=\\r\\n)")
 asynOctetSetOutputEos("$(DEVICE)", -1, "$(OEOS=\\r\\n)")
 
+## Check if hardware flow control is used
+stringiftest("HARDCNTL", "$(HARDFLOWCNTL=N)",5,"Y")
+
+# Hardware flow control
+$(IFNOTHARDCNTL) $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTHARDCNTL) $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+$(IFHARDCNTL) $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "N")
+$(IFHARDCNTL) $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","Y")
+
+# Software flow control
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","$(SOFTFLOWCNTL=N)") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","$(SOFTFLOWCNTL=N)")
+
 ## Load record instances
 
 ##ISIS## Load common DB records

--- a/KHLY2700/iocBoot/iocKHLY2700-IOC-01/config.xml
+++ b/KHLY2700/iocBoot/iocKHLY2700-IOC-01/config.xml
@@ -8,6 +8,8 @@
 <macro name="BITS" pattern="^[0-9]$" description="Serial communication number of bits, defaults to 8." />
 <macro name="PARITY" pattern="^(even)|(odd)|(none)$" description="Serial communication parity, defaults to none." />
 <macro name="STOP" pattern="^[0-9]$" description="Serial communication stop bit, defaults to 1." />
+<macro name="HARDFLOWCNTL" pattern="Y|N" description="Hardware serial communication flow control (RTS/CTS), defaults to N." />
+<macro name="SOFTFLOWCNTL" pattern="Y|N" description="Sotfware serial communication flow control (XON/XOFF) defaults to N." />
 </macros>
 </config_part>
 </ioc_config>

--- a/KHLY2700/iocBoot/iocKHLY2700-IOC-01/config.xml
+++ b/KHLY2700/iocBoot/iocKHLY2700-IOC-01/config.xml
@@ -8,8 +8,8 @@
 <macro name="BITS" pattern="^[0-9]$" description="Serial communication number of bits, defaults to 8." />
 <macro name="PARITY" pattern="^(even)|(odd)|(none)$" description="Serial communication parity, defaults to none." />
 <macro name="STOP" pattern="^[0-9]$" description="Serial communication stop bit, defaults to 1." />
-<macro name="HARDFLOWCNTL" pattern="Y|N" description="Hardware serial communication flow control (RTS/CTS), defaults to N." />
-<macro name="SOFTFLOWCNTL" pattern="Y|N" description="Sotfware serial communication flow control (XON/XOFF) defaults to N." />
+<macro name="HARDFLOWCNTL" pattern="^Y|N$" description="Hardware serial communication flow control (RTS/CTS), defaults to N." />
+<macro name="SOFTFLOWCNTL" pattern="^Y|N$" description="Sotfware serial communication flow control (XON/XOFF) defaults to N." />
 </macros>
 </config_part>
 </ioc_config>

--- a/KHLY2700/iocBoot/iocKHLY2700-IOC-01/st-common.cmd
+++ b/KHLY2700/iocBoot/iocKHLY2700-IOC-01/st-common.cmd
@@ -14,6 +14,20 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "bits", "$(BITS=8)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "parity", "$(PARITY=none)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "$(STOP=1)")
 
+## Check if hardware flow control is used
+stringiftest("HARDCNTL", "$(HARDFLOWCNTL=N)",5,"Y")
+
+# Hardware flow control
+$(IFNOTHARDCNTL) $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTHARDCNTL) $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+$(IFHARDCNTL) $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "N")
+$(IFHARDCNTL) $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","Y")
+
+# Software flow control
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","$(SOFTFLOWCNTL=N)") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","$(SOFTFLOWCNTL=N)")
+
 # Configurable terminators
 asynOctetSetInputEos("$(DEVICE)", -1, "$(IEOS=\\r\\n)")
 asynOctetSetOutputEos("$(DEVICE)", -1, "$(OEOS=\\r\\n)")

--- a/KYNCTM3K/iocBoot/iocKYNCTM3K-IOC-01/st-common.cmd
+++ b/KYNCTM3K/iocBoot/iocKYNCTM3K-IOC-01/st-common.cmd
@@ -33,9 +33,13 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "bits", "$(BITS=8)"
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "parity", "$(PARITY=none)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)")
 
-## Flow control settings:
+# Hardware flow control off
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
 
 ## Load record instances
 

--- a/LINKAM95/iocBoot/iocLINKAM95-IOC-01/st-common.cmd
+++ b/LINKAM95/iocBoot/iocLINKAM95-IOC-01/st-common.cmd
@@ -20,6 +20,14 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)"
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynOctetSetInputEos("$(DEVICE)", -1, "$(OEOS=\r)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynOctetSetOutputEos("$(DEVICE)", -1, "$(IEOS=\r)")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 asynSetTraceMask("L0",-1,0x9) 
 asynSetTraceIOMask("L0",-1,0x2)
 

--- a/LKSH218/iocBoot/iocLKSH218-IOC-01/st-common.cmd
+++ b/LKSH218/iocBoot/iocLKSH218-IOC-01/st-common.cmd
@@ -17,6 +17,14 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "bits", "7")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "parity", "odd")                                       
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "1")   
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 # Uncomment for debugging                                         
 #asynOctetSetInputEos("L0", -1, "\r")                                            
 #asynOctetSetOutputEos("L0", -1, "\r")                                           

--- a/LKSH460/iocBoot/iocLKSH460-IOC-01/st-common.cmd
+++ b/LKSH460/iocBoot/iocLKSH460-IOC-01/st-common.cmd
@@ -13,6 +13,14 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "bits", "$(BITS=7)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "parity", "$(PARITY=even)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "$(STOP=1)")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 ## Commands for turning on debugging.  Shows traffic on connection.
 #asynSetTraceMask("L0",-1,0x9) 
 #asynSetTraceIOMask("L0",-1,0x2)

--- a/MK2CHOPR/iocBoot/iocMK2CHOPR-IOC-01/st-common.cmd
+++ b/MK2CHOPR/iocBoot/iocMK2CHOPR-IOC-01/st-common.cmd
@@ -17,6 +17,14 @@ $(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)")
 $(IFNOTDEVSIM) asynOctetSetInputEos("$(DEVICE)", -1, "$(OEOS=\r)")
 $(IFNOTDEVSIM) asynOctetSetOutputEos("$(DEVICE)", -1, "$(IEOS=\r)")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 ## Load record instances
 
 ##ISIS## Load common DB records

--- a/NEOCERA/iocBoot/iocNEOCERA-IOC-01/st-common.cmd
+++ b/NEOCERA/iocBoot/iocNEOCERA-IOC-01/st-common.cmd
@@ -9,6 +9,15 @@ $(IFNOTRECSIM) $(IFNOTDEVSIM) asynSetOption("L0", -1, "bits", "8")
 $(IFNOTRECSIM) $(IFNOTDEVSIM) asynSetOption("L0", -1, "parity", "none")
 $(IFNOTRECSIM) $(IFNOTDEVSIM) asynSetOption("L0", -1, "stop", "1")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control on
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","Y") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","Y")
+
+
 $(IFNOTRECSIM) $(IFDEVSIM)  drvAsynIPPortConfigure("L0", "localhost:57677")
 
 < $(IOCSTARTUP)/dbload.cmd

--- a/PDR2000/iocBoot/iocPDR2000-IOC-01/st.cmd
+++ b/PDR2000/iocBoot/iocPDR2000-IOC-01/st.cmd
@@ -42,6 +42,14 @@ asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)")
 asynOctetSetInputEos("$(DEVICE)", -1, "$(OEOS=\n)")
 ## asynOctetSetOutputEos("$(DEVICE)", -1, "$(IEOS=\n)")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 ## Load record instances
 
 ##ISIS## Load common DB records

--- a/RKNDIO/iocBoot/iocRKNDIO-IOC-01/st.cmd
+++ b/RKNDIO/iocBoot/iocRKNDIO-IOC-01/st.cmd
@@ -32,9 +32,11 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "baud", "$(BAUD=960
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "bits", "$(BITS=8)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "parity", "$(PARITY=none)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)")
+
 ## Hardware flow control off
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", 0, "clocal", "Y")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)",0,"crtscts","N")
+
 ## Software flow control off
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)",0,"ixon","N")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)",0,"ixoff","N")

--- a/RKNPS/iocBoot/iocRKNPS-IOC-01/st-common.cmd
+++ b/RKNPS/iocBoot/iocRKNPS-IOC-01/st-common.cmd
@@ -17,6 +17,14 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "$(STOP=1)")
 $(IFNOTRECSIM) asynOctetSetInputEos("L0",0,"$(IEOS=\\n\\r)")
 $(IFNOTRECSIM) asynOctetSetOutputEos("L0",0,"$(OEOS=\\r)")
 
+## Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)",0,"crtscts","N")
+
+## Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)",0,"ixon","N")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)",0,"ixoff","N")
+
 ##ISIS## Load common DB records 
 < $(IOCSTARTUP)/dbload.cmd
 

--- a/ROTSC/iocBoot/iocROTSC-IOC-01/st.cmd
+++ b/ROTSC/iocBoot/iocROTSC-IOC-01/st.cmd
@@ -32,6 +32,14 @@ $(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)")
 $(IFNOTDEVSIM) asynOctetSetInputEos("$(DEVICE)", -1, "\r")          
 $(IFNOTDEVSIM) asynOctetSetOutputEos("$(DEVICE)", -1, "\r")         
 
+## Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)",0,"crtscts","N")
+
+## Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)",0,"ixon","N")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)",0,"ixoff","N")
+
 ## Load record instances
 
 #asynSetTraceIOMask("$(DEVICE)",0,2)

--- a/SKFMB350/iocBoot/iocSKFMB350-IOC-01/st-common.cmd
+++ b/SKFMB350/iocBoot/iocSKFMB350-IOC-01/st-common.cmd
@@ -18,6 +18,15 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "$(STOP=2)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "break_duration", "20")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "break_delay", "20")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
+
 # Need to set these for DEVSIM mode as lewis can't handle not having termination characters.
 $(IFDEVSIM) asynOctetSetOutputEos("L0",0,"\r\n") # Set it to CRLF and hope it is unlikely to ever happen "by accident" in the binary data
 $(IFDEVSIM) asynOctetSetInputEos("L0",0,"\r\n")

--- a/SPINFLIPPER306015/iocBoot/iocSPINFLIPPER-IOC-01/st.cmd
+++ b/SPINFLIPPER306015/iocBoot/iocSPINFLIPPER-IOC-01/st.cmd
@@ -33,6 +33,14 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "parity", "$(PARITY=none)"
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "$(STOP=1)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "crtscts", "N")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 asynOctetSetInputEos("L0", -1, ";")
 asynOctetSetOutputEos("L0", -1, "*")
 

--- a/SPRLG/iocBoot/iocSPRLG-IOC-01/st-common.cmd
+++ b/SPRLG/iocBoot/iocSPRLG-IOC-01/st-common.cmd
@@ -13,6 +13,14 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "bits", "$(BITS=7)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "parity", "$(PARITY=even)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "$(STOP=1)")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 #For debugging
 #asynSetTraceMask("L0",-1,0x9) 
 #asynSetTraceIOMask("L0",-1,0x2)

--- a/TEKDMM40X0/iocBoot/iocTEKDMM4040-IOC-01/st.cmd
+++ b/TEKDMM40X0/iocBoot/iocTEKDMM4040-IOC-01/st.cmd
@@ -25,6 +25,14 @@ asynSetOption("L0", -1, "bits", "8")
 asynSetOption("L0", -1, "parity", "none")
 asynSetOption("L0", -1, "stop", "1")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 ## Load record instances
 
 ##ISIS## Load common DB records 

--- a/TPG26x/iocBoot/iocTPG26x-IOC-01/st-common.cmd
+++ b/TPG26x/iocBoot/iocTPG26x-IOC-01/st-common.cmd
@@ -13,6 +13,14 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "bits", "8")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "parity", "none")   
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "1")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 $(IFNOTRECSIM) asynOctetSetInputEos("L0", -1, "\r\n")
 $(IFNOTRECSIM) asynOctetSetOutputEos("L0", -1, "\r\n")
 

--- a/TPG300/iocBoot/iocTPG300-IOC-01/st-common.cmd
+++ b/TPG300/iocBoot/iocTPG300-IOC-01/st-common.cmd
@@ -16,6 +16,14 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "bits", "8")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "parity", "none")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "1")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 ## Load record instances
 
 ##ISIS## Load common DB records 

--- a/TTIEX355P/iocBoot/iocTTIEX355P-IOC-01/st.cmd
+++ b/TTIEX355P/iocBoot/iocTTIEX355P-IOC-01/st.cmd
@@ -25,6 +25,14 @@ asynSetOption("L0", -1, "bits", "8")
 asynSetOption("L0", -1, "parity", "none")
 asynSetOption("L0", -1, "stop", "1")
 
+# Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
+
+# Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+
 ## Load record instances
 
 ##ISIS## Load common DB records 


### PR DESCRIPTION
### Description of work

Adds explicit flow control settings for all IOCs which need it (i.e. all serial devices)

### To test

https://github.com/ISISComputingGroup/IBEX/issues/3180

### Acceptance criteria

- [ ] All additions to IOCs agree with the [IOC wiki page](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-flow-control-settings)
   - [ ] There are no IOCs missing from the wiki page
- [ ] Keithley IOCs, which have variable flow control settings, can have these set by macro

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
