### PR TITLE
Ticket 3468: Attempted to fix mclennan delay issue

### DIFF
--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/st-common.cmd
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/st-common.cmd
@@ -29,7 +29,7 @@ $(IFNOTSIM) asynSetOption("$(ASERIAL)",0,"bits","$(BITS=7)")
 $(IFNOTSIM) asynSetOption("$(ASERIAL)",0,"stop","$(STOP=1)") 
 $(IFNOTSIM) asynSetOption("$(ASERIAL)",0,"parity","$(PARITY=even)")
 $(IFNOTSIM) asynSetOption("$(ASERIAL)",0,"clocal","Y") 
-$(IFNOTSIM) asynSetOption("$(ASERIAL)",0,"crtscts","N") 
+$(IFNOTSIM) asynSetOption("$(ASERIAL)",0,"crtscts","D") 
 $(IFNOTSIM) asynSetOption("$(ASERIAL)",0,"ixon","N")
 $(IFNOTSIM) asynSetOption("$(ASERIAL)",0,"ixoff","N")
 


### PR DESCRIPTION
### Description of work

See https://github.com/ISISComputingGroup/IBEX/issues/3468.

The problem was fixed by restarting the MOXA. The underlying problem seems to only occur after some time of use, similar to https://github.com/ISISComputingGroup/IBEX/issues/3006. This change brings the handshaking more in line with the Labview in an attempt to fix it.

### To test

Confirm this fix is on VESUVIO and either go down and confirm it moves or trust that I moved it earlier today.

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
