### PR TITLE
Fix misspelled IOC macro

### DIFF
--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/st-motor-init.cmd
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/st-motor-init.cmd
@@ -7,7 +7,7 @@ asynOctetConnect("MKINIT","$(ASERIAL)")
 #asynOctetWrite("MKINIT","$(MN)IN")
 
 ## Check if open loop mode has been requested
-stringiftest("CMOPEN", "$(MODE$(MN)=)",4,"OPEN")
+stringiftest("CMOPEN", "$(CMOD$(MN)=)",5,"OPEN")
 
 ## Initialise control mode. Defaults to CM14, closed
 $(IFCMOPEN) asynOctetWrite("MKINIT","$(MN)CM11")


### PR DESCRIPTION
### Description of work

Changed the name of a macro in the McLennan IOC boot files to appropriately set the Open/Closed stepper mode

### To test

https://github.com/ISISComputingGroup/IBEX/issues/3470

### Acceptance criteria

- [x] Open/Closed stepper mode changes appropriately when IOC macro is set
    - Note this will not be reflected in the status LED in the OPI, but can be verified by issuing command `xQM` over putty, where `x` is an axis number

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
