### PR TITLE
Ticket3623 loq aperture

### DIFF
--- a/GALIL/iocBoot/iocGALIL-IOC-01/st-common.cmd
+++ b/GALIL/iocBoot/iocGALIL-IOC-01/st-common.cmd
@@ -31,7 +31,7 @@ set_requestfile_path("${TOP}/iocBoot/iocGALIL-IOC-01", "")
 ## Make sure controller number is 2 digits long
 calc("MTRCTRL", "$(MTRCTRL)", 2, 2)
 
-epicsEnvSet("GALILCONFIG","$(ICPCONFIGROOT)/galil")
+epicsEnvSet("GALILCONFIG","$(GALILCONFIGDIR=$(ICPCONFIGROOT)/galil)")
 
 ## uncomment to see every command sent to every galil, of define in st.cmd for just one galil
 #epicsEnvSet("GALIL_DEBUG_FILE", "galil_debug.txt")
@@ -58,8 +58,7 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) epicsEnvSet("GALIL_MTR_PORT", "Galil")
 iocshCmdLoop("< st-axis.cmd", "MN=\$(I)", "I", 1, 8)
 
 ## configure jaws
-$(IFNOTTESTRECSIM) < $(GALILCONFIG)/jaws.cmd
-$(IFTESTRECSIM) < $(JAWS)/settings/jaws.cmd
+< $(GALILCONFIG)/jaws.cmd
 
 ## configure barndoors
 < $(GALILCONFIG)/barndoors.cmd
@@ -74,8 +73,7 @@ $(IFTESTRECSIM) < $(JAWS)/settings/jaws.cmd
 < $(GALILCONFIG)/sampleChanger.cmd
 
 # motor extensions
-$(IFNOTTESTDEVSIM) < $(GALILCONFIG)/motorExtensions.cmd
-$(IFTESTDEVSIM) < $(MOTOREXT)/settings/motorExtensions.cmd
+< $(GALILCONFIG)/motorExtensions.cmd
 
 ## motor util package
 dbLoadRecords("$(MOTOR)/db/motorUtil.db","P=$(MYPVPREFIX)$(IOCNAME):,$(IFIOC)= ,PVPREFIX=$(MYPVPREFIX)")


### PR DESCRIPTION
### Description of work

Removes the simulation specific commands which execute when the IOC is booting in favour of an IOC macro, set in the IOC test framework. This points to a directory in motorExtensions/settings which contains the minimum required files for the IOC to boot. 

### To test
https://github.com/ISISComputingGroup/IBEX/issues/3623

### Acceptance criteria

- [ ] All unit tests of existing motor extensions still boot and pass (will also need to have pulled https://github.com/ISISComputingGroup/EPICS-motorExtensions/pull/20)

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [x] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [x] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [x] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [x] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
