### PR TITLE
Ticket2133 multiple calibration directories

### DIFF
--- a/DFKPS/iocBoot/iocDFKPS-IOC-01/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-01/config.xml
@@ -9,8 +9,6 @@
 
     <macro name="CALIBRATED" pattern="^(0|1)$" description="1 to use calibration file, 0 otherwise; defaults to 1" />
     <macro name="CALIB_FILE" description="Name of calibration File; defaults to default_calib.dat" />
-    <macro name="CALIB_DIR" description="Calibration directory for magnets; defaults to magnets" />
-    <macro name="CALIB_BASE_DIR" description="Common calibrations directory; defaults to C:/Instrument/Settings/config/common" />
 	<macro name="DEV_TYPE" pattern="^(8800|8000)$" description="Type of danfysik; default 8000" />
     <macro name="SP_AT_STARTUP" pattern="^(YES|NO)$" description="Apply last setpoints at startup; defaults to NO" />
 	
@@ -19,6 +17,7 @@
 	<macro name="FACTOR_READ_V" pattern="^-?[0-9]+\.?[0-9]*$" description="Factor to apply when converting reading to voltage; defaults to 1" />
 	<macro name="FACTOR_WRITE_I" pattern="^-?[0-9]+\.?[0-9]*$" description="Factor to apply when converting current to set value; defaults to 1000" />
 	
+    <macro name="LOCAL_CALIB" pattern="^(yes)|(no)$" description="Use local instrument calibration directory instead of common one? Default is NO." />
 </macros>
 </config_part>
 </ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-01/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-01/config.xml
@@ -17,7 +17,7 @@
 	<macro name="FACTOR_READ_V" pattern="^-?[0-9]+\.?[0-9]*$" description="Factor to apply when converting reading to voltage; defaults to 1" />
 	<macro name="FACTOR_WRITE_I" pattern="^-?[0-9]+\.?[0-9]*$" description="Factor to apply when converting current to set value; defaults to 1000" />
 	
-    <macro name="LOCAL_CALIB" pattern="^(yes)|(no)$" description="Use local instrument calibration directory instead of common one? Default is NO." />
+    <macro name="LOCAL_CALIB" pattern="^(yes)|(no)$" description="Use local instrument calibration directory instead of common one? Default is no." />
 </macros>
 </config_part>
 </ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-01/st-common.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-01/st-common.cmd
@@ -1,11 +1,17 @@
-## Environment Variables
 
-epicsEnvSet "CALIB_BASE_DIR" "C:/Instrument/Settings/config/common"
-epicsEnvSet "CALIB_DIR" "magnets"
-epicsEnvSet "CALIB_FILE" "default_calib.dat"
 
 ##ISIS## Run IOC initialisation 
 < $(IOCSTARTUP)/init.cmd
+
+stringiftest  "LOCALCALIB"  "$(LOCAL_CALIB="no")"  5  "yes"
+
+## Environment Variables
+
+$(IFNOTLOCALCALIB) epicsEnvSet "CALIB_BASE_DIR" "C:/Instrument/Settings/config/common"
+$(IFNOTLOCALCALIB) epicsEnvSet "CALIB_DIR" "magnets"
+
+$(IFLOCALCALIB) epicsEnvSet "CALIB_BASE_DIR" "C:/Instrument/Settings/config/$(INSTRUMENT)"
+$(IFLOCALCALIB) epicsEnvSet "CALIB_DIR" "calib/magnets"
 
 epicsEnvSet "STREAM_PROTOCOL_PATH" "$(DANFYSIK8000)/master/danfysikMps8000App/protocol/:$(DANFYSIK8000)/master/danfysikMps8000App/protocol/DFK$(DEV_TYPE=8000)/"
 
@@ -43,7 +49,7 @@ epicsEnvSet "SP_PINI" "$(SP_AT_STARTUP=NO)"
 ## Load record instances
 dbLoadRecords("$(TOP)/db/DFKPS_common.db", "device=$(MYPVPREFIX)$(IOCNAME), P=$(MYPVPREFIX)$(IOCNAME):, FWI=$(FACTOR_WRITE_I=1000), FRI=$(FACTOR_READ_I=1), FRV=$(FACTOR_READ_V=1), port=L0,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),SP_PINI=$(SP_PINI), VADC=$(VADC=2), DEV_TYPE=$(DEV_TYPE=8000), CALIBRATED=$(CALIBRATED=1), POLARITY=$(POLARITY=BIPOLAR)")
 $(IFPOLAR) dbLoadRecords("$(TOP)/db/DFKPS_polarity.db", "device=$(MYPVPREFIX)$(IOCNAME), P=$(MYPVPREFIX)$(IOCNAME):, port=L0")
-$(IFCALIB) dbLoadRecords("$(TOP)/db/DFKPS_calibrated.db", "device=$(MYPVPREFIX)$(IOCNAME), P=$(MYPVPREFIX)$(IOCNAME):, CALIB_BASE_DIR=$(CALIB_BASE_DIR),CALIB_DIR=$(CALIB_DIR),CALIB_FILE=$(CALIB_FILE),DRVHI=$(DRIVE_HIGH=5000000),DRVLO=$(DRIVE_LOW=-5000000), port=L0")
+$(IFCALIB) dbLoadRecords("$(TOP)/db/DFKPS_calibrated.db", "device=$(MYPVPREFIX)$(IOCNAME), P=$(MYPVPREFIX)$(IOCNAME):, CALIB_BASE_DIR=$(CALIB_BASE_DIR),CALIB_DIR=$(CALIB_DIR),CALIB_FILE=$(CALIB_FILE=default_calib.dat),DRVHI=$(DRIVE_HIGH=5000000),DRVLO=$(DRIVE_LOW=-5000000), port=L0")
 $(IFSLEW) dbLoadRecords("$(TOP)/db/DFKPS_slew.db", "device=$(MYPVPREFIX)$(IOCNAME), P=$(MYPVPREFIX)$(IOCNAME):, port=L0")
 
 ## Load device type specific st.cmd

--- a/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/config.xml
+++ b/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/config.xml
@@ -17,6 +17,7 @@
 <macro name="ADDR_6" pattern="^[0-9]{1,2}$" description="Address for the 6th Eurotherm on this port e.g. 06. Blank for do not use." />
 <macro name="ADDR_7" pattern="^[0-9]{1,2}$" description="Address for the 7th Eurotherm on this port e.g. 07. Blank for do not use." />
 
+<macro name="LOCAL_CALIB" pattern="^(yes)|(no)$" description="Use local instrument calibration directory instead of common one? Default is NO." />
 </macros>
 </config_part>
 </ioc_config>

--- a/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/config.xml
+++ b/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/config.xml
@@ -17,7 +17,7 @@
 <macro name="ADDR_6" pattern="^[0-9]{1,2}$" description="Address for the 6th Eurotherm on this port e.g. 06. Blank for do not use." />
 <macro name="ADDR_7" pattern="^[0-9]{1,2}$" description="Address for the 7th Eurotherm on this port e.g. 07. Blank for do not use." />
 
-<macro name="LOCAL_CALIB" pattern="^(yes)|(no)$" description="Use local instrument calibration directory instead of common one? Default is NO." />
+<macro name="LOCAL_CALIB" pattern="^(yes)|(no)$" description="Use local instrument calibration directory instead of common one? Default is no." />
 </macros>
 </config_part>
 </ioc_config>

--- a/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-common.cmd
+++ b/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-common.cmd
@@ -3,12 +3,16 @@
 stringiftest  "LOCALCALIB"  "$(LOCAL_CALIB="no")"  5  "yes"
 
 $(IFNOTLOCALCALIB) epicsEnvSet "CALIB_BASE_DIR" "C:/Instrument/Settings/config/common"
-$(IFLOCALCALIB) epicsEnvSet "CALIB_BASE_DIR" "$(ICPCONFIGBASE)/NDXPOLARIS"
-epicsEnvSet "STREAM_PROTOCOL_PATH" "$(EUROTHERM2K)/data"
-epicsEnvSet "SENS_DIR" "temp_sensors"
+$(IFNOTLOCALCALIB) epicsEnvSet "SENS_DIR" "temp_sensors"
+$(IFNOTLOCALCALIB) epicsEnvSet "RAMP_DIR" "$(CALIB_BASE_DIR)/ramps"
+
+$(IFLOCALCALIB) epicsEnvSet "CALIB_BASE_DIR" "$(ICPCONFIGBASE)/$(INSTRUMENT)"
+$(IFLOCALCALIB) epicsEnvSet "SENS_DIR" "calib/temp_sensors"
+$(IFLOCALCALIB) epicsEnvSet "RAMP_DIR" "$(CALIB_BASE_DIR)/calib/ramps"
+
 epicsEnvSet "SENS_PAT" "^C.*"
-epicsEnvSet "RAMP_DIR" "$(CALIB_BASE_DIR)/ramps"
 epicsEnvSet "RAMP_PAT" ".*"
+epicsEnvSet "STREAM_PROTOCOL_PATH" "$(EUROTHERM2K)/data"
 
 ## Use the example ramp file
 $(IFDEVSIM) epicsEnvSet "RAMP_DIR" "$(READASCII)/example_settings"

--- a/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-common.cmd
+++ b/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-common.cmd
@@ -1,6 +1,8 @@
+stringiftest  "LOCALCALIB"  "$(LOCAL_CALIB="no")"  5  "yes"
 
+$(IFNOTLOCALCALIB) epicsEnvSet "CALIB_BASE_DIR" "C:/Instrument/Settings/config/common"
+$(IFLOCALCALIB) epicsEnvSet "CALIB_BASE_DIR" "$(ICPCONFIGROOT)/calib"
 epicsEnvSet "STREAM_PROTOCOL_PATH" "$(EUROTHERM2K)/data"
-epicsEnvSet "CALIB_BASE_DIR" "C:/Instrument/Settings/config/common"
 epicsEnvSet "SENS_DIR" "temp_sensors"
 epicsEnvSet "SENS_PAT" "^C.*"
 epicsEnvSet "RAMP_DIR" "$(CALIB_BASE_DIR)/ramps"

--- a/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-common.cmd
+++ b/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-common.cmd
@@ -1,14 +1,14 @@
+< $(IOCSTARTUP)/init.cmd
+
 stringiftest  "LOCALCALIB"  "$(LOCAL_CALIB="no")"  5  "yes"
 
 $(IFNOTLOCALCALIB) epicsEnvSet "CALIB_BASE_DIR" "C:/Instrument/Settings/config/common"
-$(IFLOCALCALIB) epicsEnvSet "CALIB_BASE_DIR" "$(ICPCONFIGROOT)/calib"
+$(IFLOCALCALIB) epicsEnvSet "CALIB_BASE_DIR" "$(ICPCONFIGBASE)/NDXPOLARIS"
 epicsEnvSet "STREAM_PROTOCOL_PATH" "$(EUROTHERM2K)/data"
 epicsEnvSet "SENS_DIR" "temp_sensors"
 epicsEnvSet "SENS_PAT" "^C.*"
 epicsEnvSet "RAMP_DIR" "$(CALIB_BASE_DIR)/ramps"
 epicsEnvSet "RAMP_PAT" ".*"
-
-< $(IOCSTARTUP)/init.cmd
 
 ## Use the example ramp file
 $(IFDEVSIM) epicsEnvSet "RAMP_DIR" "$(READASCII)/example_settings"


### PR DESCRIPTION
### Description of work

Added macro to Eurotherm and Danfysik IOCs for setting the calibration directory to a local one instead of the default common directory.

Also removed macros from Danfysik IOCs for setting arbitrary calibration dirs. It's not currently used anywhere as far as I can see and users might accidentally break the IOC if either of the entered value exceeds the EPICS 40 character limit.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2133

### Acceptance criteria

For both Eurotherm and Danfysik IOCs:
- [x] `LOCAL_CALIB` macro set to "no": IOC uses the common calibration directory
- [x] `LOCAL_CALIB` macro set to "yes": IOC uses the local calibration directory
- [x] `LOCAL_CALIB` macro defaults to "no"
- [x] OPI shows calibration directory currently in use (Eurotherm only)

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [x] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [x] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
