### PR TITLE
Updated db's to include an alarm field.

### DIFF
--- a/AG33220A/AG33220A-IOC-01App/Db/agilent33220A.db
+++ b/AG33220A/AG33220A-IOC-01App/Db/agilent33220A.db
@@ -113,6 +113,7 @@ record(ai, "$(P)FREQUENCY")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:FREQUENCY")
     field(SDIS, "$(P)DISABLE")
+	field(alarm, "AG33220A")
 }
 
 record(ao, "$(P)FREQUENCY:SP")

--- a/AG3631A/AG3631A-IOC-01App/Db/devagilent3631A.db
+++ b/AG3631A/AG3631A-IOC-01App/Db/devagilent3631A.db
@@ -87,6 +87,7 @@ record(bi, "$(P)OUTPUT_STATUS")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:CURRENT")
     field(SDIS, "$(P)DISABLE")
+	field(alarm, "AG3631A")
 }
 
 record(bo, "$(P)OUTPUT_STATUS:SP")

--- a/AG53220A/AG53220A-IOC-01App/Db/Agilent_53220A.db
+++ b/AG53220A/AG53220A-IOC-01App/Db/Agilent_53220A.db
@@ -42,6 +42,7 @@ record(bi, "$(P)COUNTING")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:COUNTING")
     field(SDIS, "$(P)DISABLE")
+	info(alarm, "AG53220A")
 }
 
 record(bo, "$(P)START:SP")

--- a/CCD100/CCD100-IOC-01App/Db/CCD100.db
+++ b/CCD100/CCD100-IOC-01App/Db/CCD100.db
@@ -38,6 +38,7 @@ record(ai, "$(P)READING")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:READING")
     field(SDIS, "$(P)DISABLE")
+	field(alarm, "CCD100")
 }
 
 record(ao, "$(P)SP")

--- a/CRYVALVE/CRYVALVE-IOC-01App/Db/CRYVALVE.db
+++ b/CRYVALVE/CRYVALVE-IOC-01App/Db/CRYVALVE.db
@@ -43,6 +43,7 @@ record(stringin, "$(P)STAT")
     info(INTEREST, "HIGH")
 	info(archive, "VAL")
     field(DESC, "Iris cryo valve status")
+	
 }
 
 # Preserve old PV for backwards-compatibility

--- a/CYBAMAN/CYBAMAN-IOC-01App/Db/cybaman.db
+++ b/CYBAMAN/CYBAMAN-IOC-01App/Db/cybaman.db
@@ -26,6 +26,7 @@ record(bo, "$(P)INITIALIZE")
 	field(OUT, "@devcybaman.proto initialize $(PORT)")
 	field(FLNK, "$(P)_SET_INITIALIZED_TRUE")
 	info(INTEREST, "MEDIUM")
+	field(alarm, "CYBAMAN")
 }
 
 record(bo, "$(P)RESET")

--- a/DELFTARDUSTEP/DELFTARDUSTEP-IOC-01App/Db/DELFTARDUSTEP-IOC-01.db
+++ b/DELFTARDUSTEP/DELFTARDUSTEP-IOC-01App/Db/DELFTARDUSTEP-IOC-01.db
@@ -30,4 +30,5 @@ record(bi, "$(P)RUNNING")
    field(SCAN, ".1 second")
    field(ZNAM, "NO")
    field(ONAM, "YES")
+   info(alarm, "DELFTARDUSTEP"
 }


### PR DESCRIPTION
### Description of work

https://github.com/ISISComputingGroup/IBEX/issues/3868

Updated multiple IOC's to include the alarm field so that they will correctly display in the alarm view perspective. Unit tests were also implemented to ensure this behaviour is emulated in lewis.

### To test

- https://github.com/ISISComputingGroup/EPICS-DeviceEmulator/pull/9
- https://github.com/ISISComputingGroup/EPICS-IOC_Test_Framework/pull/139

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
