### PR TITLE
Ticket3262: Updated config to have clear description and second ioc redirect.

### DIFF
--- a/KNR1050/iocBoot/iocKNR1050-IOC-01/config.xml
+++ b/KNR1050/iocBoot/iocKNR1050-IOC-01/config.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
 <config_part>
-<ioc_desc>This is a template description</ioc_desc>
-<ioc_details>These are template details</ioc_details>
+<ioc_desc>Knauer 1050 HPLC Pump</ioc_desc>
+<ioc_details>Knauer Smart line high pressure liquid chromatography pump.</ioc_details>
 <macros>
 <macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM port" />
 </macros>

--- a/KNR1050/iocBoot/iocKNR1050-IOC-02/config.xml
+++ b/KNR1050/iocBoot/iocKNR1050-IOC-02/config.xml
@@ -1,12 +1,4 @@
 <?xml version="1.0" ?>
 <ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
-<config_part>
-<ioc_desc>This is a template description</ioc_desc>
-<ioc_details>These are template details</ioc_details>
-<macros>
-<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM port" />
-</macros>
-<pvsets>
-</pvsets>
-</config_part>
+<xi:include href="../iocKNR1050-IOC-01/config.xml" />
 </ioc_config>


### PR DESCRIPTION
### Description of work

Rework based on the linked ticket.

- Changed the config.xml to include a correct device name and description
- Updated KNR1050_02 device to include a redirect in the config.xml to read from the _01 devices's config.xml


### To test

Fixes: https://github.com/ISISComputingGroup/IBEX/issues/3262

### Acceptance criteria

- A correct device name and description is shown in the IBEX GUI ioc configuration and device manager screens.

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [x] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [x] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [x] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [x] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
