### PR TITLE
Ticket3770 check when reading is out of range

### DIFF
--- a/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
+++ b/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
@@ -1038,6 +1038,13 @@ record(ai, "$(P)LOWLIM") {
     field(PREC, "3")
 }
 
+record(calc, "$(P)TEMP:RANGE:UNDER") {
+    field(DESC, "TEMP lower than min calibration value")
+    field(INPA, "$(P)TEMP CP")
+    # B is written to by the CAL:RANGE aSub record
+    field(CALC, "A < B")
+}
+
 ### SIMULATION RECORDS ###
 
 record(ai, "$(P)SIM:MAX_OUTPUT")

--- a/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
+++ b/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
@@ -1041,8 +1041,15 @@ record(ai, "$(P)LOWLIM") {
 record(calc, "$(P)TEMP:RANGE:UNDER") {
     field(DESC, "TEMP lower than min calibration value")
     field(INPA, "$(P)TEMP CP")
-    # B is written to by the CAL:RANGE aSub record
+    # B is the minimum calibration value written to by the CAL:RANGE aSub record
     field(CALC, "A < B")
+}
+
+record(calc, "$(P)TEMP:RANGE:OVER") {
+    field(DESC, "TEMP higher than max calibration value")
+    field(INPA, "$(P)TEMP CP")
+    # B is the maximum calibration value written to by the CAL:RANGE aSub record
+    field(CALC, "B < A")
 }
 
 ### SIMULATION RECORDS ###

--- a/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-common.cmd
+++ b/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-common.cmd
@@ -40,6 +40,9 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "$(STOP=1)")
 
 $(IFDEVSIM) asynOctetSetOutputEos("L0", -1, "\r\n")
 
+asynSetTraceIOMask("L0", -1, 0x2)
+asynSetTraceMask("L0", -1, 0x9)
+
 < $(IOCSTARTUP)/dbload.cmd
 
 ## Load the sim and disable records

--- a/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-common.cmd
+++ b/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-common.cmd
@@ -40,9 +40,6 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "$(STOP=1)")
 
 $(IFDEVSIM) asynOctetSetOutputEos("L0", -1, "\r\n")
 
-asynSetTraceIOMask("L0", -1, 0x2)
-asynSetTraceMask("L0", -1, 0x9)
-
 < $(IOCSTARTUP)/dbload.cmd
 
 ## Load the sim and disable records

--- a/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-euro.cmd
+++ b/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-euro.cmd
@@ -27,6 +27,6 @@ $(IFACTIVE) dbLoadRecords("$(ReadASCII)/db/get_metadata.db","DIR=$(P)TEMP,CAL=$(
 $(IFACTIVE) dbLoadRecords("$(ReadASCII)/db/get_metadata.db","DIR=$(P)TEMP,CAL=$(P)CAL:RBV,OUT=$(P)RATE:UPDATE_EGU,OUTF=AA,NAME=column1_units,DEFAULT=K,OUTPP=PP")
 
 # Load calibration range
-$(IFACTIVE) dbLoadRecords("$(UTILITIES)/db/calibration_range.db","P=$(P), BDIR=TEMP.BDIR,TDIR=TEMP.TDIR,SPEC=TEMP.SPEC,HIGH_PV=TEMP.HIHI,LOW_PV=TEMP.LOLO")
+$(IFACTIVE) dbLoadRecords("$(UTILITIES)/db/calibration_range.db","P=$(P), BDIR=TEMP.BDIR,TDIR=TEMP.TDIR,SPEC=TEMP.SPEC,HIGH_PV=TEMP:RANGE:UNDER.C,LOW_PV=TEMP:RANGE:UNDER.B")
 
 dbLoadRecords("$(TOP)/db/isActiveEurothrm.db","P=$(P), IFACTIVE=$(IFACTIVE), IFNOTACTIVE=$(IFNOTACTIVE)")

--- a/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-euro.cmd
+++ b/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-euro.cmd
@@ -26,5 +26,7 @@ $(IFACTIVE) dbLoadRecords("$(ReadASCII)/db/get_metadata.db","DIR=$(P)TEMP,CAL=$(
 $(IFACTIVE) dbLoadRecords("$(ReadASCII)/db/get_metadata.db","DIR=$(P)TEMP,CAL=$(P)CAL:RBV,OUT=$(P)TEMP:SP:RBV,OUTF=EGU,NAME=column1_units,DEFAULT=K")
 $(IFACTIVE) dbLoadRecords("$(ReadASCII)/db/get_metadata.db","DIR=$(P)TEMP,CAL=$(P)CAL:RBV,OUT=$(P)RATE:UPDATE_EGU,OUTF=AA,NAME=column1_units,DEFAULT=K,OUTPP=PP")
 
+# Load calibration range
+$(IFACTIVE) dbLoadRecords("$(UTILITIES)/db/calibration_range.db","P=$(P), BDIR=TEMP.BDIR,TDIR=TEMP.TDIR,SPEC=TEMP.SPEC,HIGH_PV=TEMP.HIHI,LOW_PV=TEMP.LOLO")
 
 dbLoadRecords("$(TOP)/db/isActiveEurothrm.db","P=$(P), IFACTIVE=$(IFACTIVE), IFNOTACTIVE=$(IFNOTACTIVE)")

--- a/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-euro.cmd
+++ b/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-euro.cmd
@@ -27,6 +27,6 @@ $(IFACTIVE) dbLoadRecords("$(ReadASCII)/db/get_metadata.db","DIR=$(P)TEMP,CAL=$(
 $(IFACTIVE) dbLoadRecords("$(ReadASCII)/db/get_metadata.db","DIR=$(P)TEMP,CAL=$(P)CAL:RBV,OUT=$(P)RATE:UPDATE_EGU,OUTF=AA,NAME=column1_units,DEFAULT=K,OUTPP=PP")
 
 # Load calibration range
-$(IFACTIVE) dbLoadRecords("$(UTILITIES)/db/calibration_range.db","P=$(P), BDIR=TEMP.BDIR,TDIR=TEMP.TDIR,SPEC=TEMP.SPEC,HIGH_PV=TEMP:RANGE:UNDER.C,LOW_PV=TEMP:RANGE:UNDER.B")
+$(IFACTIVE) dbLoadRecords("$(UTILITIES)/db/calibration_range.db","P=$(P), BDIR=TEMP.BDIR,TDIR=TEMP.TDIR,SPEC=TEMP.SPEC,HIGH_PV=TEMP:RANGE:OVER.B,LOW_PV=TEMP:RANGE:UNDER.B")
 
 dbLoadRecords("$(TOP)/db/isActiveEurothrm.db","P=$(P), IFACTIVE=$(IFACTIVE), IFNOTACTIVE=$(IFNOTACTIVE)")


### PR DESCRIPTION
### Description of work

- Added two PVs for each active Eurotherm to check if the temperature is above or below the max or min values of the calibration file selected for that active Eurotherm.
- Load in a `calibration_range` aSub record for each active Eurotherm to check the calibration file for that Eurotherm.

### To test
[#3770](https://github.com/ISISComputingGroup/ibex_gui/pull/842)

### Acceptance criteria

- [x] All IOC tests for the Eurotherm pass
- [x] The logic for these PVs is correct.

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [x] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [x] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [x] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [x] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [x] Devsim mode
    - [x] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
