### PR TITLE
Make stability volatge a macro

### DIFF
--- a/IPS/IPS-IOC-01App/Db/ips.db
+++ b/IPS/IPS-IOC-01App/Db/ips.db
@@ -236,7 +236,7 @@ record(compress, "$(P)SUPPLY:VOLT:_STABILITY:HIGH") {
 record(calcout, "$(P)SUPPLY:VOLT:_STABILITY:CALC") {
   field(INPA, "$(P)SUPPLY:VOLT:_STABILITY:HIGH")
   field(INPB, "$(P)SUPPLY:VOLT:_STABILITY:LOW")
-  field(CALC, "ABS(A-B)<1.0")
+  field(CALC, "ABS(A-B)<$(STABILITY_VOLTAGE)")
   field(OUT, "$(P)SUPPLY:VOLT:STABLE PP")
   field(OOPT, "Every Time")
 }

--- a/IPS/iocBoot/iocIPS-IOC-01/config.xml
+++ b/IPS/iocBoot/iocIPS-IOC-01/config.xml
@@ -5,6 +5,8 @@
 <ioc_details></ioc_details>
 <macros>
 <macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" />
+<macro name="STABILITY_VOLTAGE" pattern="^[0-9]+\.?[0-9]*$" description="Voltage difference under which the voltage is declared stable (default: 0.1)" />
+
 </macros>
 <pvsets>
 </pvsets>

--- a/IPS/iocBoot/iocIPS-IOC-01/config.xml
+++ b/IPS/iocBoot/iocIPS-IOC-01/config.xml
@@ -2,11 +2,12 @@
 <ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
 <config_part>
 <ioc_desc>Oxford Instruments IPS</ioc_desc>
-<ioc_details></ioc_details>
+<ioc_details>For info and setting see https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OxfordInstrumentsIPS</ioc_details>
 <macros>
 <macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" />
 <macro name="STABILITY_VOLTAGE" pattern="^[0-9]+\.?[0-9]*$" description="Voltage difference under which the voltage is declared stable (default: 0.1)" />
-
+<macro name="MAX_FIELD" pattern="^[0-9]+\.?[0-9]*$" description="Largest permissible field (default: 7.0)" />
+<macro name="MAX_SWEEP_RATE" pattern="^[0-9]+\.?[0-9]*$" description="Greatest  permissible field sweep rate (default: 1.0)" />
 </macros>
 <pvsets>
 </pvsets>

--- a/IPS/iocBoot/iocIPS-IOC-01/st.cmd
+++ b/IPS/iocBoot/iocIPS-IOC-01/st.cmd
@@ -49,7 +49,7 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
 epicsEnvSet("P", "$(MYPVPREFIX)$(IOCNAME):")
 
 ## Load our record instances
-dbLoadRecords("db/ips.db","PVPREFIX=$(MYPVPREFIX),P=$(P),RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),PORT=$(DEVICE),MAX_FIELD=7.0,MAX_SWEEP_RATE=1.0,STABILITY_VOLTAGE=$(STABILITY_VOLTAGE=0.1)")
+dbLoadRecords("db/ips.db","PVPREFIX=$(MYPVPREFIX),P=$(P),RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),PORT=$(DEVICE),MAX_FIELD=$(MAX_FIELD=7.0),MAX_SWEEP_RATE=$(MAX_SWEEP_RATE=1.0),STABILITY_VOLTAGE=$(STABILITY_VOLTAGE=0.1)")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd

--- a/IPS/iocBoot/iocIPS-IOC-01/st.cmd
+++ b/IPS/iocBoot/iocIPS-IOC-01/st.cmd
@@ -49,7 +49,7 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
 epicsEnvSet("P", "$(MYPVPREFIX)$(IOCNAME):")
 
 ## Load our record instances
-dbLoadRecords("db/ips.db","PVPREFIX=$(MYPVPREFIX),P=$(P),RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),PORT=$(DEVICE),MAX_FIELD=7.0,MAX_SWEEP_RATE=1.0")
+dbLoadRecords("db/ips.db","PVPREFIX=$(MYPVPREFIX),P=$(P),RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),PORT=$(DEVICE),MAX_FIELD=7.0,MAX_SWEEP_RATE=1.0,STABILITY_VOLTAGE=$(STABILITY_VOLTAGE=0.1)")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd


### PR DESCRIPTION
### Description of work

Add stability voltage macro and set the default to 0.1V as seen in the Labview (adjusted from 1V originally).
Add settings for sweep and max field. Table created in https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OxfordInstrumentsIPS.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2765

### Acceptance criteria

1) Stability voltage can be set as a macro
1) Calc show stability voltage is set.

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
