### PR TITLE
Ticket4063 keithley ux improvements

### DIFF
--- a/KHLY2400/KHLY2400-IOC-01App/Db/KHLY2400.db
+++ b/KHLY2400/KHLY2400-IOC-01App/Db/KHLY2400.db
@@ -108,7 +108,6 @@ record(seq, "$(P)_READ_MODES") {
     field(LNK5, "$(P)RES:RANGE.PROC")
     field(LNK6, "$(P)SOURCE:MODE.PROC")
     field(LNK7, "$(P)CURR:COMPLIANCE.PROC")
-    #field(LNK8, "$(P)_READ_SOURCES.PROC")
 
     field(SELM, "All")
 }
@@ -143,9 +142,6 @@ record(seq, "$(P)_READ_SOURCES") {
     field(LNK5, "$(P)VOLT:SOURCE:AUTORANGE.PROC")
     field(LNK6, "$(P)CURR:SOURCE:RANGE.PROC")
     field(LNK7, "$(P)VOLT:SOURCE:RANGE.PROC")
-    #field(LNK8, "$(P)_READ_MEASUR_SETTINGS.PROC")
-
-
 
     field(SELM, "All")
 }
@@ -177,8 +173,6 @@ record(seq, "$(P)_READ_MEASUR_SETTINGS") {
     field(LNK2, "$(P)CURR:MEAS:AUTORANGE.PROC")
     field(LNK3, "$(P)VOLT:MEAS:RANGE.PROC")
     field(LNK4, "$(P)CURR:MEAS:RANGE.PROC")
-    #field(LNK8, "$(P)_READ_MODES.PROC")
-
 
     field(SELM, "All")
 }

--- a/KHLY2400/KHLY2400-IOC-01App/Db/KHLY2400.db
+++ b/KHLY2400/KHLY2400-IOC-01App/Db/KHLY2400.db
@@ -52,6 +52,7 @@ record(bo, "$(P)OUTPUT:MODE:SP") {
     field(SDIS, "$(P)DISABLE")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:OUTPUT:MODE:SP")
+    field(FLNK, "$(P)OUTPUT:MODE")
     info(archive, "VAL")
 }
 
@@ -107,7 +108,7 @@ record(seq, "$(P)_READ_MODES") {
     field(LNK5, "$(P)RES:RANGE.PROC")
     field(LNK6, "$(P)SOURCE:MODE.PROC")
     field(LNK7, "$(P)CURR:COMPLIANCE.PROC")
-    field(LNK8, "$(P)_READ_SOURCES.PROC")
+    #field(LNK8, "$(P)_READ_SOURCES.PROC")
 
     field(SELM, "All")
 }
@@ -142,7 +143,7 @@ record(seq, "$(P)_READ_SOURCES") {
     field(LNK5, "$(P)VOLT:SOURCE:AUTORANGE.PROC")
     field(LNK6, "$(P)CURR:SOURCE:RANGE.PROC")
     field(LNK7, "$(P)VOLT:SOURCE:RANGE.PROC")
-    field(LNK8, "$(P)_READ_MEASUR_SETTINGS.PROC")
+    #field(LNK8, "$(P)_READ_MEASUR_SETTINGS.PROC")
 
 
 
@@ -151,7 +152,7 @@ record(seq, "$(P)_READ_SOURCES") {
 
 record(seq, "$(P)_READ_MEASUR_SETTINGS") {
 
-    field(SCAN, "5 second")
+    field(SCAN, "10 second")
 
     field(DO1, "1")
     field(DO2, "1")
@@ -176,7 +177,7 @@ record(seq, "$(P)_READ_MEASUR_SETTINGS") {
     field(LNK2, "$(P)CURR:MEAS:AUTORANGE.PROC")
     field(LNK3, "$(P)VOLT:MEAS:RANGE.PROC")
     field(LNK4, "$(P)CURR:MEAS:RANGE.PROC")
-    field(LNK8, "$(P)_READ_MODES.PROC")
+    #field(LNK8, "$(P)_READ_MODES.PROC")
 
 
     field(SELM, "All")
@@ -438,6 +439,7 @@ record(bo, "$(P)OCOM:SP") {
     field(SDIS, "$(P)DISABLE")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:OCOM:SP")
+    field(FLNK, "$(P)OCOM")
     info(archive, "VAL")
 }
 
@@ -481,6 +483,7 @@ record(bo, "$(P)RES:MODE:SP") {
     field(SDIS, "$(P)DISABLE")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:RES:MODE:SP")
+    field(FLNK, "$(P)RES:MODE")
     info(archive, "VAL")
 }
 
@@ -524,6 +527,7 @@ record(bo, "$(P)SENS:MODE:SP") {
     field(SDIS, "$(P)DISABLE")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:SENS:MODE:SP")
+    field(FLNK, "$(P)SENS:MODE")
     info(archive, "VAL")
 }
 
@@ -567,6 +571,7 @@ record(bo, "$(P)RES:RANGE:AUTO:SP") {
     field(SDIS, "$(P)DISABLE")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:RES:RANGE:AUTO:SP")
+    field(FLNK, "$(P)RES:RANGE:AUTO")
     info(archive, "VAL")
 }
 
@@ -646,6 +651,7 @@ record(bo, "$(P)SOURCE:MODE:SP") {
     field(SDIS, "$(P)DISABLE")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:SOURCE:MODE:SP")
+    field(FLNK, "$(P)SOURCE:MODE")
     info(archive, "VAL")
 }
 
@@ -690,6 +696,7 @@ record(ao, "$(P)CURR:COMPLIANCE:SP")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:CURR:COMPLIANCE:SP")
     field(SDIS, "$(P)DISABLE")
+    field(FLNK, "$(P)CURR:COMPLIANCE")
     info(archive, "VAL")
 }
 
@@ -735,6 +742,7 @@ record(ao, "$(P)VOLT:COMPLIANCE:SP")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:VOLT:COMPLIANCE:SP")
     field(SDIS, "$(P)DISABLE")
+    field(FLNK, "$(P)VOLT:COMPLIANCE")
     info(archive, "VAL")
 }
 
@@ -778,6 +786,7 @@ record(ao, "$(P)CURR:MEAS:RANGE:SP")
     field(SDIS, "$(P)DISABLE")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:CURR:MEAS:RANGE:SP")
+    field(FLNK, "$(P)CURR:MEAS:RANGE")
     info(archive, "VAL")
 }
 
@@ -814,6 +823,7 @@ record(ao, "$(P)VOLT:MEAS:RANGE:SP")
     field(SDIS, "$(P)DISABLE")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:VOLT:MEAS:RANGE:SP")
+    field(FLNK, "$(P)VOLT:MEAS:RANGE")
     info(archive, "VAL")
 }
 
@@ -856,6 +866,7 @@ record(ao, "$(P)VOLT:SOURCE:SP")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:VOLT:SOURCE:SP")
     field(SDIS, "$(P)DISABLE")
+    field(FLNK, "$(P)VOLT:SOURCE")
     info(archive, "VAL")
 }
 
@@ -892,6 +903,7 @@ record(ao, "$(P)CURR:SOURCE:SP")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:CURR:SOURCE:SP")
     field(SDIS, "$(P)DISABLE")
+    field(FLNK, "$(P)CURR:SOURCE")
     info(archive, "VAL")
 }
 
@@ -932,6 +944,7 @@ record(ao, "$(P)CURR:SOURCE:RANGE:SP")
     field(SDIS, "$(P)DISABLE")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:CURR:SOURCE:RANGE:SP")
+    field(FLNK, "$(P)CURR:SOURCE:RANGE")
     info(archive, "VAL")
 }
 
@@ -967,6 +980,7 @@ record(ao, "$(P)VOLT:SOURCE:RANGE:SP")
     field(PREC, "10")
     field(SDIS, "$(P)DISABLE")
     field(SIML, "$(P)SIM")
+    field(FLNK, "$(P)VOLT:SOURCE:RANGE")
     field(SIOL, "$(P)SIM:VOLT:SOURCE:RANGE:SP")
     info(archive, "VAL")
 }
@@ -1011,6 +1025,7 @@ record(bo, "$(P)CURR:SOURCE:AUTORANGE:SP")
     field(SDIS, "$(P)DISABLE")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:CURR:SOURCE:AUTORANGE:SP")
+    field(FLNK, "$(P)CURR:SOURCE:AUTORANGE")
     info(archive, "VAL")
 }
 
@@ -1049,6 +1064,7 @@ record(bo, "$(P)VOLT:SOURCE:AUTORANGE:SP")
     field(SDIS, "$(P)DISABLE")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:VOLT:SOURCE:AUTORANGE:SP")
+    field(FLNK, "$(P)VOLT:SOURCE:AUTORANGE")
     info(archive, "VAL")
 }
 
@@ -1092,6 +1108,7 @@ record(bo, "$(P)VOLT:MEAS:AUTORANGE:SP")
     field(SDIS, "$(P)DISABLE")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:VOLT:MEAS:AUTORANGE:SP")
+    field(FLNK, "$(P)VOLT:MEAS:AUTORANGE")
     info(archive, "VAL")
 }
 
@@ -1132,6 +1149,7 @@ record(bo, "$(P)CURR:MEAS:AUTORANGE:SP")
     field(SDIS, "$(P)DISABLE")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:CURR:MEAS:AUTORANGE:SP")
+    field(FLNK, "$(P)CURR:MEAS:AUTORANGE")
     info(archive, "VAL")
 }
 


### PR DESCRIPTION
### Description of work

Removes chained seq records to reduce the number of messages sent out. Each record which changes a parameter on the device also triggers its readback record to increase device responsiveness.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4063

### Acceptance criteria

- [ ] Keithely 2400 IOC tests still pass (functionality should be unchanged)
- [ ] The Keithely 2400 IOC is more responsive
- [ ] Fewer messages are sent to the Keithley
   - [ ] A real (not emulated) Keithely 2400 can deal with the number of messages sent to it

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
