### PR TITLE
Ticket4103

### DIFF
--- a/TRITON/TRITON-IOC-01App/Db/TRITON.db
+++ b/TRITON/TRITON-IOC-01App/Db/TRITON.db
@@ -35,6 +35,8 @@ record(ao, "$(P)TEMP:SP")
 	field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:TEMP:SP")
     field(SDIS, "$(P)DISABLE")
+    
+    field(FLNK, "$(P)_CHECK_LOOP_ON")
 }
 
 record(ai, "$(P)TEMP:SP:RBV")
@@ -185,6 +187,13 @@ record(bo, "$(P)CLOSEDLOOP:SP")
 	field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:CLOSEDLOOP:SP")
     field(SDIS, "$(P)DISABLE")
+}
+
+record(calcout, "$(P)_CHECK_LOOP_ON") {
+    field(INPA, "$(P)CLOSEDLOOP")
+    field(CALC, "!A")
+    field(OOPT, "When Non-zero")
+    field(OUT, "$(P)CLOSEDLOOP:SP PP")
 }
 
 

--- a/TRITON/TRITON-IOC-01App/Db/TRITON_pid_lookup.db
+++ b/TRITON/TRITON-IOC-01App/Db/TRITON_pid_lookup.db
@@ -93,6 +93,8 @@ record(stringout, "$(P)LKUP:RAMP_FILE:SP")
    field(DTYP, "asynOctetWrite")
    field(OUT,  "@asyn($(READ),0,1)DIR")
    field(SCAN, "I/O Intr")
+   field(VAL, "$(RAMP_FILE_NAME=Default.txt)")
+   field(PINI, "YES")
 }
 
 #
@@ -117,7 +119,9 @@ record(bo, "$(P)LKUP:LUTON:SP")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(READ),0,1)LUT")
    field(ZNAM, "Off")
-   field(ONAM, "On")
+   field(ONAM, "$(USE_RAMP_FILE)")
+   field(VAL, "$(USE_RAMP_FILE)")
+   field(PINI, "YES")
 }
 
 record(bi, "$(P)LKUP:LUTON")

--- a/TRITON/TRITON-IOC-01App/Db/TRITON_pid_lookup.db
+++ b/TRITON/TRITON-IOC-01App/Db/TRITON_pid_lookup.db
@@ -113,15 +113,30 @@ record(ao, "$(P)LKUP:TEMP:SP:RBV")
 	field(FLNK, "$(P)LKUP:LUTON:SP")
 }
 
+#
+# This is a filthy hack but it's the only way I found to get
+# around ReadASCII's way of initializing records.
+#
+# Essentially, assume that ReadASCII will have finished initialising
+# by the time 10 seconds have elapsed, and then write to the LUTON:SP
+# record by channel access to force ReadASCII to recognise the value change.
+# 
+record(seq, "$(P)LKUP:LUTON:SP:_INIT")
+{
+   field(DO1, "$(USE_RAMP_FILE)")
+   field(LNK1, "$(P)LKUP:LUTON:SP CA")
+   field(DLY1, "10")
+   field(PINI, "YES")
+   field(FLNK, "$(P)LKUP:LUTON:SP.PROC CA")
+}
+
 record(bo, "$(P)LKUP:LUTON:SP")
 {
    field(DESC, "Toggles the PID lookup")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(READ),0,1)LUT")
    field(ZNAM, "Off")
-   field(ONAM, "$(USE_RAMP_FILE)")
-   field(VAL, "$(USE_RAMP_FILE)")
-   field(PINI, "YES")
+   field(ONAM, "On")
 }
 
 record(bi, "$(P)LKUP:LUTON")

--- a/TRITON/iocBoot/iocTRITON-IOC-01/config.xml
+++ b/TRITON/iocBoot/iocTRITON-IOC-01/config.xml
@@ -5,6 +5,8 @@
 <macros>
 <macro name="IPADDR" pattern="^.*$" description="IP address to connect to." />
 <macro name="IPPORT" pattern="^[0-9]+$" description="Port to connect to (defaults to 33576)." />
+<macro name="RAMP_FILE_NAME" pattern="^.*$" description="File name to use for ramp (defaults to Default.txt)." />
+<macro name="USE_RAMP_FILE" pattern="^(0|1)$" description="Whether to use (1) or not use (0) the ramp file specified above (defaults to 0)." />
 </macros>
 <pvsets>
 </pvsets>

--- a/TRITON/iocBoot/iocTRITON-IOC-01/st-common.cmd
+++ b/TRITON/iocBoot/iocTRITON-IOC-01/st-common.cmd
@@ -33,10 +33,9 @@ ReadASCIIConfigure("$(READASCII_NAME)", "$(RAMP_DIR)")
 < $(IOCSTARTUP)/dbload.cmd
 
 dbLoadRecords("../../db/TRITON.db", "P=$(MYPVPREFIX)$(IOCNAME):,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),PORT=$(DEVICE),IPADDR=$(IPADDR=NUL)")
-dbLoadRecords("../../db/TRITON_valves.db", "P=$(MYPVPREFIX)$(IOCNAME):,PORT=$(DEVICE)")
 dbLoadRecords("../../db/TRITON_channels.db", "P=$(MYPVPREFIX)$(IOCNAME):,PORT=$(DEVICE)")
 dbLoadRecords("../../db/TRITON_pid.db", "P=$(MYPVPREFIX)$(IOCNAME):,PORT=$(DEVICE)")
-dbLoadRecords("../../db/TRITON_pid_lookup.db", "P=$(MYPVPREFIX)$(IOCNAME):,PORT=$(DEVICE),READ=$(READASCII_NAME),RAMPLIST=$(FILELIST_NAME)")
+dbLoadRecords("../../db/TRITON_pid_lookup.db", "P=$(MYPVPREFIX)$(IOCNAME):,PORT=$(DEVICE),READ=$(READASCII_NAME),RAMPLIST=$(FILELIST_NAME),RAMP_FILE_NAME=$(RAMP_FILE_NAME=Default.txt),USE_RAMP_FILE=$(USE_RAMP_FILE=0)")
 dbLoadRecords("../../db/TRITON_temp_channels.db", "P=$(MYPVPREFIX)$(IOCNAME):,PORT=$(DEVICE)")
 dbLoadRecords("../../db/TRITON_pressure_channels.db", "P=$(MYPVPREFIX)$(IOCNAME):,PORT=$(DEVICE)")
 


### PR DESCRIPTION
### Description of work

- Allows user to set calibration file from macro
- Allows user to choose whether to use calibration file from macro
- Closed loop mode is set to On on any temperature setpoint change

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4103

### Acceptance criteria

- Allows user to set calibration file from macro
- Allows user to choose whether to use calibration file from macro
- Closed loop mode is set to On on any temperature setpoint change

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
