### PR TITLE
Add pcre and pcrecpp

### DIFF
--- a/NIMATRO/NIMATRO-IOC-01App/src/build.mak
+++ b/NIMATRO/NIMATRO-IOC-01App/src/build.mak
@@ -41,7 +41,7 @@ $(APPNAME)_LIBS += utilities pcre libjson zlib
 $(APPNAME)_LIBS += asyn
 ## Add other libraries here ##
 $(APPNAME)_LIBS += calc
-$(APPNAME)_LIBS += lvDCOM
+$(APPNAME)_LIBS += lvDCOM pcrecpp pcre
 
 
 # NIMATRO-IOC-01_registerRecordDeviceDriver.cpp derives from NIMATRO-IOC-01.dbd

--- a/NIMATRO/NIMATRO-IOC-01App/src/build.mak
+++ b/NIMATRO/NIMATRO-IOC-01App/src/build.mak
@@ -18,7 +18,6 @@ DBD += $(APPNAME).dbd
 # NIMATRO-IOC-01.dbd will be made up from these files:
 $(APPNAME)_DBD += base.dbd
 ## ISIS standard dbd ##
-$(APPNAME)_DBD += devSequencer.dbd
 $(APPNAME)_DBD += icpconfig.dbd
 $(APPNAME)_DBD += pvdump.dbd
 $(APPNAME)_DBD += asSupport.dbd
@@ -31,17 +30,16 @@ $(APPNAME)_DBD += drvAsynSerialPort.dbd
 
 # Add all the support libraries needed by this IOC
 ## ISIS standard libraries ##
-$(APPNAME)_LIBS += seqDev seq pv
+$(APPNAME)_LIBS += lvDCOM 
 $(APPNAME)_LIBS += devIocStats 
 $(APPNAME)_LIBS += pvdump $(MYSQLLIB) easySQLite sqlite 
 $(APPNAME)_LIBS += caPutLog
 $(APPNAME)_LIBS += icpconfig pugixml
 $(APPNAME)_LIBS += autosave
-$(APPNAME)_LIBS += utilities pcre libjson zlib
 $(APPNAME)_LIBS += asyn
-## Add other libraries here ##
 $(APPNAME)_LIBS += calc
-$(APPNAME)_LIBS += lvDCOM pcrecpp pcre
+$(APPNAME)_LIBS += utilities pcrecpp pcre libjson zlib
+$(APPNAME)_LIBS += seq pv
 
 
 # NIMATRO-IOC-01_registerRecordDeviceDriver.cpp derives from NIMATRO-IOC-01.dbd


### PR DESCRIPTION
### Description of work

Adds necessary libraries for nima trough to build statically

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4263

### Acceptance criteria

- [ ] NIMA trough static build works

Easiest way to test is to do the following (will take a while, it is building the whole tree!)

```
cd C:\instrument\apps\epics
config_env.bat
set EPICS_HOST_ARCH=windows-x64-static
make
```

You could also try building just the nima trough but you'll need to build all of it's dependencies statically first, so it's probably easier to just build everything.

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
