### PR TITLE
Fix sim records. Add timeouts to protocol.

### DIFF
--- a/ASTRIUM/ASTRIUM-IOC-01App/Db/astrium.db
+++ b/ASTRIUM/ASTRIUM-IOC-01App/Db/astrium.db
@@ -36,7 +36,7 @@ record(ao, "$(P)$(Q)FREQ:SP_ACTUAL")
     field(DESC, "The frequency of the chopper")
     field(DTYP, "stream")
     field(EGU, "Hz")
-    field(OUT, "@astrium.proto setFreq $(PORT) $(I)")
+    field(OUT, "@astrium.proto setFreq($(P)$(Q)PHASE:SP:RBV) $(PORT) $(I)")
     info(archive, "VAL")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)$(Q)SIM:FREQ:SP_ACTUAL PP")
@@ -78,7 +78,7 @@ record(ao, "$(P)$(Q)PHASE:SP")
     field(DESC, "The phase of the chopper")
     field(DTYP, "stream")
     field(EGU, "deg")
-    field(OUT, "@astrium.proto setPhase $(PORT) $(I)")
+    field(OUT, "@astrium.proto setPhase($(P)$(Q)PHASE:SP:RBV) $(PORT) $(I)")
     field(PREC, "2")
     field(FLNK, "$(P)$(Q)STATE")
     info(INTEREST, "HIGH")
@@ -171,13 +171,13 @@ record(bo, "$(P)$(Q)BRAKE")
 
 ### SIMULATION RECORDS ###
 
-record(stringout,"$(P)$(Q)SIM:STATE")
+record(stringin,"$(P)$(Q)SIM:STATE")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")
 }
 
-record(ao,"$(P)$(Q)SIM:FREQ")
+record(ai,"$(P)$(Q)SIM:FREQ")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")
@@ -186,7 +186,7 @@ record(ao,"$(P)$(Q)SIM:FREQ")
 
 alias("$(P)$(Q)SIM:FREQ", "$(P)$(Q)SIM:FREQ:SP_ACTUAL")
 
-record(ao,"$(P)$(Q)SIM:PHASE")
+record(ai,"$(P)$(Q)SIM:PHASE")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")

--- a/ASTRIUM/ASTRIUM-IOC-01App/Db/astrium.db
+++ b/ASTRIUM/ASTRIUM-IOC-01App/Db/astrium.db
@@ -171,13 +171,13 @@ record(bo, "$(P)$(Q)BRAKE")
 
 ### SIMULATION RECORDS ###
 
-record(stringin,"$(P)$(Q)SIM:STATE")
+record(stringout,"$(P)$(Q)SIM:STATE")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")
 }
 
-record(ai,"$(P)$(Q)SIM:FREQ")
+record(ao,"$(P)$(Q)SIM:FREQ")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")
@@ -186,7 +186,7 @@ record(ai,"$(P)$(Q)SIM:FREQ")
 
 alias("$(P)$(Q)SIM:FREQ", "$(P)$(Q)SIM:FREQ:SP_ACTUAL")
 
-record(ai,"$(P)$(Q)SIM:PHASE")
+record(ao,"$(P)$(Q)SIM:PHASE")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")

--- a/ASTRIUM/ASTRIUM-IOC-01App/protocol/astrium.proto
+++ b/ASTRIUM/ASTRIUM-IOC-01App/protocol/astrium.proto
@@ -17,7 +17,7 @@ setFreq {
     in $acc;
     
     # Give the device a chance to digest the new frequency setpoint
-    wait 100;
+    wait 1000;
     
     # If speed is sent without then updating phase, it will phase to the wrong place.
     # The phase setpoint will be correct, but it will actually phase somewhere else.
@@ -31,7 +31,7 @@ setPhase {
     in $acc;
     
     # Give the device a chance to digest the new phase setpoint
-    wait 100;
+    wait 1000;
     
     # Update phase setpoint readback immediately after setting phase.
     # This is important because we send the phase readback value back to the

--- a/ASTRIUM/ASTRIUM-IOC-01App/protocol/astrium.proto
+++ b/ASTRIUM/ASTRIUM-IOC-01App/protocol/astrium.proto
@@ -15,11 +15,34 @@ getStatus {
 setFreq {
     out "FREQ %d";
     in $acc;
+    
+    # Give the device a chance to digest the new frequency setpoint
+    wait 100;
+    
+    # If speed is sent without then updating phase, it will phase to the wrong place.
+    # The phase setpoint will be correct, but it will actually phase somewhere else.
+    # So add a phase set here.
+    out "PHASE %(\$1)f";
+    in $acc;
 }
 
 setPhase {
     out "PHASE %f";
     in $acc;
+    
+    # Give the device a chance to digest the new phase setpoint
+    wait 100;
+    
+    # Update phase setpoint readback immediately after setting phase.
+    # This is important because we send the phase readback value back to the
+    # device as part of setFreq, and we don't want to get a race condition when
+    # setting phase and freq together. Having them both as part of the same protocol
+    # means it is uninterruptible.
+    
+    out "STATUS";
+    # Ignore everything except RPHASE.
+    in "#%*[^#]#ACCEPT CH=%*d# State= %*[^#]#ASPEED= %*f#RSPEED= %*f#APHASE= %*f#RPHASE= %(\$1)f#AVETO = %*f#DIR   = %*{CW|CCW}#MONIT = %*[^#]#FLOWR = %*f#WTEMP = %*f#MTEMP = %*f#MVIBR = %*f#MVACU = %*f#DATE%*[^#]#TIME%*#s";
+    
 }
 
 brake {

--- a/ASTRIUM/ASTRIUM-IOC-01App/protocol/astrium.proto
+++ b/ASTRIUM/ASTRIUM-IOC-01App/protocol/astrium.proto
@@ -1,10 +1,15 @@
 InTerminator = "\n";
 
+ReadTimeout = 2000;
+WriteTimeout = 2000;
+ReplyTimeout = 2000;
+LockTimeout = 10000;
+
 acc = "#%*[^#]#ACCEPT ";
 
 getStatus {
     out "STATUS";
-    in "#%*[^#]#ACCEPT CH=%*d# State= %[^#]#ASPEED= %(\$1\$2.A)f#RSPEED= %*f#APHASE= %(\$1\$2.B)f#RPHASE= %(\$1\$2.C)f#AVETO = %(\$1\$2.D)f#DIR   = %(\$1\$3){CW|CCW}#MONIT = %(\$1\$4)[^#]#FLOWR = %(\$1\$2.E)f#WTEMP = %(\$1\$2.F)f#MTEMP = %(\$1\$2.G)f#MVIBR = %(\$1\$2.H)f#MVACU = %(\$1\$2.I)f#DATE%*[^#]#TIME%*[^#]#";
+    in "#%*[^#]#ACCEPT CH=%*d# State= %[^#]#ASPEED= %(\$1\$2.A)f#RSPEED= %*f#APHASE= %(\$1\$2.B)f#RPHASE= %(\$1\$2.C)f#AVETO = %(\$1\$2.D)f#DIR   = %(\$1\$3){CW|CCW}#MONIT = %(\$1\$4)[^#]#FLOWR = %(\$1\$2.E)f#WTEMP = %(\$1\$2.F)f#MTEMP = %(\$1\$2.G)f#MVIBR = %(\$1\$2.H)f#MVACU = %(\$1\$2.I)f#DATE%*[^#]#TIME%*#s";
 }
 
 setFreq {


### PR DESCRIPTION
### Description of work

- Workaround a hardware issue in the astrium choppers by re-sending the phase setpoint explicitly after setting the speed setpoint.
- Set various comms timeouts to appropriate values based on testing with the hardware.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4123

### Acceptance criteria

See above

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [x] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [x] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [x] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [x] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [x] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [x] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [x] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [x] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
