### PR TITLE
Ticket 3991: Added TWINCAT ioc based on tcIoc

### DIFF
--- a/TWINCAT/Makefile
+++ b/TWINCAT/Makefile
@@ -1,0 +1,31 @@
+# Makefile at top of application tree
+TOP = .
+include $(TOP)/configure/CONFIG
+
+# Directories to build, any order
+DIRS += configure
+DIRS += $(wildcard *Sup)
+DIRS += $(wildcard *App)
+DIRS += $(wildcard *Top)
+DIRS += $(wildcard iocBoot)
+
+# The build order is controlled by these dependency rules:
+
+# All dirs except configure depend on configure
+$(foreach dir, $(filter-out configure, $(DIRS)), \
+    $(eval $(dir)_DEPEND_DIRS += configure))
+
+# Any *App dirs depend on all *Sup dirs
+$(foreach dir, $(filter %App, $(DIRS)), \
+    $(eval $(dir)_DEPEND_DIRS += $(filter %Sup, $(DIRS))))
+
+# Any *Top dirs depend on all *Sup and *App dirs
+$(foreach dir, $(filter %Top, $(DIRS)), \
+    $(eval $(dir)_DEPEND_DIRS += $(filter %Sup %App, $(DIRS))))
+
+# iocBoot depends on all *App dirs
+iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
+
+# Add any additional dependency rules here:
+
+include $(TOP)/configure/RULES_TOP

--- a/TWINCAT/TWINCAT-IOC-01App/Db/Makefile
+++ b/TWINCAT/TWINCAT-IOC-01App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/TWINCAT/TWINCAT-IOC-01App/Makefile
+++ b/TWINCAT/TWINCAT-IOC-01App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/TWINCAT/TWINCAT-IOC-01App/protocol/Makefile
+++ b/TWINCAT/TWINCAT-IOC-01App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += TWINCAT-IOC-01.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/TWINCAT/TWINCAT-IOC-01App/src/Makefile
+++ b/TWINCAT/TWINCAT-IOC-01App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=TWINCAT-IOC-01
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/$(APPNAME)App/src/build.mak

--- a/TWINCAT/TWINCAT-IOC-01App/src/TWINCAT-IOC-01Main.cpp
+++ b/TWINCAT/TWINCAT-IOC-01App/src/TWINCAT-IOC-01Main.cpp
@@ -1,0 +1,23 @@
+/* TWINCAT-IOC-01Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/TWINCAT/TWINCAT-IOC-01App/src/build.mak
+++ b/TWINCAT/TWINCAT-IOC-01App/src/build.mak
@@ -1,0 +1,71 @@
+TOP=../..
+
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+#=============================
+
+### NOTE: there should only be one build.mak for a given IOC family and this should be located in the ###-IOC-01 directory
+
+#=============================
+# Build the IOC application TWINCAT-IOC-01
+# We actually use $(APPNAME) below so this file can be included by multiple IOCs
+
+PROD_IOC = $(APPNAME)
+# TWINCAT-IOC-01.dbd will be created and installed
+DBD += $(APPNAME).dbd
+
+# TWINCAT-IOC-01.dbd will be made up from these files:
+$(APPNAME)_DBD += base.dbd
+## ISIS standard dbd ##
+$(APPNAME)_DBD += icpconfig.dbd
+$(APPNAME)_DBD += pvdump.dbd
+$(APPNAME)_DBD += asSupport.dbd
+$(APPNAME)_DBD += devIocStats.dbd
+$(APPNAME)_DBD += caPutLog.dbd
+$(APPNAME)_DBD += utilities.dbd
+## Stream device support ##
+
+$(APPNAME)_DBD += calcSupport.dbd
+## add other dbd here ##
+$(APPNAME)_DBD += tcIocSupport.dbd
+
+# Add all the support libraries needed by this IOC
+
+USR_DBDFLAGS += -I$(TCIOC)/InfoDeviceSupport -I$(TCIOC)/TCatDeviceSupport
+
+## ISIS standard libraries ##
+## Stream device libraries ##
+$(APPNAME)_LIBS += stream
+$(APPNAME)_LIBS += asyn
+## other standard libraries here ##
+$(APPNAME)_LIBS += devIocStats 
+$(APPNAME)_LIBS += pvdump $(MYSQLLIB) easySQLite sqlite 
+$(APPNAME)_LIBS += caPutLog
+$(APPNAME)_LIBS += icpconfig
+$(APPNAME)_LIBS += autosave
+$(APPNAME)_LIBS += utilities pugixml libjson zlib
+$(APPNAME)_LIBS += calc
+$(APPNAME)_LIBS += pcrecpp pcre
+$(APPNAME)_LIBS += seq pv
+$(APPNAME)_LIBS += tcIocSupport
+
+# TWINCAT-IOC-01_registerRecordDeviceDriver.cpp derives from TWINCAT-IOC-01.dbd
+$(APPNAME)_SRCS += $(APPNAME)_registerRecordDeviceDriver.cpp
+
+# Build the main IOC entry point on workstation OSs.
+$(APPNAME)_SRCS_DEFAULT += $(APPNAME)Main.cpp
+$(APPNAME)_SRCS_vxWorks += -nil-
+
+# Add support from base/src/vxWorks if needed
+#$(APPNAME)_OBJS_vxWorks += $(EPICS_BASE_BIN)/vxComLibrary
+
+# Finally link to the EPICS Base libraries
+$(APPNAME)_LIBS += $(EPICS_BASE_IOC_LIBS)
+
+#===========================
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/TWINCAT/configure/CONFIG
+++ b/TWINCAT/configure/CONFIG
@@ -1,0 +1,29 @@
+# CONFIG - Load build configuration data
+#
+# Do not make changes to this file!
+
+# Allow user to override where the build rules come from
+RULES = $(EPICS_BASE)
+
+# RELEASE files point to other application tops
+include $(TOP)/configure/RELEASE
+-include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).Common
+ifdef T_A
+-include $(TOP)/configure/RELEASE.Common.$(T_A)
+-include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).$(T_A)
+endif
+
+CONFIG = $(RULES)/configure
+include $(CONFIG)/CONFIG
+
+# Override the Base definition:
+INSTALL_LOCATION = $(TOP)
+
+# CONFIG_SITE files contain other build configuration settings
+include $(TOP)/configure/CONFIG_SITE
+-include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+ifdef T_A
+ -include $(TOP)/configure/CONFIG_SITE.Common.$(T_A)
+ -include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+endif
+

--- a/TWINCAT/configure/CONFIG_SITE
+++ b/TWINCAT/configure/CONFIG_SITE
@@ -1,0 +1,43 @@
+# CONFIG_SITE
+
+# Make any application-specific changes to the EPICS build
+#   configuration variables in this file.
+#
+# Host/target specific settings can be specified in files named
+#   CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+#   CONFIG_SITE.Common.$(T_A)
+#   CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+
+# CHECK_RELEASE controls the consistency checking of the support
+#   applications pointed to by the RELEASE* files.
+# Normally CHECK_RELEASE should be set to YES.
+# Set CHECK_RELEASE to NO to disable checking completely.
+# Set CHECK_RELEASE to WARN to perform consistency checking but
+#   continue building even if conflicts are found.
+CHECK_RELEASE = YES
+
+# Set this when you only want to compile this application
+#   for a subset of the cross-compiled target architectures
+#   that Base is built for.
+#CROSS_COMPILER_TARGET_ARCHS = vxWorks-ppc32
+
+# To install files into a location other than $(TOP) define
+#   INSTALL_LOCATION here.
+#INSTALL_LOCATION=</absolute/path/to/install/top>
+
+# Set this when the IOC and build host use different paths
+#   to the install location. This may be needed to boot from
+#   a Microsoft FTP server say, or on some NFS configurations.
+#IOCS_APPL_TOP = </IOC's/absolute/path/to/install/top>
+
+# For application debugging purposes, override the HOST_OPT and/
+#   or CROSS_OPT settings from base/configure/CONFIG_SITE
+#HOST_OPT = NO
+#CROSS_OPT = NO
+
+# These allow developers to override the CONFIG_SITE variable
+# settings without having to modify the configure/CONFIG_SITE
+# file itself.
+-include $(TOP)/../CONFIG_SITE.local
+-include $(TOP)/configure/CONFIG_SITE.local
+

--- a/TWINCAT/configure/Makefile
+++ b/TWINCAT/configure/Makefile
@@ -1,0 +1,8 @@
+TOP=..
+
+include $(TOP)/configure/CONFIG
+
+TARGETS = $(CONFIG_TARGETS)
+CONFIGS += $(subst ../,,$(wildcard $(CONFIG_INSTALLS)))
+
+include $(TOP)/configure/RULES

--- a/TWINCAT/configure/RELEASE
+++ b/TWINCAT/configure/RELEASE
@@ -1,0 +1,73 @@
+# RELEASE - Location of external support modules
+#
+# IF YOU MAKE ANY CHANGES to this file you must subsequently
+# do a "gnumake rebuild" in this application's top level
+# directory.
+#
+# The build process does not check dependencies against files
+# that are outside this application, thus you should do a
+# "gnumake rebuild" in the top level directory after EPICS_BASE
+# or any other external module pointed to below is rebuilt.
+#
+# Host- or target-specific settings can be given in files named
+#  RELEASE.$(EPICS_HOST_ARCH).Common
+#  RELEASE.Common.$(T_A)
+#  RELEASE.$(EPICS_HOST_ARCH).$(T_A)
+#
+# This file is parsed by both GNUmake and an EPICS Perl script,
+# so it can ONLY contain definitions of paths to other support
+# modules, variable definitions that are used in module paths,
+# and include statements that pull in other RELEASE files.
+# Variables may be used before their values have been set.
+# Build variables that are NOT used in paths should be set in
+# the CONFIG_SITE file.
+
+# Variables and paths to dependent modules:
+#MODULES = /path/to/modules
+#MYMODULE = $(MODULES)/my-module
+
+# If using the sequencer, point SNCSEQ at its top directory:
+#SNCSEQ = $(MODULES)/seq-ver
+
+# EPICS_BASE should appear last so earlier modules can override stuff:
+EPICS_BASE = C:/Instrument/Apps/EPICS/base/master
+
+# Set RULES here if you want to use build rules from somewhere
+# other than EPICS_BASE:
+#RULES = $(MODULES)/build-rules
+
+# These allow developers to override the RELEASE variable settings
+# without having to modify the configure/RELEASE file itself.
+-include $(TOP)/../RELEASE.local
+-include $(TOP)/configure/RELEASE.local
+
+# Macros required for basic ioc/stream device
+ACCESSSECURITY=$(SUPPORT)/AccessSecurity/master
+ASUBFUNCTIONS=$(SUPPORT)/asubFunctions/master
+ASYN=$(SUPPORT)/asyn/master
+AUTOSAVE=$(SUPPORT)/autosave/master
+CALC=$(SUPPORT)/calc/master
+CAPUTLOG=$(SUPPORT)/caPutLog/master
+DEVIOCSTATS=$(SUPPORT)/devIocStats/master
+ICPCONFIG=$(SUPPORT)/icpconfig/master
+LIBJSON=$(SUPPORT)/libjson/master
+MYSQL=$(SUPPORT)/MySQL/master
+ONCRPC=$(SUPPORT)/oncrpc/master
+PCRE=$(SUPPORT)/pcre/master
+PUGIXML=$(SUPPORT)/pugixml/master
+PVDUMP=$(SUPPORT)/pvdump/master
+SNCSEQ=$(SUPPORT)/seq/master
+SQLITE=$(SUPPORT)/sqlite/master
+SSCAN=$(SUPPORT)/sscan/master
+STREAMDEVICE=$(SUPPORT)/StreamDevice/master
+TCIOC=$(SUPPORT)/tcIoc/master
+UTILITIES=$(SUPPORT)/utilities/master
+ZLIB=$(SUPPORT)/zlib/master
+
+# optional extra local definitions here
+-include $(TOP)/configure/RELEASE.private
+
+include $(TOP)/../../../ISIS_CONFIG
+-include $(TOP)/../../../ISIS_CONFIG.$(EPICS_HOST_ARCH)
+
+# IOC-specific support module

--- a/TWINCAT/configure/RULES
+++ b/TWINCAT/configure/RULES
@@ -1,0 +1,6 @@
+# RULES
+
+include $(CONFIG)/RULES
+
+# Library should be rebuilt because LIBOBJS may have changed.
+$(LIBNAME): ../Makefile

--- a/TWINCAT/configure/RULES.ioc
+++ b/TWINCAT/configure/RULES.ioc
@@ -1,0 +1,2 @@
+#RULES.ioc
+include $(CONFIG)/RULES.ioc

--- a/TWINCAT/configure/RULES_DIRS
+++ b/TWINCAT/configure/RULES_DIRS
@@ -1,0 +1,2 @@
+#RULES_DIRS
+include $(CONFIG)/RULES_DIRS

--- a/TWINCAT/configure/RULES_TOP
+++ b/TWINCAT/configure/RULES_TOP
@@ -1,0 +1,3 @@
+#RULES_TOP
+include $(CONFIG)/RULES_TOP
+

--- a/TWINCAT/iocBoot/Makefile
+++ b/TWINCAT/iocBoot/Makefile
@@ -1,0 +1,6 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS += $(wildcard *ioc*)
+DIRS += $(wildcard as*)
+include $(CONFIG)/RULES_DIRS
+

--- a/TWINCAT/iocBoot/iocTWINCAT-IOC-01/Makefile
+++ b/TWINCAT/iocBoot/iocTWINCAT-IOC-01/Makefile
@@ -1,0 +1,6 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+#ARCH = windows-x64
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/TWINCAT/iocBoot/iocTWINCAT-IOC-01/st-common.cmd
+++ b/TWINCAT/iocBoot/iocTWINCAT-IOC-01/st-common.cmd
@@ -1,0 +1,19 @@
+##ISIS## Run IOC initialisation 
+< $(IOCSTARTUP)/init.cmd
+
+## Load record instances
+tcSetAlias("PLC:TEST:")
+tcSetScanRate(10, 5)
+tcLoadRecords ("$(TPY_FILE)", "-eo -devtc")
+
+##ISIS## Load common DB records 
+< $(IOCSTARTUP)/dbload.cmd
+
+##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
+< $(IOCSTARTUP)/preiocinit.cmd
+
+cd "${TOP}/iocBoot/${IOC}"
+iocInit
+
+##ISIS## Stuff that needs to be done after iocInit is called e.g. sequence programs 
+< $(IOCSTARTUP)/postiocinit.cmd

--- a/TWINCAT/iocBoot/iocTWINCAT-IOC-01/st.cmd
+++ b/TWINCAT/iocBoot/iocTWINCAT-IOC-01/st.cmd
@@ -1,0 +1,18 @@
+#!../../bin/windows-x64/y
+
+## You may have to change y to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+cd "${TOP}"
+
+## Register all support components
+dbLoadDatabase "${TOP}/dbd/TWINCAT-IOC-01.dbd"
+TWINCAT_IOC_01_registerRecordDeviceDriver pdbbase
+
+## calling common command file in ioc 01 boot dir
+< ${TOP}/iocBoot/iocTWINCAT-IOC-01/st-common.cmd


### PR DESCRIPTION
### Description of work

See https://github.com/ISISComputingGroup/IBEX/issues/3991

Note that this was the minimum required to get the IOC running and talking with a device. No GUI etc. has been made yet.

### To test

See https://github.com/ISISComputingGroup/BeckhoffPLCCode/pull/19

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
