### PR TITLE
Rename PV and add alarm

### DIFF
--- a/ITC503/ITC503-IOC-01App/Db/ITC503.db
+++ b/ITC503/ITC503-IOC-01App/Db/ITC503.db
@@ -248,6 +248,7 @@ record(mbbi, "$(P)CTRL") {
   field(ONST, "Remote only")
   field(TWST, "Local only")
   field(THST, "Local and remote")
+  field(TWSV, "MINOR")
   field(SIML, "$(P)SIM")
   field(SIOL, "$(P)SIM:CTRL")
   field(SDIS, "$(P)DISABLE")
@@ -480,14 +481,14 @@ record(ai, "$(P)HEATERV") {
 #   info(archive, "VAL")
 # }
 
-record(ao, "$(P)HEATERV:SP") {
-  field(DESC, "Set man htr v")
+record(ao, "$(P)HEATERP:SP") {
+  field(DESC, "Set man htr %")
   field(SCAN, "Passive")
   field(DTYP, "stream")
   field(OUT, "@itc503.proto set_manv $(PORT)")
   field(OMSL, "supervisory")
   field(PREC, "1")
-  field(EGU, "V")
+  field(EGU, "%")
   field(SIML, "$(P)SIM")
   field(SIOL, "$(P)SIM:HEATERV:SP")
   field(SDIS, "$(P)DISABLE")

--- a/ITC503/ITC503-IOC-01App/Db/ITC503.db
+++ b/ITC503/ITC503-IOC-01App/Db/ITC503.db
@@ -248,7 +248,7 @@ record(mbbi, "$(P)CTRL") {
   field(ONST, "Remote only")
   field(TWST, "Local only")
   field(THST, "Local and remote")
-  field(TWSV, "MINOR")
+  field(TWSV, "MAJOR")
   field(SIML, "$(P)SIM")
   field(SIOL, "$(P)SIM:CTRL")
   field(SDIS, "$(P)DISABLE")


### PR DESCRIPTION
### Description of work

Renames the heater PV to reflect it's purpose (to write a per cent value). Adds an alarm to indicate the device is in local-only mode.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4033

### Acceptance criteria

- [x] It's clear that the heater set point PV writes a per centage
- [x] The CTRL PV goes into alarm when the device is in local-only mode

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
