### PR TITLE
Ticket3562 Added string record for motor movement

### DIFF
--- a/INSTETC/INSTETC-IOC-01App/Db/INSTETC.db
+++ b/INSTETC/INSTETC-IOC-01App/Db/INSTETC.db
@@ -17,6 +17,16 @@ record (longin, "$(P)CS:MOT:STOP:ALL")
 	field(MDEL, -1)
 }
 
+## String field for the status of motor movement
+record(bi, "$(P)CS:MOT:MOVING:STR") 
+{
+	field(DESC, "IOCs with motion to complete")
+    field(INP, "$(P)CS:MOT:MOVING CP MS")
+	field(ZNAM, "STATIONARY")
+    field(ONAM, "MOVING")
+	info(archive, "VAL")
+}
+
 ## Are any motors moving
 ## A-J set by motors, L from _MOVING1
 record(calc, "$(P)CS:MOT:MOVING") 

--- a/INSTETC/INSTETC-IOC-01App/Db/INSTETC.db
+++ b/INSTETC/INSTETC-IOC-01App/Db/INSTETC.db
@@ -21,10 +21,10 @@ record (longin, "$(P)CS:MOT:STOP:ALL")
 record(bi, "$(P)CS:MOT:MOVING:STR") 
 {
 	field(DESC, "IOCs with motion to complete")
-    field(INP, "$(P)CS:MOT:MOVING CP MS")
+	field(INP, "$(P)CS:MOT:MOVING CP MS")
 	field(ZNAM, "STATIONARY")
-    field(ONAM, "MOVING")
-	info(archive, "VAL")
+	field(ONAM, "MOVING")
+	field(ASG, "NOTRAPW")
 }
 
 ## Are any motors moving


### PR DESCRIPTION
### Description of work

Added a string record which is used by the GUI to display the status of the motors.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/3562

### Acceptance criteria

- [ ] A record called `CS:MOT:MOVING:STR` exists which is "STATIONARY" if the motors are not moving and "MOVING" if they are moving.

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
