### PR TITLE
Ticket 4611: Reduced default speed for attocube

### DIFF
--- a/ATTOCUBE/ATTOCUBE-IOC-01App/Db/single_axis.substitutions
+++ b/ATTOCUBE/ATTOCUBE-IOC-01App/Db/single_axis.substitutions
@@ -7,5 +7,5 @@ pattern
 file $(MOTOR)/db/basic_asyn_motor.db {
 pattern
 {P,                 M,                 DESC,                       DTYP,      DIR, VELO, VBAS, ACCL, BDST, BVEL, BACC, PORT,           ADDR,       MRES,  PREC, EGU, DHLM,  DLLM,   INIT}
-{\$(MYPVPREFIX),    MOT:\$(MOTOR_PV),  "\$(MOTOR_PV) Attocube",    asynMotor, 0,   300,  50,   1,    0,    0,    0,    \$(MOTOR_PORT), \$(ADDR),   0.001, 3,    um,  10000, -10000, 0}
+{\$(MYPVPREFIX),    MOT:\$(MOTOR_PV),  "\$(MOTOR_PV) Attocube",    asynMotor, 0,   20,   0,   1,    0,    0,    0,    \$(MOTOR_PORT), \$(ADDR),   0.001, 3,    um,  10000, -10000, 0}
 }


### PR DESCRIPTION
### Description of work

See https://github.com/ISISComputingGroup/IBEX/issues/4611

The attocube had a silly default speed, causing tests to fail as it was going too fast for the test to pick up. This reduces the speed

### To test

* Rebuild the attocube
* Confirm it moves at a sensible speed

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
