### PR TITLE
Make default -ve

### DIFF
--- a/GALIL/GALIL-IOC-01App/Db/galil_userdef_records8.substitutions
+++ b/GALIL/GALIL-IOC-01App/Db/galil_userdef_records8.substitutions
@@ -52,7 +52,7 @@ pattern
 {"\$(P)", "MTR\$(CCP)",     "ZP",  "Galil"   "Passive", "Positive antifriction bias", "",    "", "",    "", "MINOR", "MINOR", "Invalid", "Ok",  "MAJOR",    "NO_ALARM", $(CC), "",    "", "YES"}
 {"\$(P)", "MTR\$(CCP)",     "ZN",  "Galil"   "Passive", "Negative antifriction bias", "",    "", "",    "", "MINOR", "MINOR", "Invalid", "Ok",  "MAJOR",    "NO_ALARM", $(CC), "",    "", "YES"}
 {"\$(P)", "MTR\$(CCP)",     "TL",  "Galil"   "Passive", "Torque Limit", "",    "", "",    "", "MINOR", "MINOR", "Invalid", "Ok",  "MAJOR",    "NO_ALARM", $(CC), "",    "", "YES"}
-{"\$(P)", "MTR\$(CCP)",     "CP",  "Galil"   "Passive", "Motor off deadband", "",    "", "",    "", "MINOR", "MINOR", "Invalid", "Ok",  "MAJOR",    "NO_ALARM", $(CC), "",    "", "YES"}
+{"\$(P)", "MTR\$(CCP)",     "CP",  "Galil"   "Passive", "Motor off deadband", "",    "", "",    "", "MINOR", "MINOR", "Invalid", "Ok",  "MAJOR",    "NO_ALARM", $(CC), "-1.0",    "", "YES"}
 {"\$(P)", "MTR\$(CCP)",     "CT",  "Galil"   "Passive", "IL increment rate for CP", "",    "", "",    "", "MINOR", "MINOR", "Invalid", "Ok",  "MAJOR",    "NO_ALARM", $(CC), "",    "", "YES"}
 {"\$(P)", "MTR\$(CCP)",     "AF",  "Galil"   "Passive", "Analog Feedback", "",    "", "",    "", "MINOR", "MINOR", "Invalid", "Ok",  "MAJOR",    "NO_ALARM", $(CC), "",    "", "YES"}
 {"\$(P)", "MTR\$(CCP)",     "DS",  "Galil"   "Passive", "Off band", "",    "", "",    "", "MINOR", "MINOR", "Invalid", "Ok",  "MAJOR",    "NO_ALARM", $(CC), "",    "", "YES"}


### PR DESCRIPTION
### Description of work

Make deadband default to -ve

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4602

### Acceptance criteria

1. New motor has default motor off deadband -1 (see galil engineering screen)

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
