### PR TITLE
Added HVCAEN ability to add crates through macros (tested on NDADETMON)

### DIFF
--- a/HVCAEN/iocBoot/iocHVCAEN-IOC-01/config.xml
+++ b/HVCAEN/iocBoot/iocHVCAEN-IOC-01/config.xml
@@ -3,7 +3,14 @@
 	<config_part>
 		<ioc_desc>CAEN high voltage power supply</ioc_desc>
 		<macros>
-			<macro name ="HVCAENIP0" pattern="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$" description="IP address of the device." />
+			<macro name ="HVCAENIP0" pattern="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$" description="IP address of the first device." />
+			<macro name ="HVCAENIP1" pattern="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$" description="IP address of the second device." />
+			<macro name ="HVCAENIP2" pattern="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$" description="IP address of the third device." />
+			<macro name ="HVCAENIP3" pattern="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$" description="IP address of the fourth device." />
+			<macro name ="HVCAENIP4" pattern="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$" description="IP address of the fifth device." />
+			<macro name ="HVCAENIP5" pattern="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$" description="IP address of the sixth device." />
+			<macro name ="HVCAENIP6" pattern="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$" description="IP address of the seventh device." />
+			<macro name ="HVCAENIP7" pattern="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$" description="IP address of the eighth device." />
 		</macros>
 	</config_part>
 </ioc_config>

--- a/HVCAEN/iocBoot/iocHVCAEN-IOC-01/st.cmd
+++ b/HVCAEN/iocBoot/iocHVCAEN-IOC-01/st.cmd
@@ -19,7 +19,13 @@ HVCAEN_IOC_01_registerRecordDeviceDriver pdbbase
 ## arguments to CAENx527ConfigureCreate are: name, ip_address, username, password
 ## username, password are optional and the crate factory default is used if these are not specified
 CAENx527ConfigureCreate "hv0", "$(HVCAENIP0)"
-#CAENx527ConfigureCreate "hv1", "halldcaenhv1"
+CAENx527ConfigureCreate "hv1", "$(HVCAENIP1)"
+CAENx527ConfigureCreate "hv2", "$(HVCAENIP2)"
+CAENx527ConfigureCreate "hv3", "$(HVCAENIP3)"
+CAENx527ConfigureCreate "hv4", "$(HVCAENIP4)"
+CAENx527ConfigureCreate "hv5", "$(HVCAENIP5)"
+CAENx527ConfigureCreate "hv6", "$(HVCAENIP6)"
+CAENx527ConfigureCreate "hv7", "$(HVCAENIP7)"
 
 ##ISIS## Load common DB records 
 < $(IOCSTARTUP)/dbload.cmd

--- a/HVCAEN/iocBoot/iocHVCAEN-IOC-01/st.cmd
+++ b/HVCAEN/iocBoot/iocHVCAEN-IOC-01/st.cmd
@@ -16,16 +16,27 @@ HVCAEN_IOC_01_registerRecordDeviceDriver pdbbase
 
 # use -D argument to turn on debugging
 
+stringiftest("IP0Present", "$(HVCAENIP0="")", 13, "")
+stringiftest("IP1Present", "$(HVCAENIP1="")", 13, "")
+stringiftest("IP2Present", "$(HVCAENIP2="")", 13, "")
+stringiftest("IP3Present", "$(HVCAENIP3="")", 13, "")
+stringiftest("IP4Present", "$(HVCAENIP4="")", 13, "")
+stringiftest("IP5Present", "$(HVCAENIP5="")", 13, "")
+stringiftest("IP6Present", "$(HVCAENIP6="")", 13, "")
+stringiftest("IP7Present", "$(HVCAENIP7="")", 13, "")
+
+
 ## arguments to CAENx527ConfigureCreate are: name, ip_address, username, password
 ## username, password are optional and the crate factory default is used if these are not specified
-CAENx527ConfigureCreate "hv0", "$(HVCAENIP0)"
-CAENx527ConfigureCreate "hv1", "$(HVCAENIP1)"
-CAENx527ConfigureCreate "hv2", "$(HVCAENIP2)"
-CAENx527ConfigureCreate "hv3", "$(HVCAENIP3)"
-CAENx527ConfigureCreate "hv4", "$(HVCAENIP4)"
-CAENx527ConfigureCreate "hv5", "$(HVCAENIP5)"
-CAENx527ConfigureCreate "hv6", "$(HVCAENIP6)"
-CAENx527ConfigureCreate "hv7", "$(HVCAENIP7)"
+$(IFIP0Present) CAENx527ConfigureCreate "hv0", "$(HVCAENIP0="")"
+$(IFIP1Present) CAENx527ConfigureCreate "hv1", "$(HVCAENIP1="")"
+$(IFIP2Present) CAENx527ConfigureCreate "hv2", "$(HVCAENIP2="")"
+$(IFIP3Present) CAENx527ConfigureCreate "hv3", "$(HVCAENIP3="")"
+$(IFIP4Present) CAENx527ConfigureCreate "hv4", "$(HVCAENIP4="")"
+$(IFIP5Present) CAENx527ConfigureCreate "hv5", "$(HVCAENIP5="")"
+$(IFIP6Present) CAENx527ConfigureCreate "hv6", "$(HVCAENIP6="")"
+$(IFIP7Present) CAENx527ConfigureCreate "hv7", "$(HVCAENIP7="")"
+
 
 ##ISIS## Load common DB records 
 < $(IOCSTARTUP)/dbload.cmd


### PR DESCRIPTION
### Description of work

Added macros that can be set on the HVCAEN IOC so we can talk to crates in multiple locations (up to 8)

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4182

### Acceptance criteria

- [ ] 8 macros exist to set the IP of a CAEN crate
- [ ] We can set the macros in a config 
- [ ] In our config we can use these to point blocks at a CAEN crate

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
