### PR TITLE
Copy ADEL from motor to _MTRENC_DRIFT

### DIFF
--- a/GALIL/GALIL-IOC-01App/Db/galil_motor_extras.substitutions
+++ b/GALIL/GALIL-IOC-01App/Db/galil_motor_extras.substitutions
@@ -54,4 +54,16 @@ pattern
 }
 
 
+file "$(UTILITIES)/utilitiesApp/db/field_setter.template" {
+    pattern
+    {P, FROM, TO, FIELD}
+    {"\$(P):", MTR\$(CCP)01, MTR\$(CCP)01_MTRENC_DRIFT, ADEL}
+    {"\$(P):", MTR\$(CCP)02, MTR\$(CCP)02_MTRENC_DRIFT, ADEL}
+    {"\$(P):", MTR\$(CCP)03, MTR\$(CCP)03_MTRENC_DRIFT, ADEL}
+    {"\$(P):", MTR\$(CCP)04, MTR\$(CCP)04_MTRENC_DRIFT, ADEL}
+    {"\$(P):", MTR\$(CCP)05, MTR\$(CCP)05_MTRENC_DRIFT, ADEL}
+    {"\$(P):", MTR\$(CCP)06, MTR\$(CCP)06_MTRENC_DRIFT, ADEL}
+    {"\$(P):", MTR\$(CCP)07, MTR\$(CCP)07_MTRENC_DRIFT, ADEL}
+    {"\$(P):", MTR\$(CCP)08, MTR\$(CCP)08_MTRENC_DRIFT, ADEL}
+}
 # end


### PR DESCRIPTION
### Description of work

Adds a record to copy across the archive deadband value (ADEL) from the underlying motors to the motor encoder drift record.

This is difficult to test as an IOC system test becuase of the differences between a simulated and a real galil. The added functionality can be tested here by running a non-simulated GALIL IOC, manually setting the motor's ADEL and confirming it is mirrored in the appropriate _MTRENC_DRIFT record.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4695

### Acceptance criteria
- [ ] ADEL is copied from the motor to the corresponding motor _MTRENC_DRIFT record
- [ ] All other operation of the GALIL is unaffected

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
