### PR TITLE
Exclude TWINCAT on VS2010

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,13 +41,18 @@ ifeq ($(TWINCAT3DIR),)
 DIRS_NOTBUILD += TWINCAT
 endif
 
+## module decisions based on Visual Studio version
+ifneq ($(findstring 10.0,$(VCVERSION)),)
+# What not to build with VS2010
+DIRS_NOTBUILD += TWINCAT
+else
+# What not to build if do not have VS2010
+DIRS_NOTBUILD += MK3CHOPR ASTRIUM
+endif
+
 ## modules not to build on windows 64bit
 ifneq ($(findstring windows,$(EPICS_HOST_ARCH)),)
 DIRS_NOTBUILD += 
-# don't build the mk3chopper if not using VS2010
-ifeq ($(findstring 10.0,$(VCVERSION)),)
-DIRS_NOTBUILD += MK3CHOPR ASTRIUM
-endif
 endif
 
 ## modules not to build on windows 32bit


### PR DESCRIPTION
### Description of work

Exclude TWINCAT with VS2010

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
