### PR TITLE
Ticket 4834 - Gamry IOC description update

### DIFF
--- a/GAMRY/iocBoot/iocGAMRY-IOC-01/config.xml
+++ b/GAMRY/iocBoot/iocGAMRY-IOC-01/config.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" ?>
 <ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
  <config_part>
-  <ioc_desc>Gamry</ioc_desc>
-  <ioc_details>This IOC is to support the ISIS Gamry trigger device. It is NOT for individual Gamry potentiostats.</ioc_details>
+  <ioc_desc>This IOC is to support the ISIS Gamry trigger device. It is NOT for individual Gamry potentiostats.</ioc_desc>
   <macros>
     <macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" hasDefault="NO" />
 

--- a/GAMRY/iocBoot/iocGAMRY-IOC-01/config.xml
+++ b/GAMRY/iocBoot/iocGAMRY-IOC-01/config.xml
@@ -2,7 +2,7 @@
 <ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
  <config_part>
   <ioc_desc>Gamry</ioc_desc>
-  <ioc_details>Gamry</ioc_details>
+  <ioc_details>This IOC is to support the ISIS Gamry trigger device. It is NOT for individual Gamry potentiostats.</ioc_details>
   <macros>
     <macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" hasDefault="NO" />
 


### PR DESCRIPTION
### Description of work

Updated the description of the Gamry IOC for clarity. This driver is for the ISIS created Gamry trigger and not individual Gamry devices.