### PR TITLE
Updated CRYOSMS library name

### DIFF
--- a/CRYOSMS/CRYOSMS-IOC-01App/src/build.mak
+++ b/CRYOSMS/CRYOSMS-IOC-01App/src/build.mak
@@ -39,7 +39,7 @@ $(APPNAME)_LIBS += caPutLog
 $(APPNAME)_LIBS += icpconfig pugixml
 $(APPNAME)_LIBS += autosave
 ## Add other libraries here ##
-$(APPNAME)_LIBS += cryosms
+$(APPNAME)_LIBS += CRYOSMS
 $(APPNAME)_LIBS += stream
 $(APPNAME)_LIBS += utilities
 $(APPNAME)_LIBS += asyn


### PR DESCRIPTION
Updated case of lib name in the makefile to fix the RH6 Static Linux build.