### PR TITLE
Add 4th Kepco IOC

### DIFF
--- a/KEPCO/KEPCO-IOC-04App/Db/Makefile
+++ b/KEPCO/KEPCO-IOC-04App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/KEPCO/KEPCO-IOC-04App/Makefile
+++ b/KEPCO/KEPCO-IOC-04App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/KEPCO/KEPCO-IOC-04App/protocol/Makefile
+++ b/KEPCO/KEPCO-IOC-04App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += KEPCO-IOC-03.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/KEPCO/KEPCO-IOC-04App/src/KEPCO-IOC-04Main.cpp
+++ b/KEPCO/KEPCO-IOC-04App/src/KEPCO-IOC-04Main.cpp
@@ -1,0 +1,23 @@
+/* KEPCO-IOC-03Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/KEPCO/KEPCO-IOC-04App/src/Makefile
+++ b/KEPCO/KEPCO-IOC-04App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=KEPCO-IOC-04
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/KEPCO-IOC-01App/src/build.mak

--- a/KEPCO/iocBoot/iocKEPCO-IOC-04/Makefile
+++ b/KEPCO/iocBoot/iocKEPCO-IOC-04/Makefile
@@ -1,0 +1,6 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+#ARCH = windows-x64
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/KEPCO/iocBoot/iocKEPCO-IOC-04/config.xml
+++ b/KEPCO/iocBoot/iocKEPCO-IOC-04/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocKEPCO-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/KEPCO/iocBoot/iocKEPCO-IOC-04/st.cmd
+++ b/KEPCO/iocBoot/iocKEPCO-IOC-04/st.cmd
@@ -1,0 +1,17 @@
+#!../../bin/windows-x64/KEPCO-IOC-04
+
+## You may have to change kepco to something else
+## everywhere it appears in this file
+
+< envPaths
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/KEPCO-IOC-04.dbd"
+KEPCO_IOC_04_registerRecordDeviceDriver pdbbase
+
+cd ${TOP}/iocBoot/iocKEPCO-IOC-01
+
+< st-common.cmd
+


### PR DESCRIPTION
### Description of work

EMU needed another instance of the kepco IOC as they are using 3 for the 3 axes of the zero-field system and need one more for the vertical steering magnet

### To test

n/a

### Acceptance criteria

- IOC tests work for IOC 4

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [x] Devsim mode
    - [x] Recsim mode
    - [ ] Real device, if available
- [x] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [x] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
