### PR TITLE
Add MUONTPAR ioc

### DIFF
--- a/MUONTPAR/MUONTPAR-IOC-01App/Db/Makefile
+++ b/MUONTPAR/MUONTPAR-IOC-01App/Db/Makefile
@@ -1,0 +1,21 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+DB += muon_tpar.db
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/MUONTPAR/MUONTPAR-IOC-01App/Db/muon_tpar.db
+++ b/MUONTPAR/MUONTPAR-IOC-01App/Db/muon_tpar.db
@@ -1,0 +1,5 @@
+record(stringout, "$(P)TPAR_FILE") {
+    field(VAL, "$(TPAR_FILE)")
+    field(PINI, "YES")
+    field(ASG, "READONLY")
+}

--- a/MUONTPAR/MUONTPAR-IOC-01App/Db/muon_tpar.db
+++ b/MUONTPAR/MUONTPAR-IOC-01App/Db/muon_tpar.db
@@ -1,5 +1,6 @@
 record(stringout, "$(P)TPAR_FILE") {
     field(VAL, "$(TPAR_FILE)")
     field(PINI, "YES")
+    field(DESC, "filename of tpar file")
     field(ASG, "READONLY")
 }

--- a/MUONTPAR/MUONTPAR-IOC-01App/Makefile
+++ b/MUONTPAR/MUONTPAR-IOC-01App/Makefile
@@ -1,0 +1,8 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/MUONTPAR/MUONTPAR-IOC-01App/src/MUONTPAR-IOC-01Main.cpp
+++ b/MUONTPAR/MUONTPAR-IOC-01App/src/MUONTPAR-IOC-01Main.cpp
@@ -1,0 +1,23 @@
+/* INSTETC-IOC-01Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/MUONTPAR/MUONTPAR-IOC-01App/src/Makefile
+++ b/MUONTPAR/MUONTPAR-IOC-01App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=MUONTPAR-IOC-01
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/MUONTPAR-IOC-01App/src/build.mak

--- a/MUONTPAR/MUONTPAR-IOC-01App/src/build.mak
+++ b/MUONTPAR/MUONTPAR-IOC-01App/src/build.mak
@@ -1,0 +1,58 @@
+TOP=../..
+
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+#=============================
+
+### NOTE: there should only be one build.mak for a given IOC family and this should be located in the ###-IOC-01 directory
+
+#=============================
+# Build the IOC application MUONTPAR-IOC-01
+# We actually use $(APPNAME) below so this file can be included by multiple IOCs
+
+PROD_IOC = $(APPNAME)
+# MUONTPAR-IOC-01.dbd will be created and installed from INSTETC-IOC-01Include.dbd 
+DBD += $(APPNAME).dbd
+
+$(APPNAME)_DBD += base.dbd
+## ISIS standard dbd ##
+$(APPNAME)_DBD += icpconfig.dbd
+$(APPNAME)_DBD += pvdump.dbd
+$(APPNAME)_DBD += asSupport.dbd
+$(APPNAME)_DBD += devIocStats.dbd
+$(APPNAME)_DBD += caPutLog.dbd
+$(APPNAME)_DBD += utilities.dbd
+
+# Add all the support libraries needed by this IOC
+## ISIS standard libraries ##
+$(APPNAME)_LIBS += asubFunctions
+$(APPNAME)_LIBS += seq pv
+$(APPNAME)_LIBS += devIocStats 
+$(APPNAME)_LIBS += pvdump $(MYSQLLIB) easySQLite sqlite 
+$(APPNAME)_LIBS += caPutLog
+$(APPNAME)_LIBS += icpconfig pugixml
+$(APPNAME)_LIBS += autosave
+$(APPNAME)_LIBS += utilities pcre
+## Add other libraries here ##
+$(APPNAME)_LIBS += asyn calc busy sscan
+
+# INSTETC-IOC-01_registerRecordDeviceDriver.cpp derives from INSTETC-IOC-01.dbd
+$(APPNAME)_SRCS += $(APPNAME)_registerRecordDeviceDriver.cpp
+
+# Build the main IOC entry point on workstation OSs.
+$(APPNAME)_SRCS_DEFAULT += $(APPNAME)Main.cpp
+$(APPNAME)_SRCS_vxWorks += -nil-
+
+# Add support from base/src/vxWorks if needed
+#$(APPNAME)_OBJS_vxWorks += $(EPICS_BASE_BIN)/vxComLibrary
+
+# Finally link to the EPICS Base libraries
+$(APPNAME)_LIBS += $(EPICS_BASE_IOC_LIBS)
+
+#===========================
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/MUONTPAR/Makefile
+++ b/MUONTPAR/Makefile
@@ -1,0 +1,17 @@
+#Makefile at top of application tree
+TOP = .
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), configure)
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *App))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard iocBoot))
+
+define DIR_template
+ $(1)_DEPEND_DIRS = configure
+endef
+$(foreach dir, $(filter-out configure,$(DIRS)),$(eval $(call DIR_template,$(dir))))
+
+iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
+
+include $(TOP)/configure/RULES_TOP
+
+

--- a/MUONTPAR/configure/CONFIG
+++ b/MUONTPAR/configure/CONFIG
@@ -1,0 +1,29 @@
+# CONFIG - Load build configuration data
+#
+# Do not make changes to this file!
+
+# Allow user to override where the build rules come from
+RULES = $(EPICS_BASE)
+
+# RELEASE files point to other application tops
+include $(TOP)/configure/RELEASE
+-include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).Common
+ifdef T_A
+-include $(TOP)/configure/RELEASE.Common.$(T_A)
+-include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).$(T_A)
+endif
+
+CONFIG = $(RULES)/configure
+include $(CONFIG)/CONFIG
+
+# Override the Base definition:
+INSTALL_LOCATION = $(TOP)
+
+# CONFIG_SITE files contain other build configuration settings
+include $(TOP)/configure/CONFIG_SITE
+-include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+ifdef T_A
+ -include $(TOP)/configure/CONFIG_SITE.Common.$(T_A)
+ -include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+endif
+

--- a/MUONTPAR/configure/CONFIG_SITE
+++ b/MUONTPAR/configure/CONFIG_SITE
@@ -1,0 +1,33 @@
+# CONFIG_SITE
+
+# Make any application-specific changes to the EPICS build
+#   configuration variables in this file.
+#
+# Host/target specific settings can be specified in files named
+#   CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+#   CONFIG_SITE.Common.$(T_A)
+#   CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+
+# CHECK_RELEASE controls the consistency checking of the support
+#   applications pointed to by the RELEASE* files.
+# Normally CHECK_RELEASE should be set to YES.
+# Set CHECK_RELEASE to NO to disable checking completely.
+# Set CHECK_RELEASE to WARN to perform consistency checking but
+#   continue building anyway if conflicts are found.
+CHECK_RELEASE = YES
+
+# Set this when you only want to compile this application
+#   for a subset of the cross-compiled target architectures
+#   that Base is built for.
+#CROSS_COMPILER_TARGET_ARCHS = vxWorks-68040
+
+# To install files into a location other than $(TOP) define
+#   INSTALL_LOCATION here.
+#INSTALL_LOCATION=</path/name/to/install/top>
+
+# Set this when your IOC and the host use different paths
+#   to access the application. This will be needed to boot
+#   from a Microsoft FTP server or with some NFS mounts.
+# You must rebuild in the iocBoot directory for this to
+#   take effect.
+#IOCS_APPL_TOP = </IOC/path/to/application/top>

--- a/MUONTPAR/configure/Makefile
+++ b/MUONTPAR/configure/Makefile
@@ -1,0 +1,8 @@
+TOP=..
+
+include $(TOP)/configure/CONFIG
+
+TARGETS = $(CONFIG_TARGETS)
+CONFIGS += $(subst ../,,$(wildcard $(CONFIG_INSTALLS)))
+
+include $(TOP)/configure/RULES

--- a/MUONTPAR/configure/RELEASE
+++ b/MUONTPAR/configure/RELEASE
@@ -1,0 +1,11 @@
+# top level master release and local private options 
+include $(TOP)/../../../configure/MASTER_RELEASE
+-include $(TOP)/../../../configure/MASTER_RELEASE.$(EPICS_HOST_ARCH)
+-include $(TOP)/../../../configure/MASTER_RELEASE.private
+-include $(TOP)/../../../configure/MASTER_RELEASE.private.$(EPICS_HOST_ARCH)
+
+# optional extra local definitions here
+-include $(TOP)/configure/RELEASE.private
+
+include $(TOP)/../../../ISIS_CONFIG
+-include $(TOP)/../../../ISIS_CONFIG.$(EPICS_HOST_ARCH)

--- a/MUONTPAR/configure/RULES
+++ b/MUONTPAR/configure/RULES
@@ -1,0 +1,6 @@
+# RULES
+
+include $(CONFIG)/RULES
+
+# Library should be rebuilt because LIBOBJS may have changed.
+$(LIBNAME): ../Makefile

--- a/MUONTPAR/configure/RULES.ioc
+++ b/MUONTPAR/configure/RULES.ioc
@@ -1,0 +1,2 @@
+#RULES.ioc
+include $(CONFIG)/RULES.ioc

--- a/MUONTPAR/configure/RULES_DIRS
+++ b/MUONTPAR/configure/RULES_DIRS
@@ -1,0 +1,2 @@
+#RULES_DIRS
+include $(CONFIG)/RULES_DIRS

--- a/MUONTPAR/configure/RULES_TOP
+++ b/MUONTPAR/configure/RULES_TOP
@@ -1,0 +1,3 @@
+#RULES_TOP
+include $(CONFIG)/RULES_TOP
+

--- a/MUONTPAR/iocBoot/Makefile
+++ b/MUONTPAR/iocBoot/Makefile
@@ -1,0 +1,6 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS += $(wildcard *ioc*)
+DIRS += $(wildcard as*)
+include $(CONFIG)/RULES_DIRS
+

--- a/MUONTPAR/iocBoot/iocMUONTPAR-IOC-01/Makefile
+++ b/MUONTPAR/iocBoot/iocMUONTPAR-IOC-01/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat runIOC.bat relPaths.sh runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/MUONTPAR/iocBoot/iocMUONTPAR-IOC-01/config.xml
+++ b/MUONTPAR/iocBoot/iocMUONTPAR-IOC-01/config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+  <config_part>
+    <ioc_desc>Provides the muon TPAR files</ioc_desc>
+    <macros>
+      <macro name="TPAR_FILE" pattern="^.{0,40}$" description="TPAR file name in directory C:\\Instrument\\Settings. 40 Character maximum." hasDefault="NO" />
+    </macros>
+  </config_part>
+</ioc_config>

--- a/MUONTPAR/iocBoot/iocMUONTPAR-IOC-01/st.cmd
+++ b/MUONTPAR/iocBoot/iocMUONTPAR-IOC-01/st.cmd
@@ -1,0 +1,29 @@
+#!../../bin/windows-x64-debug/MUONTPAR-IOC-01
+
+< envPaths
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/MUONTPAR-IOC-01.dbd"
+MUONTPAR_IOC_01_registerRecordDeviceDriver pdbbase
+
+##ISIS## Run IOC initialisation 
+< $(IOCSTARTUP)/init.cmd
+
+## Load record instances
+
+##ISIS## Load common DB records 
+< $(IOCSTARTUP)/dbload.cmd
+
+## Load our record instances
+dbLoadRecords("$(TOP)/db/muon_tpar.db","P=$(MYPVPREFIX)$(IOCNAME):,TPAR_FILE=$(TPAR_FILE=)")
+
+##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
+< $(IOCSTARTUP)/preiocinit.cmd
+
+cd ${TOP}/iocBoot/${IOC}
+iocInit
+
+##ISIS## Stuff that needs to be done after iocInit is called e.g. sequence programs 
+< $(IOCSTARTUP)/postiocinit.cmd

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ IOCDIRS += ICEFRDGE
 IOCDIRS += CRYOSMS
 IOCDIRS += ZFMAGFLD
 IOCDIRS += ZFCNTRL
+IOCDIRS += MUONTPAR
 
 ## check on missing directories
 IOCMAKES = $(wildcard */Makefile)


### PR DESCRIPTION
Adds an IOC holding the muon tpar files.

This is needed for the muon beamlines, to let them configure which tpar file they need to use in their configuration. We could not use the existing INSTETC PVs as they are not configurable in the config.