### PR TITLE
made changes to regex for some macros to allow users to input only 40…

### DIFF
--- a/CCD100/iocBoot/iocCCD100-IOC-01/config.xml
+++ b/CCD100/iocBoot/iocCCD100-IOC-01/config.xml
@@ -9,7 +9,7 @@
 <macro name="PARITY" pattern="^(even)|(odd)|(none)$" description="Serial communication parity, defaults to none." defaultValue="none" hasDefault="YES" />
 <macro name="STOP" pattern="^[0-9]$" description="Serial communication stop bit, defaults to 1." defaultValue="1" hasDefault="YES" />
 <macro name="ADDRESS" pattern="^[a-h]$" description="The address of the CCD100, defaults to a." defaultValue="a" hasDefault="YES" />
-<macro name="DEV_NAME" pattern="^\w*$" description="A user friendly name for the device, defaults to blank." defaultValue="" hasDefault="YES" />
+<macro name="DEV_NAME" pattern="^\w{0,40}$" description="A user friendly name for the device, defaults to blank." defaultValue="" hasDefault="YES" />
 
 </macros>
 </config_part>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-01/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-01/config.xml
@@ -8,7 +8,7 @@
 	<macro name="USE_SLEW" pattern="^(0|1)$" description="1 to user slew, 0 otherwise; defaults to 0" defaultValue="0" hasDefault="YES" />
 
     <macro name="CALIBRATED" pattern="^(0|1)$" description="1 to use calibration file, 0 otherwise; defaults to 1" defaultValue="1" hasDefault="YES" />
-    <macro name="CALIB_FILE" description="Name of calibration File; defaults to default_calib.dat" defaultValue="default_calib.dat" hasDefault="YES" />
+    <macro name="CALIB_FILE" pattern="^\w{0,40}$" description="Name of calibration File; defaults to default_calib.dat" defaultValue="default_calib.dat" hasDefault="YES" />
 	<macro name="DEV_TYPE" pattern="^(8800|8500|8000)$" description="Type of danfysik; default 8000" defaultValue="8000" hasDefault="YES" />
     <macro name="SP_AT_STARTUP" pattern="^(YES|NO)$" description="Apply last setpoints at startup; defaults to NO" defaultValue="NO" hasDefault="YES" />
 	

--- a/TRITON/iocBoot/iocTRITON-IOC-01/config.xml
+++ b/TRITON/iocBoot/iocTRITON-IOC-01/config.xml
@@ -5,7 +5,7 @@
 <macros>
 <macro name="IPADDR" pattern="^.*$" description="IP address to connect to." hasDefault="UNKNOWN" />
 <macro name="IPPORT" pattern="^[0-9]+$" description="Port to connect to (defaults to 33576)." defaultValue="33576" hasDefault="YES" />
-<macro name="RAMP_FILE_NAME" pattern="^.*$" description="File name to use for ramp (defaults to Default.txt)." defaultValue="Default.txt" hasDefault="YES" />
+<macro name="RAMP_FILE_NAME" pattern="^\w{0,40}$" description="File name to use for ramp (defaults to Default.txt)." defaultValue="Default.txt" hasDefault="YES" />
 <macro name="USE_RAMP_FILE" pattern="^(0|1)$" description="Whether to use (1) or not use (0) the ramp file specified above (defaults to 0)." defaultValue="0" hasDefault="YES" />
 </macros>
 <pvsets>


### PR DESCRIPTION
### Description of work

Changed Regex to limit certain macro values to 40 characters

### To test

[#4934](https://github.com/ISISComputingGroup/IBEX/issues/4934)

### Acceptance criteria

- [x] Changes are reflected on the GUI 

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
