### PR TITLE
Hot Fix: terminators created after port created as required by real device

### DIFF
--- a/LINMOT/iocBoot/iocLINMOT-IOC-01/st-common.cmd
+++ b/LINMOT/iocBoot/iocLINMOT-IOC-01/st-common.cmd
@@ -22,11 +22,10 @@ $(IFRECSIM) epicsEnvSet("SIMSFX","Sim")
 
 $(IFDEVSIM) drvAsynIPPortConfigure("$(ASERIAL)", "localhost:$(EMULATOR_PORT=57677)")
 $(IFDEVSIM) epicsEnvSet("SIMSFX","")
- 
+  
+$(IFNOTDEVSIM) $(IFNOTRECSIM) drvAsynSerialPortConfigure("$(ASERIAL)", "$(PORT=NUL)", 0, 0, 0)
 $(IFNOTRECSIM) asynOctetSetInputEos("$(ASERIAL)",0,"\r") 
 $(IFNOTRECSIM) asynOctetSetOutputEos("$(ASERIAL)",0,"\r\n")
- 
-$(IFNOTDEVSIM) $(IFNOTRECSIM) drvAsynSerialPortConfigure("$(ASERIAL)", "$(PORT=NUL)", 0, 0, 0)
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(ASERIAL)",0,"baud","$(BAUD=9600)") 
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(ASERIAL)",0,"bits","$(BITS=8)") 
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(ASERIAL)",0,"stop","$(STOP=1)") 


### PR DESCRIPTION
### Description of work

Fixed: Ensured port creation occurred before input/output EOS as this is required by real devices.
