### PR TITLE
Add motion setpoint axes etc to SMC100 and make same as SM300

### DIFF
--- a/SM300/iocBoot/iocSM300-IOC-01/st-common.cmd
+++ b/SM300/iocBoot/iocSM300-IOC-01/st-common.cmd
@@ -60,14 +60,18 @@ iocshCmdLoop("< st-axes.cmd", "MN=\$(I)", "I", 1, 8)
 
 epicsEnvSet("SM300CONFIG","$(ICPCONFIGROOT)/$(IOCNAME)")
 
-# configure axes
+# axes (if configured otherwise this will error)
 < $(SM300CONFIG)/axes.cmd
 
-# motion set points
+# motion set points (if configured otherwise this will error)
 < $(SM300CONFIG)/motionsetpoints.cmd
 
-# sample changer
+# sample changer (if configured otherwise this will error)
 < $(SM300CONFIG)/sampleChanger.cmd
+
+# sample changer (if configured otherwise this will error)
+< $(SM300CONFIG)/motorextensions.cmd
+
 
 ## motor util package
 dbLoadRecords("$(MOTOR)/db/motorUtil.db","P=$(MYPVPREFIX)$(IOCNAME):,$(IFIOC)= ,PVPREFIX=$(MYPVPREFIX)")

--- a/SMC100/iocBoot/iocSMC100-IOC-01/st-common.cmd
+++ b/SMC100/iocBoot/iocSMC100-IOC-01/st-common.cmd
@@ -35,6 +35,21 @@ epicsEnvSet(PN,8)
 ## motor util package
 dbLoadRecords("$(MOTOR)/db/motorUtil.db","P=$(MYPVPREFIX)$(IOCNAME):,$(IFIOC)= ,PVPREFIX=$(MYPVPREFIX)")
 
+
+epicsEnvSet("SMC100CONFIG","$(ICPCONFIGROOT)/$(IOCNAME)")
+
+# axes (if configured otherwise this will error)
+< $(SMC100CONFIG)/axes.cmd
+
+# motion set points (if configured otherwise this will error)
+< $(SMC100CONFIG)/motionsetpoints.cmd
+
+# sample changer (if configured otherwise this will error)
+< $(SMC100CONFIG)/sampleChanger.cmd
+
+# sample changer (if configured otherwise this will error)
+< $(SMC100CONFIG)/motorextensions.cmd
+
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd
 
@@ -64,3 +79,5 @@ $(IFPORT7) create_monitor_set("$(IOCNAME)_7_built_settings.req", 30, "P=$(MYPVPR
 $(IFPORT8) create_monitor_set("$(IOCNAME)_8_built_settings.req", 30, "P=$(MYPVPREFIX)MOT:")
 
 #create_monitor_set("$(IOCNAME)_settings.req", 5, "P=$(MYPVPREFIX)MOT:")
+
+


### PR DESCRIPTION
### Description of work

Add motion setpoints and other standard extensions to the SMC100. Tidy the copied place to highlight possible error.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/5165

### Acceptance criteria

- motion setpoints load

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
