### PR TITLE
Ticket 4919: Update tcIOC to specify PLC version

### DIFF
--- a/TWINCAT/iocBoot/iocTWINCAT-IOC-01/config.xml
+++ b/TWINCAT/iocBoot/iocTWINCAT-IOC-01/config.xml
@@ -5,6 +5,7 @@
 <macros>
 <macro name="TPY_FILE" pattern="^.+$" description="Path to the .tpy file describing the PLC" />
 <macro name="MTRCTRL" pattern="^[0-9]{1,2}$" description="Controller number used in motor address assignment" />
+<macro name="PLC_VERSION" pattern="^[0|1]$" description="The PLC version to communicate with: 0 for the new code and 1 for the old ISIS code" defaultValue="0" hasDefault="YES" />
 </macros>
 </config_part>
 </ioc_config>

--- a/TWINCAT/iocBoot/iocTWINCAT-IOC-01/config.xml
+++ b/TWINCAT/iocBoot/iocTWINCAT-IOC-01/config.xml
@@ -5,7 +5,7 @@
 <macros>
 <macro name="TPY_FILE" pattern="^.+$" description="Path to the .tpy file describing the PLC" />
 <macro name="MTRCTRL" pattern="^[0-9]{1,2}$" description="Controller number used in motor address assignment" />
-<macro name="PLC_VERSION" pattern="^[0|1]$" description="The PLC version to communicate with: 0 for the new code and 1 for the old ISIS code" defaultValue="0" hasDefault="YES" />
+<macro name="PLC_VERSION" pattern="^[0|1]$" description="The PLC version to communicate with: 0 for the old ISIS code and 1 new collaboration code" defaultValue="0" hasDefault="YES" />
 </macros>
 </config_part>
 </ioc_config>

--- a/TWINCAT/iocBoot/iocTWINCAT-IOC-01/st-common.lua
+++ b/TWINCAT/iocBoot/iocTWINCAT-IOC-01/st-common.lua
@@ -1,18 +1,28 @@
-motor_port = "L0"
-num_axes = 8
-pv_prefix = os.getenv("MYPVPREFIX")
-tpy_file = os.getenv("TPY_FILE")
+package.path = package.path .. ';' .. os.getenv("UTILITIES") .. '/lua/luaUtils.lua;'
+local utils = require("luaUtils")
+local getMacroValue = utils.getMacroValue
 
-iocsh.tcSetScanRate(150, 5)
-iocsh.tcLoadRecords (tpy_file, string.format("-eo -devtc -p %s", pv_prefix))
+function twincat_stcommon_main()
+	local motor_port = "L0"
+	local num_axes = 8
+	local pv_prefix = getMacroValue{macro="MYPVPREFIX"}
+	local tpy_file = getMacroValue{macro="TPY_FILE"}
+	local plc_version = getMacroValue{macro="PLC_VERSION", default="0"}
 
-iocsh.devMotorCreateController(motor_port, "Controller", num_axes, pv_prefix)
+	iocsh.tcSetScanRate(150, 2)
+	iocsh.tcLoadRecords (tpy_file, string.format("-eo -devtc -p %s", pv_prefix))
 
-for axis_num=1,num_axes,1
-do
-    motor_pv = string.format("MTR%02i%02i", os.getenv("MTRCTRL"), axis_num)
-    single_axis_db = "db/single_axis.db"
-    db_args = string.format("MYPVPREFIX=%s,MOTOR_PV=%s,MOTOR_PORT=%s,ADDR=%s", pv_prefix, motor_pv, motor_port, axis_num-1)
-	iocsh.devMotorCreateAxis(motor_port, axis_num-1)
-	iocsh.dbLoadRecords(single_axis_db, db_args)
+	iocsh.devMotorCreateController(motor_port, "Controller", num_axes, pv_prefix)
+
+	for axis_num=1,num_axes,1
+	do
+		motor_pv = string.format("MTR%02i%02i", os.getenv("MTRCTRL"), axis_num)
+		single_axis_db = "db/single_axis.db"
+		db_args = string.format("MYPVPREFIX=%s,MOTOR_PV=%s,MOTOR_PORT=%s,ADDR=%s", pv_prefix, motor_pv, motor_port, axis_num-1)
+		iocsh.devMotorCreateAxis(motor_port, axis_num-1, plc_version)
+		iocsh.dbLoadRecords(single_axis_db, db_args)
+	end
+
 end
+
+twincat_stcommon_main()

--- a/TWINCAT/iocBoot/iocTWINCAT-IOC-01/st-common.lua
+++ b/TWINCAT/iocBoot/iocTWINCAT-IOC-01/st-common.lua
@@ -7,7 +7,7 @@ function twincat_stcommon_main()
 	local num_axes = 8
 	local pv_prefix = getMacroValue{macro="MYPVPREFIX"}
 	local tpy_file = getMacroValue{macro="TPY_FILE"}
-	local plc_version = getMacroValue{macro="PLC_VERSION", default="0"}
+	local plc_version = getMacroValue{macro="PLC_VERSION", default="1"}
 
 	iocsh.tcSetScanRate(150, 2)
 	iocsh.tcLoadRecords (tpy_file, string.format("-eo -devtc -p %s", pv_prefix))


### PR DESCRIPTION
### Description of work

See https://github.com/ISISComputingGroup/IBEX/issues/4919

tcIOC can now support both the old ISIS code and the new code from the Twincat collaboration, this is controlled through an environment variable. The LUA code was also updated.

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
