### PR TITLE
Fix recsim mode for ioc system tests

### DIFF
--- a/MK2CHOPR/iocBoot/iocMK2CHOPR-IOC-01/st-common.cmd
+++ b/MK2CHOPR/iocBoot/iocMK2CHOPR-IOC-01/st-common.cmd
@@ -5,17 +5,19 @@ epicsEnvSet "DEVICE" "L0"
 < $(IOCSTARTUP)/init.cmd
 
 ## For emulator use:
-$(IFNOTRECSIM) $(IFDEVSIM) freeIPPort("FREEPORT")  
-$(IFNOTRECSIM) $(IFDEVSIM) epicsEnvShow("FREEPORT") 
-$(IFNOTRECSIM) $(IFDEVSIM) drvAsynIPPortConfigure("$(DEVICE)", "localhost:$(FREEPORT=0)")
+$(IFDEVSIM) freeIPPort("FREEPORT")  
+$(IFDEVSIM) epicsEnvShow("FREEPORT") 
+$(IFDEVSIM) drvAsynIPPortConfigure("$(DEVICE)", "localhost:$(FREEPORT=0)")
 
-$(IFNOTDEVSIM) drvAsynSerialPortConfigure("$(DEVICE)", "$(PORT)", 0, 0, 0, 0)
-$(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "baud", "$(BAUD=9600)")
-$(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "bits", "$(BITS=7)")
-$(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "parity", "$(PARITY=even)")
-$(IFNOTDEVSIM) asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)")
-$(IFNOTDEVSIM) asynOctetSetInputEos("$(DEVICE)", -1, "$(OEOS=\r)")
-$(IFNOTDEVSIM) asynOctetSetOutputEos("$(DEVICE)", -1, "$(IEOS=\r)")
+$(IFRECSIM) drvAsynSerialPortConfigure("$(DEVICE)", "NUL", 0, 1, 0, 0)
+
+$(IFNOTDEVSIM) $(IFNOTRECSIM) drvAsynSerialPortConfigure("$(DEVICE)", "$(PORT)", 0, 0, 0, 0)
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "baud", "$(BAUD=9600)")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "bits", "$(BITS=7)")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "parity", "$(PARITY=even)")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynOctetSetInputEos("$(DEVICE)", -1, "$(OEOS=\r)")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynOctetSetOutputEos("$(DEVICE)", -1, "$(IEOS=\r)")
 
 # Hardware flow control off
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")

--- a/MK3CHOPR/MK3CHOPR-IOC-01App/Db/mk3_common.db
+++ b/MK3CHOPR/MK3CHOPR-IOC-01App/Db/mk3_common.db
@@ -6,7 +6,6 @@ record(bo, "$(P)SIM")
     field(ONAM, "YES")
     field(VAL, "$(RECSIM=0)")
 	field(PINI, "YES")
-    field(FLNK, "$(P)VERSION")
 }
 
 record(bo, "$(P)DISABLE") 

--- a/MK3CHOPR/iocBoot/iocMk3CHOPR-IOC-01/st.cmd
+++ b/MK3CHOPR/iocBoot/iocMk3CHOPR-IOC-01/st.cmd
@@ -18,7 +18,8 @@ MK3CHOPR_IOC_01_registerRecordDeviceDriver pdbbase
 < $(IOCSTARTUP)/init.cmd
 
 # Portname, path to config file, use mock (=1 for mock)
-mk3DriverConfigure("MK3", "C:/LabVIEW Modules/Drivers/ISIS MK3 Disc Chopper/MK3_Chopper.config", $(DEVSIM))
+$(IFSIM) mk3DriverConfigure("MK3", "ignored_notneeded.config", 1) # RECSIM or DEVSIM
+$(IFNOTSIM) mk3DriverConfigure("MK3", "C:/LabVIEW Modules/Drivers/ISIS MK3 Disc Chopper/MK3_Chopper.config", 0)
 
 ## Load record instances
 


### PR DESCRIPTION
### Description of work

Define mock chopper in RECSIM as well as DEVSIM

### To test

See ISISComputingGroup/IBEX#5354

### Acceptance criteria

* ioc system tests work in recsim

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
