### PR TITLE
Recode to fix setpoint/readback sync issue and also remove use of epicsThreadSleep

### DIFF
--- a/FERMCHOP/FERMCHOP-IOC-01App/src/keep_sp_and_rbv_in_sync.st
+++ b/FERMCHOP/FERMCHOP-IOC-01App/src/keep_sp_and_rbv_in_sync.st
@@ -22,7 +22,7 @@ PV(double, readback, "{READBACK}", Monitor);
 
 /* system pvs */
 PV(double, tolerance, "{TOLERANCE}", Monitor);
-PV(double, delay, "{DELAY}", Monitor);
+PV(double, delay_time, "{DELAY}", Monitor);
 
 %{
 int notWithinTolerance(double setpoint, double readback, double tolerance) {
@@ -39,10 +39,15 @@ ss keep_sp_and_rbv_in_sync
     /* setpoint alarm must be zero to avoid sending zero to device when first starting driver (SP will be UDF_alarm) */
     when(notWithinTolerance(setpoint, readback, tolerance) && setpoint_alarm == 0) 
 	{
-      errlogSevPrintf(errlogMinor, "Keep SP and RBV in sync: setpoint ('%s') not equal readback ('%s'). Reprocessing setpoint in %f seconds if still not the same.\n", setpoint_description, readback_description, delay);
+      errlogSevPrintf(errlogMinor, "Keep SP and RBV in sync: setpoint ('%s') not equal readback ('%s'). Reprocessing setpoint in %f seconds if still not the same.\n", setpoint_description, readback_description, delay_time);
 	  
-	  epicsThreadSleep(delay);
-	  
+    } state checksp
+  }
+
+  state checksp
+  {
+    when(delay(delay_time))
+	{
 	  if (notWithinTolerance(setpoint, readback, tolerance) && setpoint_alarm == 0) {
 	      errlogSevPrintf(errlogMinor, "Keep SP and RBV in sync: setpoint ('%s') not equal readback ('%s'). Reprocessing setpoint now.\n", setpoint_description, readback_description);
 	      PVPUT(setpoint_proc, 1);
@@ -54,9 +59,9 @@ ss keep_sp_and_rbv_in_sync
   
   state wait
   {
-    when(1)
+    when(delay(delay_time))
 	{
-	  epicsThreadSleep(delay);
+	  ;
 	} state idle
   }
 }

--- a/FERMCHOP/FERMCHOP-IOC-01App/src/keep_sp_and_rbv_in_sync.st
+++ b/FERMCHOP/FERMCHOP-IOC-01App/src/keep_sp_and_rbv_in_sync.st
@@ -24,6 +24,8 @@ PV(double, readback, "{READBACK}", Monitor);
 PV(double, tolerance, "{TOLERANCE}", Monitor);
 PV(double, delay_time, "{DELAY}", Monitor);
 
+double old_setpoint; /* keep track of setpoint prior to delay, so as not to accidentally reporcess a new setpoint */
+
 %{
 int notWithinTolerance(double setpoint, double readback, double tolerance) {
     return fabs(setpoint - readback) > tolerance;
@@ -38,30 +40,34 @@ ss keep_sp_and_rbv_in_sync
   {
     /* setpoint alarm must be zero to avoid sending zero to device when first starting driver (SP will be UDF_alarm) */
     when(notWithinTolerance(setpoint, readback, tolerance) && setpoint_alarm == 0) 
-	{
-      errlogSevPrintf(errlogMinor, "Keep SP and RBV in sync: setpoint ('%s') not equal readback ('%s'). Reprocessing setpoint in %f seconds if still not the same.\n", setpoint_description, readback_description, delay_time);
-	  
+    {
+      errlogSevPrintf(errlogMinor, "Keep SP and RBV in sync: setpoint %f ('%s') not equal readback %f ('%s'). Reprocessing setpoint in %f seconds if still not the same.\n", setpoint, setpoint_description, readback, readback_description, delay_time);
+      old_setpoint = setpoint;
     } state checksp
   }
 
   state checksp
   {
+    when(setpoint != old_setpoint)
+    {
+        errlogSevPrintf(errlogMinor, "Keep SP and RBV in sync: Not reprocessing setpoint ('%s') as now changed (%f -> %f).\n", setpoint_description, old_setpoint, setpoint);
+    } state idle
     when(delay(delay_time))
-	{
-	  if (notWithinTolerance(setpoint, readback, tolerance) && setpoint_alarm == 0) {
-	      errlogSevPrintf(errlogMinor, "Keep SP and RBV in sync: setpoint ('%s') not equal readback ('%s'). Reprocessing setpoint now.\n", setpoint_description, readback_description);
-	      PVPUT(setpoint_proc, 1);
-	  } else {
-	      errlogSevPrintf(errlogMinor, "Keep SP and RBV in sync: Not reprocessing setpoint ('%s') because readback is now in sync.\n", setpoint_description);
-	  }
-	} state wait
+    {
+      if (notWithinTolerance(setpoint, readback, tolerance) && setpoint_alarm == 0) {
+          errlogSevPrintf(errlogMinor, "Keep SP and RBV in sync: setpoint %f ('%s') not equal readback %f ('%s'). Reprocessing setpoint now.\n", setpoint, setpoint_description, readback, readback_description);
+          PVPUT(setpoint_proc, 1);
+      } else {
+          errlogSevPrintf(errlogMinor, "Keep SP and RBV in sync: Not reprocessing setpoint %f ('%s') because readback ('%s') is now in sync.\n", setpoint, setpoint_description, readback_description);
+      }
+    } state wait
   }
   
   state wait
   {
     when(delay(delay_time))
-	{
-	  ;
-	} state idle
+    {
+      ;
+    } state idle
   }
 }


### PR DESCRIPTION
### Description of work

* Fix issue with setpoint changing
* Add additional state to remove use of epicsThreadSleep()

### To test

See ISISComputingGroup/IBEX#5383

### Acceptance criteria

* IOC units tests pass

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
