### PR TITLE
macros as int instead of string; remove debug code

### DIFF
--- a/REFL/iocBoot/iocREFL-IOC-01/config.xml
+++ b/REFL/iocBoot/iocREFL-IOC-01/config.xml
@@ -5,10 +5,10 @@
   <ioc_details>Reflectometry Server bla</ioc_details>
   <macros>
     <macro name="CONFIG_FILE" pattern="^[\w\-]+\.py$" description="Reflectometry configuration to use. Default is config.py" defaultValue="config.py" hasDefault="YES" />
-    <macro name="OPTIONAL_1" pattern="^True|False$" description="Boolean flag 1 for use inside reflectometry configuration." defaultValue="False" hasDefault="YES" />
-    <macro name="OPTIONAL_2" pattern="^True|False$" description="Boolean flag 2 for use inside reflectometry configuration." defaultValue="False" hasDefault="YES" />
-    <macro name="OPTIONAL_3" pattern="^True|False$" description="Boolean flag 3 for use inside reflectometry configuration." defaultValue="False" hasDefault="YES" />
-    <macro name="OPTIONAL_4" pattern="^True|False$" description="Boolean flag 4 for use inside reflectometry configuration." defaultValue="False" hasDefault="YES" />
+    <macro name="OPTIONAL_1" pattern="^0|1$" description="Boolean flag 1 for use inside reflectometry configuration." defaultValue="0" hasDefault="YES" />
+    <macro name="OPTIONAL_2" pattern="^0|1$" description="Boolean flag 2 for use inside reflectometry configuration." defaultValue="0" hasDefault="YES" />
+    <macro name="OPTIONAL_3" pattern="^0|1$" description="Boolean flag 3 for use inside reflectometry configuration." defaultValue="0" hasDefault="YES" />
+    <macro name="OPTIONAL_4" pattern="^0|1$" description="Boolean flag 4 for use inside reflectometry configuration." defaultValue="0" hasDefault="YES" />
   </macros>
  </config_part>
 </ioc_config>

--- a/REFL/iocBoot/iocREFL-IOC-01/runIOC.bat
+++ b/REFL/iocBoot/iocREFL-IOC-01/runIOC.bat
@@ -1,4 +1,4 @@
-REM @echo off
+@echo off
 setlocal
 set MYDIRBLOCK=%~dp0
 call C:\Instrument\Apps\EPICS\config_env_base.bat
@@ -12,8 +12,6 @@ set PYTHONUNBUFFERED=TRUE
 
 set "GETMACROS=C:\Instrument\Apps\EPICS\support\icpconfig\master\bin\%EPICS_HOST_ARCH%\icpconfigGetMacros.exe"
 set "MYIOCNAME=REFL_01"
-
-echo PRE %REFL_MACROS%
 
 if "%REFL_MACROS%"=="" (
     REM need this funny syntax to be able to set eol correctly - see google


### PR DESCRIPTION
Fix possible macro values in ioc config (and remove some leftover debug code) 