### PR TITLE
Allow . in card macro names

### DIFF
--- a/MERCURY_ITC/iocBoot/iocMERCURY-IOC-01/config.xml
+++ b/MERCURY_ITC/iocBoot/iocMERCURY-IOC-01/config.xml
@@ -5,14 +5,14 @@
 <macros>
 <!-- check st-port.cmd for defaults -->
 <macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" hasDefault="NO" />
-<macro name="TEMP_1" pattern="^[A-Z0-9]+$" description="Card identifier for Temperature 1 (e.g. MB1). Blank for no controller." hasDefault="YES" defaultValue=""/>
-<macro name="TEMP_2" pattern="^[A-Z0-9]+$" description="Card identifier for Temperature 2 (e.g. MB1). Blank for no controller." hasDefault="YES" defaultValue="" />
-<macro name="TEMP_3" pattern="^[A-Z0-9]+$" description="Card identifier for Temperature 3 (e.g. MB1). Blank for no controller." hasDefault="YES" defaultValue="" />
-<macro name="TEMP_4" pattern="^[A-Z0-9]+$" description="Card identifier for Temperature 4 (e.g. MB1). Blank for no controller." hasDefault="YES" defaultValue="" />
-<macro name="LEVEL_1" pattern="^[A-Z0-9]+$" description="Card identifier for Level 1 (e.g. DB1). Blank for no controller." hasDefault="YES" defaultValue="" />
-<macro name="LEVEL_2" pattern="^[A-Z0-9]+$" description="Card identifier for Level 2 (e.g. DB1). Blank for no controller." hasDefault="YES" defaultValue="" />
-<macro name="PRESSURE_1" pattern="^[A-Z0-9]+$" description="Card identifier for Pressure 1 (e.g. DB1). Blank for no controller." hasDefault="YES" defaultValue="" />
-<macro name="PRESSURE_2" pattern="^[A-Z0-9]+$" description="Card identifier for Pressure 2 (e.g. DB1). Blank for no controller." hasDefault="YES" defaultValue="" />
+<macro name="TEMP_1" pattern="^.*$" description="Card identifier for Temperature 1 (e.g. MB1). Blank for no controller." hasDefault="YES" defaultValue=""/>
+<macro name="TEMP_2" pattern="^.*$" description="Card identifier for Temperature 2 (e.g. MB1). Blank for no controller." hasDefault="YES" defaultValue="" />
+<macro name="TEMP_3" pattern="^.*$" description="Card identifier for Temperature 3 (e.g. MB1). Blank for no controller." hasDefault="YES" defaultValue="" />
+<macro name="TEMP_4" pattern="^.*$" description="Card identifier for Temperature 4 (e.g. MB1). Blank for no controller." hasDefault="YES" defaultValue="" />
+<macro name="LEVEL_1" pattern="^.*$" description="Card identifier for Level 1 (e.g. DB1). Blank for no controller." hasDefault="YES" defaultValue="" />
+<macro name="LEVEL_2" pattern="^.*$" description="Card identifier for Level 2 (e.g. DB1). Blank for no controller." hasDefault="YES" defaultValue="" />
+<macro name="PRESSURE_1" pattern="^.*$" description="Card identifier for Pressure 1 (e.g. DB1). Blank for no controller." hasDefault="YES" defaultValue="" />
+<macro name="PRESSURE_2" pattern="^.*$" description="Card identifier for Pressure 2 (e.g. DB1). Blank for no controller." hasDefault="YES" defaultValue="" />
 </macros>
 </config_part>
 </ioc_config>

--- a/MERCURY_ITC/iocBoot/iocMERCURY-IOC-01/config.xml
+++ b/MERCURY_ITC/iocBoot/iocMERCURY-IOC-01/config.xml
@@ -5,14 +5,14 @@
 <macros>
 <!-- check st-port.cmd for defaults -->
 <macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" hasDefault="NO" />
-<macro name="TEMP_1" pattern="^.*$" description="Card identifier for Temperature 1 (e.g. MB1). Blank for no controller." hasDefault="YES" defaultValue=""/>
-<macro name="TEMP_2" pattern="^.*$" description="Card identifier for Temperature 2 (e.g. MB1). Blank for no controller." hasDefault="YES" defaultValue="" />
-<macro name="TEMP_3" pattern="^.*$" description="Card identifier for Temperature 3 (e.g. MB1). Blank for no controller." hasDefault="YES" defaultValue="" />
-<macro name="TEMP_4" pattern="^.*$" description="Card identifier for Temperature 4 (e.g. MB1). Blank for no controller." hasDefault="YES" defaultValue="" />
-<macro name="LEVEL_1" pattern="^.*$" description="Card identifier for Level 1 (e.g. DB1). Blank for no controller." hasDefault="YES" defaultValue="" />
-<macro name="LEVEL_2" pattern="^.*$" description="Card identifier for Level 2 (e.g. DB1). Blank for no controller." hasDefault="YES" defaultValue="" />
-<macro name="PRESSURE_1" pattern="^.*$" description="Card identifier for Pressure 1 (e.g. DB1). Blank for no controller." hasDefault="YES" defaultValue="" />
-<macro name="PRESSURE_2" pattern="^.*$" description="Card identifier for Pressure 2 (e.g. DB1). Blank for no controller." hasDefault="YES" defaultValue="" />
+<macro name="TEMP_1" pattern="^.*$" description="Card identifier for Temperature 1 (e.g. MB1.T1). Blank for no controller." hasDefault="YES" defaultValue=""/>
+<macro name="TEMP_2" pattern="^.*$" description="Card identifier for Temperature 2 (e.g. MB1.T1). Blank for no controller." hasDefault="YES" defaultValue="" />
+<macro name="TEMP_3" pattern="^.*$" description="Card identifier for Temperature 3 (e.g. MB1.T1). Blank for no controller." hasDefault="YES" defaultValue="" />
+<macro name="TEMP_4" pattern="^.*$" description="Card identifier for Temperature 4 (e.g. MB1.T1). Blank for no controller." hasDefault="YES" defaultValue="" />
+<macro name="LEVEL_1" pattern="^.*$" description="Card identifier for Level 1 (e.g. DB1.L1). Blank for no controller." hasDefault="YES" defaultValue="" />
+<macro name="LEVEL_2" pattern="^.*$" description="Card identifier for Level 2 (e.g. DB1.L1). Blank for no controller." hasDefault="YES" defaultValue="" />
+<macro name="PRESSURE_1" pattern="^.*$" description="Card identifier for Pressure 1 (e.g. DB1.P1). Blank for no controller." hasDefault="YES" defaultValue="" />
+<macro name="PRESSURE_2" pattern="^.*$" description="Card identifier for Pressure 2 (e.g. DB1.P1). Blank for no controller." hasDefault="YES" defaultValue="" />
 </macros>
 </config_part>
 </ioc_config>


### PR DESCRIPTION
### Description of work

config.xml was too strict not allowing DB1.P1 which is required for running with some card names.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/5497

### Acceptance criteria

https://github.com/ISISComputingGroup/IBEX/issues/5497#issuecomment-668023501

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
