### PR TITLE
Fix library order for linux static

### DIFF
--- a/KHLY2001/KHLY2001-IOC-01App/src/build.mak
+++ b/KHLY2001/KHLY2001-IOC-01App/src/build.mak
@@ -38,6 +38,8 @@ $(APPNAME)_DBD += keithley_2001_buffer_parsing.dbd
 $(APPNAME)_DBD += keithley_2001_state_machine.dbd
 
 # Add all the support libraries needed by this IOC
+## IOC support LIB
+$(APPNAME)_LIBS += Keithley_2001
 ## ISIS standard libraries ##
 $(APPNAME)_LIBS += devIocStats 
 $(APPNAME)_LIBS += pvdump $(MYSQLLIB) easySQLite sqlite 
@@ -52,9 +54,7 @@ $(APPNAME)_LIBS += asyn
 $(APPNAME)_LIBS += asubFunctions 
 $(APPNAME)_LIBS += calc sscan
 $(APPNAME)_LIBS += VISAdrv
-$(APPNAME)_LIBS += seq pv 
-## IOC support LIB
-$(APPNAME)_LIBS += Keithley_2001
+$(APPNAME)_LIBS += seq pv
 
 include $(VISADRV)/visa_lib.mak
 


### PR DESCRIPTION
### Description of work

Fix library order for linux static build

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
