### PR TITLE
Ticket3185 remote mode reliability

### DIFF
--- a/KEPCO/iocBoot/iocKEPCO-IOC-01/config.xml
+++ b/KEPCO/iocBoot/iocKEPCO-IOC-01/config.xml
@@ -4,6 +4,7 @@
 <ioc_desc>Kepco power supply unit</ioc_desc>
 <macros>
 <macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" hasDefault="NO" />
+<macro name="ON_START" pattern="^0|1|2$" description="What to do on start? 0 for nothing, 1 for reset and resend parameters and 2 for set to remote mode" hasDefault="YES" defaultValue="2" />
 </macros>
 </config_part>
 </ioc_config>

--- a/KEPCO/iocBoot/iocKEPCO-IOC-01/config.xml
+++ b/KEPCO/iocBoot/iocKEPCO-IOC-01/config.xml
@@ -4,7 +4,7 @@
 <ioc_desc>Kepco power supply unit</ioc_desc>
 <macros>
 <macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" hasDefault="NO" />
-<macro name="ON_START" pattern="^0|1|2|3$" description="What to do on start? 0 for use firmware, 1 for reset and resend parameters, 2 for set to remote mode, 3 for do nothing" hasDefault="YES" defaultValue="0" />
+<macro name="RESET_ON_START" pattern="^0|1|2$" description="Whether to reset and resend setpoints at ioc start. 0 to not. 1 to do so if firmware is less than version 2.0. 2 to do so and disregard firmware version" hasDefault="YES" defaultValue="1" />
 </macros>
 </config_part>
 </ioc_config>

--- a/KEPCO/iocBoot/iocKEPCO-IOC-01/config.xml
+++ b/KEPCO/iocBoot/iocKEPCO-IOC-01/config.xml
@@ -4,7 +4,7 @@
 <ioc_desc>Kepco power supply unit</ioc_desc>
 <macros>
 <macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" hasDefault="NO" />
-<macro name="ON_START" pattern="^0|1|2$" description="What to do on start? 0 for nothing, 1 for reset and resend parameters and 2 for set to remote mode" hasDefault="YES" defaultValue="2" />
+<macro name="ON_START" pattern="^0|1|2|3$" description="What to do on start? 0 for use firmware, 1 for reset and resend parameters, 2 for set to remote mode, 3 for do nothing" hasDefault="YES" defaultValue="0" />
 </macros>
 </config_part>
 </ioc_config>

--- a/KEPCO/iocBoot/iocKEPCO-IOC-01/st-common.cmd
+++ b/KEPCO/iocBoot/iocKEPCO-IOC-01/st-common.cmd
@@ -28,7 +28,7 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "ixoff", "Y")
 < $(IOCSTARTUP)/dbload.cmd
 
 ## Load record instances
-dbLoadRecords("$(KEPCO)/db/kepco.db","P=$(MYPVPREFIX)$(IOCNAME):, PORT=L0, RESET=NO, DISABLE=$(DISABLE=0),RECSIM=$(RECSIM=0), ON_START=$(ON_START=0)")
+dbLoadRecords("$(KEPCO)/db/kepco.db","P=$(MYPVPREFIX)$(IOCNAME):, PORT=L0, RESET=NO, DISABLE=$(DISABLE=0),RECSIM=$(RECSIM=0), RESET_ON_START=$(RESET_ON_START=1)")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd

--- a/KEPCO/iocBoot/iocKEPCO-IOC-01/st-common.cmd
+++ b/KEPCO/iocBoot/iocKEPCO-IOC-01/st-common.cmd
@@ -28,7 +28,7 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "ixoff", "Y")
 < $(IOCSTARTUP)/dbload.cmd
 
 ## Load record instances
-dbLoadRecords("$(KEPCO)/db/kepco.db","P=$(MYPVPREFIX)$(IOCNAME):, PORT=L0, RESET=NO, DISABLE=$(DISABLE=0),RECSIM=$(RECSIM=0)")
+dbLoadRecords("$(KEPCO)/db/kepco.db","P=$(MYPVPREFIX)$(IOCNAME):, PORT=L0, RESET=NO, DISABLE=$(DISABLE=0),RECSIM=$(RECSIM=0), ON_START=$(ON_START=2)")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd

--- a/KEPCO/iocBoot/iocKEPCO-IOC-01/st-common.cmd
+++ b/KEPCO/iocBoot/iocKEPCO-IOC-01/st-common.cmd
@@ -28,7 +28,7 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "ixoff", "Y")
 < $(IOCSTARTUP)/dbload.cmd
 
 ## Load record instances
-dbLoadRecords("$(KEPCO)/db/kepco.db","P=$(MYPVPREFIX)$(IOCNAME):, PORT=L0, RESET=NO, DISABLE=$(DISABLE=0),RECSIM=$(RECSIM=0), ON_START=$(ON_START=2)")
+dbLoadRecords("$(KEPCO)/db/kepco.db","P=$(MYPVPREFIX)$(IOCNAME):, PORT=L0, RESET=NO, DISABLE=$(DISABLE=0),RECSIM=$(RECSIM=0), ON_START=$(ON_START=0)")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd


### PR DESCRIPTION
### Description of work

Add macro to allow configuration of resetting the kepco and resending setpoints on startup of the ioc.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/3185

### Acceptance criteria

*List the acceptance criteria for the PR*

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
