### PR TITLE
Remove logging RAW status

### DIFF
--- a/FERMCHOP/FERMCHOP-IOC-01App/Db/fermchop.db
+++ b/FERMCHOP/FERMCHOP-IOC-01App/Db/fermchop.db
@@ -33,7 +33,7 @@ record(waveform, "$(P)STATUS:RAW")
 {
     field(DESC, "Raw response from chopper")
     field(DTYP, "stream")
-    field(NELM, "20")
+    field(NELM, "100")
     field(FTVL, "STRING")
     field(INP,  "@fc_$(INST=merlin).proto getStatus $(PORT)")
     field(SCAN, "1 second")

--- a/FERMCHOP/FERMCHOP-IOC-01App/Db/fermchop.db
+++ b/FERMCHOP/FERMCHOP-IOC-01App/Db/fermchop.db
@@ -33,7 +33,7 @@ record(waveform, "$(P)STATUS:RAW")
 {
     field(DESC, "Raw response from chopper")
     field(DTYP, "stream")
-    field(NELM, "100")
+    field(NELM, "20")
     field(FTVL, "STRING")
     field(INP,  "@fc_$(INST=merlin).proto getStatus $(PORT)")
     field(SCAN, "1 second")
@@ -41,8 +41,6 @@ record(waveform, "$(P)STATUS:RAW")
 	field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:STATUS:RAW")
     field(SDIS, "$(P)DISABLE")
-	
-	info(archive, "VAL")
 }
 
 record(ao, "$(P)_MHZ") {


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/5644

### To test

* On master, with a running instrument start the fermichopper ioc with devsim `%PYTHON% run_tests.py -t fermichopper_merlin -a -tm DEVSIM`.
* Confirm that ARINST is logging a large number of messages about `FERMCHOP_01:STATUS:RAW.VAL exceeds 80 chars`
* Switch to this branch and rebuild the IOC
* Restart ARINST
* Re run the ioc and confirm that there is no longer any logging

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
