### PR TITLE
Ticket 5836: Fix autosave for GALILMUL

### DIFF
--- a/GALILMUL/iocBoot/iocGALILMUL-IOC-01/GALILMUL_01_positions.req
+++ b/GALILMUL/iocBoot/iocGALILMUL-IOC-01/GALILMUL_01_positions.req
@@ -1,0 +1,2 @@
+file "GALIL_controller_positions.req" "P=$(P),CCP=$(MTRCTRL1)"
+file "GALIL_controller_positions.req" "P=$(P),CCP=$(MTRCTRL2)"

--- a/GALILMUL/iocBoot/iocGALILMUL-IOC-01/GALILMUL_01_settings.req
+++ b/GALILMUL/iocBoot/iocGALILMUL-IOC-01/GALILMUL_01_settings.req
@@ -1,0 +1,2 @@
+file "GALIL_controller_settings.req" "P=$(P),CCP=$(MTRCTRL1)"
+file "GALIL_controller_settings.req" "P=$(P),CCP=$(MTRCTRL2)"

--- a/GALILMUL/iocBoot/iocGALILMUL-IOC-01/GALIL_01_positions.req
+++ b/GALILMUL/iocBoot/iocGALILMUL-IOC-01/GALIL_01_positions.req
@@ -1,1 +1,0 @@
-file "GALIL_controller_positions.req" "P=$(P),CCP=$(CCP)"

--- a/GALILMUL/iocBoot/iocGALILMUL-IOC-01/GALIL_01_settings.req
+++ b/GALILMUL/iocBoot/iocGALILMUL-IOC-01/GALIL_01_settings.req
@@ -1,1 +1,0 @@
-file "GALIL_controller_settings.req" "P=$(P),CCP=$(CCP)"

--- a/GALILMUL/iocBoot/iocGALILMUL-IOC-01/IMATStagesMenu.req
+++ b/GALILMUL/iocBoot/iocGALILMUL-IOC-01/IMATStagesMenu.req
@@ -1,2 +1,0 @@
-file configMenu.req P=$(CMP),CONFIG=$(CONFIG)
-file $(IOCNAME)_settings.req P=$(P),CCP=$(MTRCTRL)

--- a/GALILMUL/iocBoot/iocGALILMUL-IOC-01/st-common.cmd
+++ b/GALILMUL/iocBoot/iocGALILMUL-IOC-01/st-common.cmd
@@ -64,14 +64,8 @@ motorUtilInit("$(MYPVPREFIX)$(IOCNAME):")
 ##ISIS## Stuff that needs to be done after iocInit is called e.g. sequence programs 
 < $(IOCSTARTUP)/postiocinit.cmd
 
-stringiftest("HASMTRCTRL1", "$(MTRCTRL1=)", 0, 0)
-$(IFNOTHASMTRCTRL1) errlogSev(2, "MTRCTRL1 has not been set")
-
-stringiftest("HASMTRCTRL2", "$(MTRCTRL2=)", 0, 0)
-$(IFNOTHASMTRCTRL2) errlogSev(2, "MTRCTRL2 has not been set")
-
 # Save motor positions every 5 seconds
-$(IFNOTRECSIM) create_monitor_set("$(IOCNAME)_positions.req", 5, "P=$(MYPVPREFIX)MOT:,MTRCTRL1=$(MTRCTRL1),MTRCTRL2=$(MTRCTRL2),IFHASMTRCTRL1=$(IFHASMTRCTRL1),IFHASMTRCTRL2=$(IFHASMTRCTRL2)")
+$(IFNOTDEVSIM)$(IFNOTRECSIM) create_monitor_set("$(IOCNAME)_positions.req", 5, "P=$(MYPVPREFIX)MOT:,MTRCTRL1=$(MTRCTRL1=),MTRCTRL2=$(MTRCTRL2=)")
 
 # Save motor settings every 30 seconds
-$(IFNOTRECSIM) create_monitor_set("$(IOCNAME)_settings.req", 30, "P=$(MYPVPREFIX)MOT:,MTRCTRL1=$(MTRCTRL1),MTRCTRL2=$(MTRCTRL2),IFHASMTRCTRL1=$(IFHASMTRCTRL1),IFHASMTRCTRL2=$(IFHASMTRCTRL2)")
+$(IFNOTDEVSIM)$(IFNOTRECSIM) create_monitor_set("$(IOCNAME)_settings.req", 30, "P=$(MYPVPREFIX)MOT:,MTRCTRL1=$(MTRCTRL1=),MTRCTRL2=$(MTRCTRL2=)")

--- a/GALILMUL/iocBoot/iocGALILMUL-IOC-01/st-common.cmd
+++ b/GALILMUL/iocBoot/iocGALILMUL-IOC-01/st-common.cmd
@@ -65,12 +65,13 @@ motorUtilInit("$(MYPVPREFIX)$(IOCNAME):")
 < $(IOCSTARTUP)/postiocinit.cmd
 
 stringiftest("HASMTRCTRL1", "$(MTRCTRL1=)", 0, 0)
-$(IFNOTHASMTRCTRL1) errlogSev(2, "MTRCTRL has not been set")
+$(IFNOTHASMTRCTRL1) errlogSev(2, "MTRCTRL1 has not been set")
+
+stringiftest("HASMTRCTRL2", "$(MTRCTRL2=)", 0, 0)
+$(IFNOTHASMTRCTRL2) errlogSev(2, "MTRCTRL2 has not been set")
 
 # Save motor positions every 5 seconds
-$(IFHASMTRCTRL1) $(IFNOTDEVSIM) $(IFNOTRECSIM) create_monitor_set("$(IOCNAME)_positions.req", 5, "P=$(MYPVPREFIX)MOT:,CCP=$(MTRCTRL)")
+$(IFNOTRECSIM) create_monitor_set("$(IOCNAME)_positions.req", 5, "P=$(MYPVPREFIX)MOT:,MTRCTRL1=$(MTRCTRL1),MTRCTRL2=$(MTRCTRL2),IFHASMTRCTRL1=$(IFHASMTRCTRL1),IFHASMTRCTRL2=$(IFHASMTRCTRL2)")
 
 # Save motor settings every 30 seconds
-$(IFHASMTRCTRL1) $(IFNOTDEVSIM) $(IFNOTRECSIM) create_monitor_set("$(IOCNAME)_settings.req", 30, "P=$(MYPVPREFIX)MOT:,CCP=$(MTRCTRL)")
-
-$(IFHASMTRCTRL1) $(IFMOTORCONFIG) create_manual_set("$(MOTORCONFIG=)Menu.req","P=$(MYPVPREFIX)MOT:,CMP=$(MYPVPREFIX)$(IOCNAME):CONFIG:,CONFIG=$(MOTORCONFIG=),IOCNAME=$(IOCNAME),MTRCTRL=$(MTRCTRL),CONFIGMENU=1")
+$(IFNOTRECSIM) create_monitor_set("$(IOCNAME)_settings.req", 30, "P=$(MYPVPREFIX)MOT:,MTRCTRL1=$(MTRCTRL1),MTRCTRL2=$(MTRCTRL2),IFHASMTRCTRL1=$(IFHASMTRCTRL1),IFHASMTRCTRL2=$(IFHASMTRCTRL2)")


### PR DESCRIPTION
### Description of work

Fixed autosave. See https://github.com/ISISComputingGroup/IBEX/issues/5836

### To test

* Remove `$(IFNOTDEVSIM)` from lines 68 and 71 in st-common
* Put the following into globals.txt:
```
GALILMUL_01__DEVSIM=yes
GALILMUL_01__MTRCTRL1=01
GALILMUL_01__MTRCTRL2=02
```
* Start GALILMUL_01
* Set a setting on MTR0101 and MTR0201
* Wait 1 minute
* Restart GALILMUL_01
* Confirm settings on MTR0101 and MTR0201 are what was previously set

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
