### PR TITLE
Fix ioc system tests

### DIFF
--- a/LINMOT/iocBoot/iocLINMOT-IOC-01/st-common.cmd
+++ b/LINMOT/iocBoot/iocLINMOT-IOC-01/st-common.cmd
@@ -1,6 +1,5 @@
 
 < $(IOCSTARTUP)/init.cmd
-stringiftest("GEMJAWS", "$(IFGEMJAWS=#)", 5, "#")
 
 < $(IOCSTARTUP)/dbload.cmd
 

--- a/LINMOT/iocBoot/iocLINMOT-IOC-01/st-common.cmd
+++ b/LINMOT/iocBoot/iocLINMOT-IOC-01/st-common.cmd
@@ -1,5 +1,6 @@
 
 < $(IOCSTARTUP)/init.cmd
+stringiftest("GEMJAWS", "$(IFGEMJAWS=#)", 5, "#")
 
 < $(IOCSTARTUP)/dbload.cmd
 

--- a/MERCURY_ITC/iocBoot/iocMERCURY-IOC-01/st-common.cmd
+++ b/MERCURY_ITC/iocBoot/iocMERCURY-IOC-01/st-common.cmd
@@ -4,8 +4,8 @@
 epicsEnvSet "STREAM_PROTOCOL_PATH" "$(MERCURY_ITC)/data"
 
 ## Environment Variables
-epicsEnvSet "CALIB_BASE_DIR" "$(ICPCONFIGBASE)/common"
-epicsEnvSet "CALIB_DIR" "other_devices"
+epicsEnvSet "CALIB_BASE_DIR" "$(CALIB_BASE_DIR=$(ICPCONFIGBASE)/common)"
+epicsEnvSet "CALIB_DIR" "$(CALIB_DIR=other_devices)"
 
 ## For recsim:
 $(IFRECSIM) drvAsynSerialPortConfigure("L0", "$(PORT=NUL)", 0, 1, 0, 0)

--- a/MERCURY_ITC/iocBoot/iocMERCURY-IOC-01/st-common.cmd
+++ b/MERCURY_ITC/iocBoot/iocMERCURY-IOC-01/st-common.cmd
@@ -55,7 +55,7 @@ iocshCmdLoop("< st-pressure.cmd", "PRESSURE_NUM=\$(I)", "I", 1, 2)
 
 iocshCmdLoop("< st-temp-spc.cmd", "TEMP_NUM=\$(J)", "J", 1, 4)
 
-dbLoadRecords("$(TOP)/db/MercuryGlobal.db", "P=$(MYPVPREFIX)$(IOCNAME):,PORT=L0,RECSIM=$(RECSIM),DISABLE=$(DISABLE)")
+dbLoadRecords("$(MERCURY_ITC)/db/MercuryGlobal.db", "P=$(MYPVPREFIX)$(IOCNAME):,PORT=L0,RECSIM=$(RECSIM),DISABLE=$(DISABLE)")
 
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 


### PR DESCRIPTION
### Description of work

~~gem_jaws IOC system tests were failing because jaws.db had not been called correctly. This was caused by the IFGEMJAWS macro not being defined correctly, define it here.~~ This is now fixed by writing the macros correctly in the IOC_Test_Framework

mercuryitc IOC system tests were failing because it was not loading the MercuryGlobal.db as it was looking in the wrong place. Use correct macro to look in the right place.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/5888

### Acceptance criteria

*List the acceptance criteria for the PR*

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
