### PR TITLE
Set default to 0

### DIFF
--- a/KEPCO/iocBoot/iocKEPCO-IOC-01/config.xml
+++ b/KEPCO/iocBoot/iocKEPCO-IOC-01/config.xml
@@ -6,7 +6,7 @@
 <macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" hasDefault="NO" />
 <macro name="CURRENT_MAX" pattern="^[0-9.]+$" description="The maximum current you can set on the device, 0 for no max" hasDefault="YES" defaultValue="0" />
 <macro name="STEP_NUMBER" pattern="^[0-9]+$" description="Number of steps the ramp does per minute" hasDefault="YES" defaultValue="20" />
-<macro name="RESET_ON_START" pattern="^0|1|2$" description="Whether to reset and resend setpoints at ioc start. 0 to not. 1 to do so if firmware is less than version 2.0. 2 to do so and disregard firmware version" hasDefault="YES" defaultValue="1" />
+<macro name="RESET_ON_START" pattern="^0|1|2$" description="Whether to reset and resend setpoints at ioc start. 0 to not. 1 to do so if firmware is less than version 2.0. 2 to do so and disregard firmware version" hasDefault="YES" defaultValue="0" />
 </macros>
 </config_part>
 </ioc_config>

--- a/KEPCO/iocBoot/iocKEPCO-IOC-01/st-common.cmd
+++ b/KEPCO/iocBoot/iocKEPCO-IOC-01/st-common.cmd
@@ -31,7 +31,7 @@ ReadASCIIConfigure("READASCII", "", $(STEP_NUMBER=20))
 
 ## Load record instances
 
-dbLoadRecords("$(KEPCO)/db/kepco.db","P=$(MYPVPREFIX)$(IOCNAME):, PORT=L0, RESET=NO, DISABLE=$(DISABLE=0),RECSIM=$(RECSIM=0), RESET_ON_START=$(RESET_ON_START=1)")
+dbLoadRecords("$(KEPCO)/db/kepco.db","P=$(MYPVPREFIX)$(IOCNAME):, PORT=L0, RESET=NO, DISABLE=$(DISABLE=0),RECSIM=$(RECSIM=0), RESET_ON_START=$(RESET_ON_START=0)")
 dbLoadRecords("$(KEPCO)/db/kepco_ramping.db","P=$(MYPVPREFIX)$(IOCNAME):, READ=READASCII, CURRENT_MAX=$(CURRENT_MAX=0)")
 
 


### PR DESCRIPTION
### Description of work

After chatting with @DominicOram and @John-Holt-Tessella we decided that by default we should keep the behaviour of the kepco's the same (i.e. not resetting and resending setpoints) and to set the config up in more specific cases to do this.

### To test

*Which ticket does this PR fix?*

### Acceptance criteria

*List the acceptance criteria for the PR*

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
