### PR TITLE
MUONTPAR: Add an optional second tpar file

### DIFF
--- a/MUONTPAR/MUONTPAR-IOC-01App/Db/muon_tpar.db
+++ b/MUONTPAR/MUONTPAR-IOC-01App/Db/muon_tpar.db
@@ -1,4 +1,4 @@
-record(stringout, "$(P)$(TPAR_FILE_NAME)") {
+record(stringout, "$(P)$(TPAR_FILE_PV_NAME)") {
     field(VAL, "$(TPAR_FILE)")
     field(PINI, "YES")
     field(DESC, "filename of tpar file")

--- a/MUONTPAR/MUONTPAR-IOC-01App/Db/muon_tpar.db
+++ b/MUONTPAR/MUONTPAR-IOC-01App/Db/muon_tpar.db
@@ -1,4 +1,4 @@
-record(stringout, "$(P)TPAR_FILE$(SUFFIX)") {
+record(stringout, "$(P)$(TPAR_FILE_NAME)") {
     field(VAL, "$(TPAR_FILE)")
     field(PINI, "YES")
     field(DESC, "filename of tpar file")

--- a/MUONTPAR/MUONTPAR-IOC-01App/Db/muon_tpar.db
+++ b/MUONTPAR/MUONTPAR-IOC-01App/Db/muon_tpar.db
@@ -1,4 +1,4 @@
-record(stringout, "$(P)TPAR_FILE") {
+record(stringout, "$(P)TPAR_FILE$(SUFFIX)") {
     field(VAL, "$(TPAR_FILE)")
     field(PINI, "YES")
     field(DESC, "filename of tpar file")

--- a/MUONTPAR/iocBoot/iocMUONTPAR-IOC-01/config.xml
+++ b/MUONTPAR/iocBoot/iocMUONTPAR-IOC-01/config.xml
@@ -4,7 +4,7 @@
     <ioc_desc>Provides the muon TPAR files</ioc_desc>
     <macros>
       <macro name="TPAR_FILE" pattern="^.{0,40}$" description="TPAR file name in directory C:\\Instrument\\Settings. 40 Character maximum." hasDefault="NO" />
-      <macro name="TPAR_FILE_2" pattern="^.{0,40}$" description="Second TPAR file name in directory C:\\Instrument\\Settings. 40 Character maximum." hasDefault="YES" defaultValue="" />
+      <macro name="BOOSTER_TPAR_FILE" pattern="^.{0,40}$" description="Booster heater TPAR file name in directory C:\\Instrument\\Settings. 40 Character maximum." hasDefault="YES" defaultValue="" />
     </macros>
   </config_part>
 </ioc_config>

--- a/MUONTPAR/iocBoot/iocMUONTPAR-IOC-01/config.xml
+++ b/MUONTPAR/iocBoot/iocMUONTPAR-IOC-01/config.xml
@@ -4,6 +4,7 @@
     <ioc_desc>Provides the muon TPAR files</ioc_desc>
     <macros>
       <macro name="TPAR_FILE" pattern="^.{0,40}$" description="TPAR file name in directory C:\\Instrument\\Settings. 40 Character maximum." hasDefault="NO" />
+      <macro name="TPAR_FILE_2" pattern="^.{0,40}$" description="Second TPAR file name in directory C:\\Instrument\\Settings. 40 Character maximum." hasDefault="YES" defaultValue="" />
     </macros>
   </config_part>
 </ioc_config>

--- a/MUONTPAR/iocBoot/iocMUONTPAR-IOC-01/st.cmd
+++ b/MUONTPAR/iocBoot/iocMUONTPAR-IOC-01/st.cmd
@@ -17,8 +17,8 @@ MUONTPAR_IOC_01_registerRecordDeviceDriver pdbbase
 < $(IOCSTARTUP)/dbload.cmd
 
 ## Load our record instances
-dbLoadRecords("$(TOP)/db/muon_tpar.db","P=$(MYPVPREFIX)$(IOCNAME):,TPAR_FILE=$(TPAR_FILE=),TPAR_FILE_NAME=TPAR_FILE")
-dbLoadRecords("$(TOP)/db/muon_tpar.db","P=$(MYPVPREFIX)$(IOCNAME):,TPAR_FILE=$(BOOSTER_TPAR_FILE=),TPAR_FILE_NAME=BOOSTER_TPAR_FILE")
+dbLoadRecords("$(TOP)/db/muon_tpar.db","P=$(MYPVPREFIX)$(IOCNAME):,TPAR_FILE=$(TPAR_FILE=),TPAR_FILE_PV_NAME=TPAR_FILE")
+dbLoadRecords("$(TOP)/db/muon_tpar.db","P=$(MYPVPREFIX)$(IOCNAME):,TPAR_FILE=$(BOOSTER_TPAR_FILE=),TPAR_FILE_PV_NAME=BOOSTER_TPAR_FILE")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd

--- a/MUONTPAR/iocBoot/iocMUONTPAR-IOC-01/st.cmd
+++ b/MUONTPAR/iocBoot/iocMUONTPAR-IOC-01/st.cmd
@@ -17,8 +17,8 @@ MUONTPAR_IOC_01_registerRecordDeviceDriver pdbbase
 < $(IOCSTARTUP)/dbload.cmd
 
 ## Load our record instances
-dbLoadRecords("$(TOP)/db/muon_tpar.db","P=$(MYPVPREFIX)$(IOCNAME):,TPAR_FILE=$(TPAR_FILE=),SUFFIX=")
-dbLoadRecords("$(TOP)/db/muon_tpar.db","P=$(MYPVPREFIX)$(IOCNAME):,TPAR_FILE=$(TPAR_FILE_2=),SUFFIX=_2")
+dbLoadRecords("$(TOP)/db/muon_tpar.db","P=$(MYPVPREFIX)$(IOCNAME):,TPAR_FILE=$(TPAR_FILE=),TPAR_FILE_NAME=TPAR_FILE")
+dbLoadRecords("$(TOP)/db/muon_tpar.db","P=$(MYPVPREFIX)$(IOCNAME):,TPAR_FILE=$(BOOSTER_TPAR_FILE=),TPAR_FILE_NAME=BOOSTER_TPAR_FILE")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd

--- a/MUONTPAR/iocBoot/iocMUONTPAR-IOC-01/st.cmd
+++ b/MUONTPAR/iocBoot/iocMUONTPAR-IOC-01/st.cmd
@@ -17,7 +17,8 @@ MUONTPAR_IOC_01_registerRecordDeviceDriver pdbbase
 < $(IOCSTARTUP)/dbload.cmd
 
 ## Load our record instances
-dbLoadRecords("$(TOP)/db/muon_tpar.db","P=$(MYPVPREFIX)$(IOCNAME):,TPAR_FILE=$(TPAR_FILE=)")
+dbLoadRecords("$(TOP)/db/muon_tpar.db","P=$(MYPVPREFIX)$(IOCNAME):,TPAR_FILE=$(TPAR_FILE=),SUFFIX=")
+dbLoadRecords("$(TOP)/db/muon_tpar.db","P=$(MYPVPREFIX)$(IOCNAME):,TPAR_FILE=$(TPAR_FILE_2=),SUFFIX=_2")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd


### PR DESCRIPTION
### Description of work

MuSR requires 2 tpar files for two separate ITC503s in the same configuration, add an option in the MUONTPAR ioc to have a second. Default to empty if not used.

### To test

*Which ticket does this PR fix?*

### Acceptance criteria

*List the acceptance criteria for the PR*

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
