### PR TITLE
Change ramping labels and interaction with LabVIEW

### DIFF
--- a/HIFIMAGS/HIFIMAGS-IOC-01App/Db/hifimags.db
+++ b/HIFIMAGS/HIFIMAGS-IOC-01App/Db/hifimags.db
@@ -228,6 +228,12 @@ record(bi, "$(P)SIM:COMP:L:ON:RBV") {
   field(ONAM, "On")
 }
 
+### Added aliases for use with LabVIEW as new PV names are too long for CALab
+alias("$(P)COMP:R:ERROR:TEXT:RBV", "$(P)COMP:R:E:TEXT")
+alias("$(P)COMP:R:ERROR:STAT:RBV", "$(P)COMP:R:E:STAT")
+alias("$(P)COMP:L:ERROR:TEXT:RBV", "$(P)COMP:L:E:TEXT")
+alias("$(P)COMP:L:ERROR:STAT:RBV", "$(P)COMP:L:E:STAT")
+
 ### Magnets Off - triggers SNL action
 
 record(bo, "$(P)MAGNETS:OFF:SP") {

--- a/HIFIMAGS/HIFIMAGS-IOC-01App/Db/mainpsu.db
+++ b/HIFIMAGS/HIFIMAGS-IOC-01App/Db/mainpsu.db
@@ -15,8 +15,8 @@ record(bo, "$(P)$(MAG):RAMP:LEADS:SP") {
   
   field(OUT,"$(PVPREFIX)$(PSU_IOC):RAMP:LEADS:SP")
   
-  field(ZNAM, "Not Ramping")
-  field(ONAM, "Ramping")
+  field(ZNAM, "Leads at B")
+  field(ONAM, "Leads to 0")
   
   field(SIML, "$(P)SIM")
   field(SIOL, "$(P)SIM:$(MAG):RAMP:LEADS")
@@ -30,8 +30,8 @@ record(bi, "$(P)$(MAG):RAMP:LEADS:SP:RBV") {
   
   field(INP,"$(PVPREFIX)$(PSU_IOC):RAMP:LEADS:SP:RBV MS")
   
-  field(ZNAM, "Not Ramping")
-  field(ONAM, "Ramping")
+  field(ZNAM, "Leads at B")
+  field(ONAM, "Leads to 0")
   
   field(SIML, "$(P)SIM")
   field(SIOL, "$(P)SIM:$(MAG):RAMP:LEADS")
@@ -45,8 +45,8 @@ record(bi, "$(P)$(MAG):RAMP:LEADS") {
   
   field(INP,"$(PVPREFIX)$(PSU_IOC):RAMP:LEADS MS")
   
-  field(ZNAM, "Not Ramping")
-  field(ONAM, "Ramping")
+  field(ZNAM, "Leads at B")
+  field(ONAM, "Leads to 0")
   
   field(SIML, "$(P)SIM")
   field(SIOL, "$(P)SIM:$(MAG):RAMP:LEADS")
@@ -60,8 +60,8 @@ record(bi, "$(P)SIM:$(MAG):RAMP:LEADS") {
   field(DESC, "Simulated lead ramping of $(MAG)")
   field(DTYP, "Soft Channel")
   
-  field(ZNAM, "Not Ramping")
-  field(ONAM, "Ramping")
+  field(ZNAM, "Leads at B")
+  field(ONAM, "Leads to 0")
 }
 
 ### Main - Persist Mode


### PR DESCRIPTION
After a demo to the IS they wanted a change to the labels from `Not Ramping` to  `Leads at B` and `Ramping` to `Leads to 0`

Whilst testing with LabVIEW found a few changes were needed

### Description of work

Changed ZNAM and ONAM for the 'ramping' leads records
Aliases to allow shorter PV names for use with LabVIEW

See https://github.com/ISISComputingGroup/IBEX/issues/6224

### To test

Run the IOC in RECSIM mode
Check the OPI has the new labels
Run the latest version of `LabVIEW Modules\Instruments\HIFI\Cryomag\Client Side\HIFI - Cryomag.llb\HIFI - Cryomag - Front Panel.vi` from Source Safe (or ask for a copy) with no errors and updating as appropriate

### Acceptance criteria

The labels for the lead ramp records are changed from `Not Ramping` to  `Leads at B` and `Ramping` to `Leads to 0`
The VI runs as expected

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
