### PR TITLE
Ticket 6285: Poll zero field for multiple samples

### DIFF
--- a/ZFMAGFLD/iocBoot/iocZFMAGFLD-IOC-01/st-daq.cmd
+++ b/ZFMAGFLD/iocBoot/iocZFMAGFLD-IOC-01/st-daq.cmd
@@ -1,8 +1,9 @@
 epicsEnvSet("CDAQ","$(HOST=cDAQ9181-1B0C1FCMod1)")
 
 ## 3xAI inputs from a cDAQ 9181, one input per magnetometer channel
-$(IFNOTRECSIM) DAQmxConfig("R0", "$(CDAQ)/$(X_DAQ_CHANNEL=ai0)", 0, "AI","MONSTER TerminalDiff N=1 F=1000") # X (horizontal transverse - parallel to the floor)
-$(IFNOTRECSIM) DAQmxConfig("R0", "$(CDAQ)/$(Y_DAQ_CHANNEL=ai1)", 1, "AI","MONSTER TerminalDiff N=1 F=1000") # Y (vertical transverse - perpendicular to the floor)
-$(IFNOTRECSIM) DAQmxConfig("R0", "$(CDAQ)/$(Z_DAQ_CHANNEL=ai2)", 2, "AI","MONSTER TerminalDiff N=1 F=1000") # Z (along the beam, in the direction of the beam)
+## Read in 100 samples at a time at a frequency of 10Hz (so 1000 samples/s)
+$(IFNOTRECSIM) DAQmxConfig("R0", "$(CDAQ)/$(X_DAQ_CHANNEL=ai0)", 0, "AI","MONSTER TerminalDiff N=100 F=10") # X (horizontal transverse - parallel to the floor)
+$(IFNOTRECSIM) DAQmxConfig("R0", "$(CDAQ)/$(Y_DAQ_CHANNEL=ai1)", 1, "AI","MONSTER TerminalDiff N=100 F=10") # Y (vertical transverse - perpendicular to the floor)
+$(IFNOTRECSIM) DAQmxConfig("R0", "$(CDAQ)/$(Z_DAQ_CHANNEL=ai2)", 2, "AI","MONSTER TerminalDiff N=100 F=10") # Z (along the beam, in the direction of the beam)
 
 $(IFNOTRECSIM) $(IFHAS_EXTRA_DAQ_CHANNEL) DAQmxConfig("R0", "$(CDAQ)/$(EXTRA_DAQ_CHANNEL=ai3)", 3, "AI","MONSTER TerminalDiff N=1 F=1000")


### PR DESCRIPTION
### Description of work

Originally added mistakenly in https://github.com/ISISComputingGroup/EPICS-ioc/pull/597. I believe that it relates to https://github.com/ISISComputingGroup/IBEX/issues/6285 as these changes are currently on NDXMUSR and presumably were for testing the zero field. Could @rerpha, @JamesKingWork or @Tom-Willemsen shed any light on it?

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
