### PR TITLE
Ticket 5739: Change mclennan to talk to an emulator

### DIFF
--- a/MCLEN/MCLEN-IOC-01App/Db/motor.substitutions
+++ b/MCLEN/MCLEN-IOC-01App/Db/motor.substitutions
@@ -11,6 +11,6 @@ pattern {P, M, OFF, JVEL}
 }
 
 file $(MOTOR)/db/periodic_polling.db {
-pattern {P, M}
-{"\$(P)", "\$(M)"}
+pattern {P, M, POLL_RATE}
+{"\$(P)", "\$(M)", "\$(POLL_RATE=10)"}
 }

--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/st-motor.cmd
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/st-motor.cmd
@@ -5,10 +5,10 @@ epicsEnvSet("AMOTORPV", "MOT:$(AMOTORNAME)")
 ## Load record instances
 
 ## Initialise control mode. Defaults to CM14, closed
-$(IFNOTSIM) asynOctetConnect("MKINIT","$(ASERIAL)")
-$(IFNOTSIM) $(IFCMOPEN) asynOctetWrite("MKINIT","$(MN)CM11")
-$(IFNOTSIM) $(IFNOTCMOPEN) asynOctetWrite("MKINIT","$(MN)CM14")
-$(IFNOTSIM) asynOctetWrite("MKINIT","$(MN)ER$(ERES$(MN)=400/4096)")
+$(IFNOTRECSIM) asynOctetConnect("MKINIT","$(ASERIAL)")
+$(IFNOTRECSIM) $(IFCMOPEN) asynOctetWrite("MKINIT","$(MN)CM11")
+$(IFNOTRECSIM) $(IFNOTCMOPEN) asynOctetWrite("MKINIT","$(MN)CM14")
+$(IFNOTRECSIM) asynOctetWrite("MKINIT","$(MN)ER$(ERES$(MN)=400/4096)")
 
 # Set motor specific initial conditions
 epicsEnvSet("EGUI",$(UNIT$(MN)="mm"))
@@ -21,8 +21,8 @@ dcalc("JVELCALC", "0.1*$(VELOI)",1,3)
 epicsEnvSet("JVELI", "$(JVEL$(MN)=$(JVELCALC))")
 
 # Need a non-zero encoder resolution for sim mode
-$(IFSIM) epicsEnvSet("ERESI",1)
-$(IFNOTSIM) epicsEnvSet("ERESI",0)
+$(IFRECSIM) epicsEnvSet("ERESI",1)
+$(IFNOTRECSIM) epicsEnvSet("ERESI",0)
 epicsEnvSet("DHLMI",$(DHLM$(MN)=200))
 epicsEnvSet("DLLMI",$(DLLM$(MN)=-200))
 epicsEnvSet("NAMEI","$(NAME$(MN)=$(AMOTORNAME))")
@@ -32,7 +32,7 @@ epicsEnvSet("OFSTI", "$(OFST$(MN)=0)")
 
 # The signal number is the axis-1
 calc("SN", "$(MN)-1", 2, 2)
-$(IFSIM) motorSimConfigAxis("motorSim", $(SN), $(DHLMI), $(DLLMI),  $(DLLMI), 0)
+$(IFRECSIM) motorSimConfigAxis("motorSim", $(SN), $(DHLMI), $(DLLMI),  $(DLLMI), 0)
 
 # Load asyn record 
 dbLoadRecords("$(ASYN)/db/asynRecord.db", "P=$(MYPVPREFIX),R=$(AMOTORPV):ASYN,PORT=$(ASERIAL),ADDR=0,OMAX=256,IMAX=256")
@@ -43,12 +43,12 @@ dbLoadRecords("$(ASYN)/db/asynRecord.db", "P=$(MYPVPREFIX),R=$(AMOTORPV):ASYN,PO
 # Set the VBAS, the base speed, to 0.0 as it has no effect (that I know of) on the McLennan except that the acceleration won't be set
 # on an absolute move unless the speed and base speed are different
 #
-
-dbLoadRecords("$(TOP)/db/motor$(SIMSFX=).db", "P=$(MYPVPREFIX),M=$(AMOTORPV),VELO=$(VELOI),JVEL=$(JVELI),VBAS=0.0,ACCL=$(ACCLI),MRES=$(MRESI),ERES=$(ERESI),DHLM=$(DHLMI),DLLM=$(DLLMI),NAME=$(NAMEI),S=$(SN),C=0,UEIP=1,EGU=$(EGUI),OFF=$(OFSTI)")
+$(IFRECSIM) dbLoadRecords("$(TOP)/db/motorSim.db", "P=$(MYPVPREFIX),M=$(AMOTORPV),VELO=$(VELOI),JVEL=$(JVELI),VBAS=0.0,ACCL=$(ACCLI),MRES=$(MRESI),ERES=$(ERESI),DHLM=$(DHLMI),DLLM=$(DLLMI),NAME=$(NAMEI),S=$(SN),C=0,UEIP=1,EGU=$(EGUI),OFF=$(OFSTI)")
+$(IFNOTRECSIM) dbLoadRecords("$(TOP)/db/motor.db", "P=$(MYPVPREFIX),M=$(AMOTORPV),VELO=$(VELOI),JVEL=$(JVELI),VBAS=0.0,ACCL=$(ACCLI),MRES=$(MRESI),ERES=$(ERESI),DHLM=$(DHLMI),DLLM=$(DLLMI),NAME=$(NAMEI),S=$(SN),C=0,UEIP=1,EGU=$(EGUI),OFF=$(OFSTI), POLL_RATE=$(POLL_RATE=10)")
 dbLoadRecords("$(MOTOR)/db/motorStatus.db", "P=$(MYPVPREFIX),M=$(AMOTORPV)") 
 dbLoadRecords("$(AXIS)/db/axis.db", "P=$(MYPVPREFIX),AXIS=$(IOCNAME):AXIS$(MN),mAXIS=$(AMOTORPV)") 
 
 ## Start homing sequencer
 seq homing, "MOTPV=$(MYPVPREFIX)$(AMOTORPV),MODE=$(HOME$(MN)=1),AXIS=$(MN),DEBUG=0"
 
-$(IFNOTSIM) < st-motor-init.cmd
+$(IFNOTRECSIM) < st-motor-init.cmd


### PR DESCRIPTION
### Description of work

See https://github.com/ISISComputingGroup/IBEX/issues/5739
Stopped polling the motor when its moving as this causes jogs to stop

### To test

* Pull all associated branches
* Make motor/master and ioc/MCLEN
* Run the mclennan ioc tests and confirm they pass
* In the mclennan motor.db remove the SDIS field from the SCAN record (as on master) and confirm jogging IOC test fails
* In the mclennan motor.db remove the PP from the OUT field from the SCAN record and confirm the other test fails (proving that we are still correctly polling when stationary)

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
