### PR TITLE
Update EPICS EUROTHRM SENSOR record to include mV metric

### DIFF
--- a/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
+++ b/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
@@ -690,7 +690,7 @@ record(ai, "$(P)RBV") {
     field(SIML, "$(Q)SIM")
     field(SIOL, "$(P)SIM:TEMP")
     field(SDIS, "$(Q)DISABLE")
-    field(EGU, "")
+    field(EGU, "mV")
     field(PREC, "3")
     info(archive, "VAL")
     info(alarm, "Euro")


### PR DESCRIPTION
### Description of work

Add millivolt (mV) metric to EUROTHRM SENSOR EPICS record

### To test
Eurotherm: display millivolts somewhere
#6571
https://github.com/ISISComputingGroup/IBEX/issues/6571

### Acceptance criteria

EUROTHRM SENSOR can return millivolts (mV) metric with associated value


---

#### Code Review

- [ NA ] A copy of the manual has been placed on the shared drive
- [ NA ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ NA ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ NA ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ NA ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ NA ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ NA ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
