### PR TITLE
Ticket 6754: beckhoff axes checking

### DIFF
--- a/TWINCAT/iocBoot/iocTWINCAT-IOC-01/TWINCAT_01_settings.req
+++ b/TWINCAT/iocBoot/iocTWINCAT-IOC-01/TWINCAT_01_settings.req
@@ -1,9 +1,0 @@
-# Motor settings
-file "motor_settings.req" P=$(P), M=MTR$(MTRCTRL)01
-file "motor_settings.req" P=$(P), M=MTR$(MTRCTRL)02
-file "motor_settings.req" P=$(P), M=MTR$(MTRCTRL)03
-file "motor_settings.req" P=$(P), M=MTR$(MTRCTRL)04
-file "motor_settings.req" P=$(P), M=MTR$(MTRCTRL)05
-file "motor_settings.req" P=$(P), M=MTR$(MTRCTRL)06
-file "motor_settings.req" P=$(P), M=MTR$(MTRCTRL)07
-file "motor_settings.req" P=$(P), M=MTR$(MTRCTRL)08

--- a/TWINCAT/iocBoot/iocTWINCAT-IOC-01/st-common.cmd
+++ b/TWINCAT/iocBoot/iocTWINCAT-IOC-01/st-common.cmd
@@ -22,9 +22,7 @@ iocInit
 ##ISIS## Stuff that needs to be done after iocInit is called e.g. sequence programs 
 < $(IOCSTARTUP)/postiocinit.cmd
 
-## Make sure controller number is 2 digits long
-calc("MTRCTRL", "$(MTRCTRL)", 2, 2)
-
-# Save motor settings every 30 seconds
+# Save motor settings every 30 seconds, this requests file is written dynamically by LUA
 set_requestfile_path("${MOTOR}/motorApp/Db", "")
-$(IFNOTRECSIM) create_monitor_set("$(IOCNAME)_settings.req", 30, "P=$(MYPVPREFIX)MOT:,MTRCTRL=$(MTRCTRL)")
+set_requestfile_path("$(TOP)")
+$(IFNOTRECSIM) create_monitor_set("$(IOCNAME)_settings.req", 30)

--- a/TWINCAT/iocBoot/iocTWINCAT-IOC-01/st-common.lua
+++ b/TWINCAT/iocBoot/iocTWINCAT-IOC-01/st-common.lua
@@ -5,6 +5,7 @@ function twincat_stcommon_main()
 	local motor_port = "L0"
 	local pv_prefix = ibex_utils.getMacroValue{macro="MYPVPREFIX"}
 	local tpy_file = ibex_utils.getMacroValue{macro="TPY_FILE"}
+	local ioc_name = ibex_utils.getMacroValue{macro="IOCNAME"}
 	local plc_version = ibex_utils.getMacroValue{macro="PLC_VERSION", default="1"}
 
 	iocsh.tcSetScanRate(150, 2)
@@ -14,18 +15,20 @@ function twincat_stcommon_main()
 
 	local num_axes = ibex_utils.getMacroValue{macro="AXES_NUM", default="8"}
 
-	print(num_axes)
-
-	-- iocsh.devMotorCreateController(motor_port, "Controller", num_axes, pv_prefix)
-
+	iocsh.devMotorCreateController(motor_port, "Controller", num_axes, pv_prefix)
+	
+	autosave_file = io.open (ioc_name .. "_settings.req", "w")
+	
 	for axis_num=1,num_axes,1
 	do
 		motor_pv = string.format("MTR%02i%02i", os.getenv("MTRCTRL"), axis_num)
 		single_axis_db = "db/single_axis.db"
 		db_args = string.format("MYPVPREFIX=%s,MOTOR_PV=%s,MOTOR_PORT=%s,ADDR=%s", pv_prefix, motor_pv, motor_port, axis_num-1)
-		-- iocsh.devMotorCreateAxis(motor_port, axis_num-1, plc_version)
-		-- iocsh.dbLoadRecords(single_axis_db, db_args)
+		iocsh.devMotorCreateAxis(motor_port, axis_num-1, plc_version)
+		iocsh.dbLoadRecords(single_axis_db, db_args)
+		autosave_file:write(string.format("file \"motor_settings.req\" P=%s, M=MOT:%s\n", pv_prefix, motor_pv))
 	end
+	autosave_file:close()
 
 end
 

--- a/TWINCAT/iocBoot/iocTWINCAT-IOC-01/st-common.lua
+++ b/TWINCAT/iocBoot/iocTWINCAT-IOC-01/st-common.lua
@@ -3,23 +3,28 @@ ibex_utils = require "luaUtils"
 
 function twincat_stcommon_main()
 	local motor_port = "L0"
-	local num_axes = 8
 	local pv_prefix = ibex_utils.getMacroValue{macro="MYPVPREFIX"}
 	local tpy_file = ibex_utils.getMacroValue{macro="TPY_FILE"}
 	local plc_version = ibex_utils.getMacroValue{macro="PLC_VERSION", default="1"}
 
 	iocsh.tcSetScanRate(150, 2)
-	iocsh.tcLoadRecords (tpy_file, string.format("-eo -devtc -p %s", pv_prefix))
+	iocsh.tcLoadRecords(tpy_file, string.format("-eo -devtc -p %s", pv_prefix))
 
-	iocsh.devMotorCreateController(motor_port, "Controller", num_axes, pv_prefix)
+	iocsh.countdbgrep("AXES_NUM", "*ASTAXES_*:STCONTROL-BENABLE*")
+
+	local num_axes = ibex_utils.getMacroValue{macro="AXES_NUM", default="8"}
+
+	print(num_axes)
+
+	-- iocsh.devMotorCreateController(motor_port, "Controller", num_axes, pv_prefix)
 
 	for axis_num=1,num_axes,1
 	do
 		motor_pv = string.format("MTR%02i%02i", os.getenv("MTRCTRL"), axis_num)
 		single_axis_db = "db/single_axis.db"
 		db_args = string.format("MYPVPREFIX=%s,MOTOR_PV=%s,MOTOR_PORT=%s,ADDR=%s", pv_prefix, motor_pv, motor_port, axis_num-1)
-		iocsh.devMotorCreateAxis(motor_port, axis_num-1, plc_version)
-		iocsh.dbLoadRecords(single_axis_db, db_args)
+		-- iocsh.devMotorCreateAxis(motor_port, axis_num-1, plc_version)
+		-- iocsh.dbLoadRecords(single_axis_db, db_args)
 	end
 
 end


### PR DESCRIPTION
### Description of work

See https://github.com/ISISComputingGroup/IBEX/issues/6754. This will dynamically check how many motor records to load for the beckhoff.

### To test

* Ensure you have Twincat XAE installed and set up as specified at https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Beckhoff#code-on-the-controller
* With the ESS_base_code branch of the BeckhoffTestRunner checked out modify https://github.com/ISISComputingGroup/BeckhoffTestRunner/blob/ESS_base_code/test_config/plc/declarations/gvlAppDeclaration.txt to have a different number of axes
* Run the tests as specified in https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Beckhoff#testing but with the `-a` flag
* Confirm that the correct number of `%MYPVPREFIX%MOT:MTR010X` axes exist

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
