### PR TITLE
Update config.xml

### DIFF
--- a/TRITON/iocBoot/iocTRITON-IOC-01/config.xml
+++ b/TRITON/iocBoot/iocTRITON-IOC-01/config.xml
@@ -5,7 +5,7 @@
 <macros>
 <macro name="IPADDR" pattern="^.*$" description="IP address to connect to." defaultValue="localhost" hasDefault="YES" />
 <macro name="IPPORT" pattern="^[0-9]+$" description="Port to connect to (defaults to 33576)." defaultValue="33576" hasDefault="YES" />
-<macro name="RAMP_FILE_NAME" pattern="^\w{0,40}$" description="File name to use for ramp (defaults to Default.txt)." defaultValue="Default.txt" hasDefault="YES" />
+<macro name="RAMP_FILE_NAME" pattern="^\w{0,36}(?:\.txt|.TXT)$" description="File name to use for ramp (defaults to Default.txt)." defaultValue="Default.txt" hasDefault="YES" />
 <macro name="USE_RAMP_FILE" pattern="^(0|1)$" description="Whether to use (1) or not use (0) the ramp file specified above (defaults to 0)." defaultValue="0" hasDefault="YES" />
 <macro name="POLL_RATE" pattern="^.*$" description="The poll rate of non-channel values." hasDefault="YES" defaultValue="1 second"/>
 <macro name="CHANNEL_POLL_RATE" pattern="^.*$" description="The poll rate of channel values." hasDefault="YES" defaultValue="10 second"/>


### PR DESCRIPTION
Correct regular expression for checking ramp file name.  Previously it failed due to `.` separator.

### Description of work

As above

### To test

None - flash review

### Acceptance criteria

Filename of up to 40 characters including extension ("36.3") using alphanumeric (with underscore) passes regex check in macro configuration in client.

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
