### PR TITLE
Use asyn_motors.db if simulating motors

### DIFF
--- a/GALIL/GALIL-IOC-01App/Db/Makefile
+++ b/GALIL/GALIL-IOC-01App/Db/Makefile
@@ -18,7 +18,7 @@ include $(TOP)/configure/CONFIG
 DB += galil_motors.db galil_motor_extras.db galil_dmc_ctrl.db galil_userdef_records8.db 
 DB += galil_profileMoveController.db galil_profileMoveAxis.db galil_analog_ports.db 
 DB += galil_digital_ports.db galil_user_array.db galil_csmotor_kinematics.db
-DB += galil_coordinate_systems.db galil_csmotor_extras.db
+DB += galil_coordinate_systems.db galil_csmotor_extras.db asyn_motors.db
 
 include $(TOP)/configure/RULES
 #----------------------------------------

--- a/GALIL/GALIL-IOC-01App/Db/asyn_motors.substitutions
+++ b/GALIL/GALIL-IOC-01App/Db/asyn_motors.substitutions
@@ -1,0 +1,35 @@
+#
+# version of galil_motors.substitutions for generating asyn_motor DB for use with simulated motor
+#
+
+file "$(MOTOR)/db/asyn_motor.db"
+{
+pattern
+{   P,    ASG,    M,   GPORT,    PORT,    ADDR, EGU, DESC, VELO,  VMAX,  ACCL,  BDST,  BVEL,  BACC,  MRES,  SREV, ERES,     PREC, DHLM,    DLLM,     OFF,     UEIP, RTRY, NTM,   PCOF, ICOF, DCOF}
+
+# Real motors
+   {"\$(P)", "\$(ASG01=DEFAULT)", "MTR\$(CCP)01", "\$(GPORT=Galil)", "\$(PORT=Galil)", 0,    mm,  "MTR\$(CCP)01 (GALIL)",   20,    20,    1,     0,     0,     5,     .0025, 1000, 0.001,    5,    42273.3, -42273.3, 0,       0,    0   , "YES", 0,    0,    0}
+   {"\$(P)", "\$(ASG01=DEFAULT)", "MTR\$(CCP)02", "\$(GPORT=Galil)", "\$(PORT=Galil)", 1,    mm,  "MTR\$(CCP)02 (GALIL)",   .2,    .2,    1,     0,     0,     5,     .0025, 1000, 0.001,    5,    42273.3, -42273.3, 0,       0,    0   , "YES", 0,    0,    0}
+   {"\$(P)", "\$(ASG01=DEFAULT)", "MTR\$(CCP)03", "\$(GPORT=Galil)", "\$(PORT=Galil)", 2,    mm,  "MTR\$(CCP)03 (GALIL)",   .2,    .2,    1,     0,     0,     5,     .0025, 400,  0.001,    5,    42273.3, -42273.3, 0,       0,    0   , "YES", 0,    0,    0}
+   {"\$(P)", "\$(ASG01=DEFAULT)", "MTR\$(CCP)04", "\$(GPORT=Galil)", "\$(PORT=Galil)", 3,    mm,  "MTR\$(CCP)04 (GALIL)",   .2,    .2,    1,     0,     0,     5,     .0025, 400,  0.001,    5,    42273.3, -42273.3, 0,       0,    0   , "YES", 0,    0,    0}
+   {"\$(P)", "\$(ASG01=DEFAULT)", "MTR\$(CCP)05", "\$(GPORT=Galil)", "\$(PORT=Galil)", 4,    mm,  "MTR\$(CCP)05 (GALIL)",   .2,    .2,    1,     0,     0,     5,     .0025, 400,  0.001,    5,    42273.3, -42273.3, 0,       0,    0   , "YES", 0,    0,    0}
+   {"\$(P)", "\$(ASG01=DEFAULT)", "MTR\$(CCP)06", "\$(GPORT=Galil)", "\$(PORT=Galil)", 5,    mm,  "MTR\$(CCP)06 (GALIL)",   .2,    .2,    1,     0,     0,     5,     .0025, 400,  0.001,    5,    42273.3, -42273.3, 0,       0,    0   , "YES", 0,    0,    0}
+   {"\$(P)", "\$(ASG01=DEFAULT)", "MTR\$(CCP)07", "\$(GPORT=Galil)", "\$(PORT=Galil)", 6,    mm,  "MTR\$(CCP)07 (GALIL)",   .2,    .2,    1,     0,     0,     5,     .0025, 400,  0.001,    5,    42273.3, -42273.3, 0,       0,    0   , "YES", 0,    0,    0}
+   {"\$(P)", "\$(ASG01=DEFAULT)", "MTR\$(CCP)08", "\$(GPORT=Galil)", "\$(PORT=Galil)", 7,    mm,  "MTR\$(CCP)08 (GALIL)",   .2,    .2,    1,     0,     0,     5,     .0025, 400,  0.001,    5,    42273.3, -42273.3, 0,       0,    0   , "YES", 0,    0,    0}
+
+# Coordinate system (CS) motors
+# If real motors in CSAxis require backlash correction then NTM must be NO
+# If only CSAxis requires backlash correction NTM can be any value
+   {"\$(P)", "\$(ASG01=DEFAULT)", "MTR\$(CCP)09", "\$(GPORT=Galil)", "\$(PORT=Galil)", 8,    mm,  "MTR\$(CCP)09 (GALIL)",   20,    20,    1,     0,     0,     5,     .001,  1000, 0.001,     5,    42273.3, -42273.3, 0,       0,    0   , "NO",  0,    0,    0}
+   {"\$(P)", "\$(ASG01=DEFAULT)", "MTR\$(CCP)10", "\$(GPORT=Galil)", "\$(PORT=Galil)", 9,    mm,  "MTR\$(CCP)10 (GALIL)",   20,    20,    1,     0,     0,     5,     .001,  1000, 0.001,     5,    42273.3, -42273.3, 0,       0,    0   , "NO",  0,    0,    0}
+   {"\$(P)", "\$(ASG01=DEFAULT)", "MTR\$(CCP)11", "\$(GPORT=Galil)", "\$(PORT=Galil)", 10,   mm,  "MTR\$(CCP)11 (GALIL)",   20,    20,    1,     0,     0,     5,     .001,  1000, 0.001,     5,    42273.3, -42273.3, 0,       0,    0   , "NO",  0,    0,    0}
+   {"\$(P)", "\$(ASG01=DEFAULT)", "MTR\$(CCP)12", "\$(GPORT=Galil)", "\$(PORT=Galil)", 11,   mm,  "MTR\$(CCP)12 (GALIL)",   20,    20,    1,     0,     0,     5,     .001,  1000, 0.001,     5,    42273.3, -42273.3, 0,       0,    0   , "NO",  0,    0,    0}
+   {"\$(P)", "\$(ASG01=DEFAULT)", "MTR\$(CCP)13", "\$(GPORT=Galil)", "\$(PORT=Galil)", 12,   mm,  "MTR\$(CCP)13 (GALIL)",   20,    20,    1,     0,     0,     5,     .001,  1000, 0.001,     5,    42273.3, -42273.3, 0,       0,    0   , "NO",  0,    0,    0}
+   {"\$(P)", "\$(ASG01=DEFAULT)", "MTR\$(CCP)14", "\$(GPORT=Galil)", "\$(PORT=Galil)", 13,   mm,  "MTR\$(CCP)14 (GALIL)",   20,    20,    1,     0,     0,     5,     .001,  1000, 0.001,     5,    42273.3, -42273.3, 0,       0,    0   , "NO",  0,    0,    0}
+   {"\$(P)", "\$(ASG01=DEFAULT)", "MTR\$(CCP)15", "\$(GPORT=Galil)", "\$(PORT=Galil)", 14,   mm,  "MTR\$(CCP)15 (GALIL)",   20,    20,    1,     0,     0,     5,     .001,  1000, 0.001,     5,    42273.3, -42273.3, 0,       0,    0   , "NO",  0,    0,    0}
+   {"\$(P)", "\$(ASG01=DEFAULT)", "MTR\$(CCP)16", "\$(GPORT=Galil)", "\$(PORT=Galil)", 15,   mm,  "MTR\$(CCP)16 (GALIL)",   20,    20,    1,     0,     0,     5,     .001,  1000, 0.001,     5,    42273.3, -42273.3, 0,       0,    0   , "NO",  0,    0,    0}
+
+}
+
+# end
+

--- a/GALIL/iocBoot/iocGALIL-IOC-01/galildb.cmd
+++ b/GALIL/iocBoot/iocGALIL-IOC-01/galildb.cmd
@@ -3,7 +3,9 @@
 ## MTRCTRL is the galil crate number - 01, 02, ...
 
 ## GALIL_MTR_PORT will be Galil or GalilSim
-dbLoadRecords("$(TOP)/db/galil_motors.db", "GPORT=$(GALIL_MTR_PORT),P=$(MYPVPREFIX)MOT:,CCP=$(MTRCTRL)")
+$(IFDEVSIM) dbLoadRecords("$(TOP)/db/asyn_motors.db", "PORT=$(GALIL_MTR_PORT),P=$(MYPVPREFIX)MOT:,CCP=$(MTRCTRL),DTYP=asynMotor,DIR=Pos,INIT=,VBAS=0")
+$(IFRECSIM) dbLoadRecords("$(TOP)/db/asyn_motors.db", "PORT=$(GALIL_MTR_PORT),P=$(MYPVPREFIX)MOT:,CCP=$(MTRCTRL),DTYP=asynMotor,DIR=Pos,INIT=,VBAS=0")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) dbLoadRecords("$(TOP)/db/galil_motors.db", "GPORT=$(GALIL_MTR_PORT),P=$(MYPVPREFIX)MOT:,CCP=$(MTRCTRL)")
 
 #Load DMC controller features (eg.  Limit switch type, home switch type, output compare, message consoles)
 #Load extra functionality, untop of motorRecord features for axis/motors (eg. runtime gear ratio changes between master & slaves)


### PR DESCRIPTION
### Description of work

Load standard motor module asyn_motors.db instead of galil_motors.db when simulating motors

### To test

See ISISComputingGroup/IBEX#6881

### Acceptance criteria

* Issue with MRES fixed

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
