### PR TITLE
Ticket 6624: Added variable baud rate based on model number

### DIFF
--- a/DFKPS/iocBoot/iocDFKPS-IOC-01/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-01/config.xml
@@ -4,6 +4,7 @@
 <ioc_desc>Danfysik power supply</ioc_desc>
 <macros>
     <macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" hasDefault="NO" />
+    <macro name="BAUD" pattern="^[0-9]+$" description="Serial communication baud rate, defaults to 9600 for most Danfysiks, 115200 for the 9X00 versions" defaultValue="9600" hasDefault="YES" />
 	<macro name="POLARITY" pattern="^(BIPOLAR|UNIPOLAR)$" description="Polarity type, BIPOLAR - polarity is stable; defaults to BIPOLAR" defaultValue="BIPOLAR" hasDefault="YES" />
 	<macro name="USE_SLEW" pattern="^(0|1)$" description="1 to user slew, 0 otherwise; defaults to 0" defaultValue="0" hasDefault="YES" />
 

--- a/DFKPS/iocBoot/iocDFKPS-IOC-01/st-common.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-01/st-common.cmd
@@ -19,8 +19,13 @@ epicsEnvSet "STREAM_PROTOCOL_PATH" "$(DANFYSIK8000)/master/danfysikMps8000App/pr
 $(IFDEVSIM) drvAsynIPPortConfigure("L0", "localhost:$(EMULATOR_PORT)")
 
 ## use with real device
+
+stringiftest  "DEV_TYPE_9X00"  "$(DEV_TYPE="8000")"  5  "9X00"
+$(IFDEV_TYPE_9X00) epicsEnvSet "DEFAULT_BAUD" "115200"
+$(IFNOTDEV_TYPE_9X00) epicsEnvSet "DEFAULT_BAUD" "9600"
+
 $(IFNOTRECSIM) $(IFNOTDEVSIM) drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
-$(IFNOTRECSIM) $(IFNOTDEVSIM) asynSetOption("L0", -1, "baud", "$(BAUD=9600)")
+$(IFNOTRECSIM) $(IFNOTDEVSIM) asynSetOption("L0", -1, "baud", "$(BAUD=$(DEFAULT_BAUD))")
 $(IFNOTRECSIM) $(IFNOTDEVSIM) asynSetOption("L0", -1, "bits", "$(BITS=8)")
 $(IFNOTRECSIM) $(IFNOTDEVSIM) asynSetOption("L0", -1, "parity", "$(PARITY="none")")
 $(IFNOTRECSIM) $(IFNOTDEVSIM) asynSetOption("L0", -1, "stop", "$(STOP=2)")


### PR DESCRIPTION
### Description of work

See https://github.com/ISISComputingGroup/IBEX/issues/6624

### To test

* In the epics directory run `make iocstartups` (this will expose the baud rate in the config)
* Start your instrument
* Add a Danfysik 9X00 to your configs
* Confirm in the log it has a baud rate of 115200
* Confirm setting the baud rate in the config changed it in the logs

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
