### PR TITLE
Fix num axes

### DIFF
--- a/BKHOFF/iocBoot/iocBKHOFF-IOC-01/st-common.cmd
+++ b/BKHOFF/iocBoot/iocBKHOFF-IOC-01/st-common.cmd
@@ -78,6 +78,9 @@ dbLoadRecords("db/IMAT.db","P=$(MYPVPREFIX),PORT=MCU1,M1=MOT:MTR0901,M2=MOT:MTR0
 ## note: IOC name needs to have been added to _FAN element of this DB file
 dbLoadRecords("$(MOTOR)/db/motorUtil.db","P=$(MYPVPREFIX)$(IOCNAME):,$(IFIOC)= ,PVPREFIX=$(MYPVPREFIX)")
 
+## per controller PVs
+dbLoadRecords("$(MOTOR)/db/motorController.db","P=$(MYPVPREFIX),Q=MOT:MTR$(MTRCTRL):,AXES_NUM=2")
+
 dbLoadRecords("$(MOTOR)/db/motorStatus.db", "P=$(MYPVPREFIX),M=MOT:MTR0901")
 dbLoadRecords("$(MOTOR)/db/motorStatus.db", "P=$(MYPVPREFIX),M=MOT:MTR0902")
 

--- a/CONEXAGP/iocBoot/iocCONEXAGP-IOC-01/st-common.cmd
+++ b/CONEXAGP/iocBoot/iocCONEXAGP-IOC-01/st-common.cmd
@@ -35,6 +35,9 @@ epicsEnvSet(PN,8)
 ## motor util package
 dbLoadRecords("$(MOTOR)/db/motorUtil.db","P=$(MYPVPREFIX)$(IOCNAME):,$(IFIOC)= ,PVPREFIX=$(MYPVPREFIX)")
 
+## per controller PVs
+dbLoadRecords("$(MOTOR)/db/motorController.db","P=$(MYPVPREFIX),Q=MOT:MTR$(MTRCTRL):")
+
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd
 

--- a/GALIL/iocBoot/iocGALIL-IOC-01/st-common.cmd
+++ b/GALIL/iocBoot/iocGALIL-IOC-01/st-common.cmd
@@ -52,7 +52,10 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) epicsEnvSet("GALIL_MTR_PORT", "Galil")
 < galildb.cmd
 
 ## motor util package
-dbLoadRecords("$(MOTOR)/db/motorUtil.db","P=$(MYPVPREFIX)$(IOCNAME):,$(IFIOC)= ,PVPREFIX=$(MYPVPREFIX),MTRCTRL=$(MTRCTRL)")
+dbLoadRecords("$(MOTOR)/db/motorUtil.db","P=$(MYPVPREFIX)$(IOCNAME):,$(IFIOC)= ,PVPREFIX=$(MYPVPREFIX)")
+
+## per controller PVs
+dbLoadRecords("$(MOTOR)/db/motorController.db","P=$(MYPVPREFIX),Q=MOT:MTR$(MTRCTRL):")
 
 stringiftest("MOTORCONFIG", "$(MOTORCONFIG=)", 0, 0)
 $(IFMOTORCONFIG) dbLoadRecords("$(AUTOSAVE)/asApp/Db/configMenu.db","P=$(MYPVPREFIX)$(IOCNAME):CONFIG:,CONFIG=$(MOTORCONFIG=)")

--- a/GALILMUL/iocBoot/iocGALILMUL-IOC-01/st-motor-controller.cmd
+++ b/GALILMUL/iocBoot/iocGALILMUL-IOC-01/st-motor-controller.cmd
@@ -23,6 +23,9 @@ $(IFHASMTRCTRL$(CN)) $(IFNOTDEVSIM) $(IFNOTRECSIM) < $(GALILCONFIG)/galilmul$(MT
 $(IFHASMTRCTRL$(CN)) ## load the galil db files
 $(IFHASMTRCTRL$(CN)) < galildb.cmd
 $(IFHASMTRCTRL$(CN)) 
+$(IFHASMTRCTRL$(CN)) ## per controller PVs
+$(IFHASMTRCTRL$(CN)) dbLoadRecords("$(MOTOR)/db/motorController.db","P=$(MYPVPREFIX),Q=MOT:MTR$(MTRCTRL):")
+$(IFHASMTRCTRL$(CN))
 $(IFHASMTRCTRL$(CN)) ## load the generic ISIS axis db for each axis
 $(IFHASMTRCTRL$(CN)) iocshCmdLoop("< st-axis.cmd", "MN=\$(I)", "I", 1, 8)
 $(IFHASMTRCTRL$(CN)) 

--- a/INSTETC/INSTETC-IOC-01App/Db/INSTETC.db
+++ b/INSTETC/INSTETC-IOC-01App/Db/INSTETC.db
@@ -76,7 +76,7 @@ record(bi, "$(P)CS:MOT:MOVING:STR")
 }
 
 ## Are any motors moving
-## A-J set by motors, L from _MOVING1
+## A-K set by motors, L from _MOVING1
 record(calc, "$(P)CS:MOT:MOVING") 
 {
 	field(DESC, "IOCs with motion to complete")
@@ -87,7 +87,7 @@ record(calc, "$(P)CS:MOT:MOVING")
 	info(archive, "VAL")
 }
 
-## A-J set by motors, L from _MOVING2
+## A-K set by motors, L from _MOVING2
 record(calcout, "$(P)CS:MOT:_MOVING1") 
 {
 	field(DESC, "IOCs with motion to complete")
@@ -101,7 +101,7 @@ record(calcout, "$(P)CS:MOT:_MOVING1")
 	info(archive, "VAL")
 }
 
-## A-J set by motors, L from _MOVING3
+## A-K set by motors, L from _MOVING3
 record(calcout, "$(P)CS:MOT:_MOVING2") 
 {
 	field(DESC, "IOCs with motion to complete")

--- a/LINMOT/iocBoot/iocLINMOT-IOC-01/st-common.cmd
+++ b/LINMOT/iocBoot/iocLINMOT-IOC-01/st-common.cmd
@@ -58,6 +58,9 @@ $(IFRECSIM) < $(MOTOREXT)/settings/motorExtensions.cmd
 ## motor util package
 dbLoadRecords("$(MOTOR)/db/motorUtil.db","P=$(MYPVPREFIX)$(IOCNAME):,$(IFIOC)= ,PVPREFIX=$(MYPVPREFIX)")
 
+## per controller PVs
+dbLoadRecords("$(MOTOR)/db/motorController.db","P=$(MYPVPREFIX),Q=MOT:MTR$(MTRCTRL):,AXES_NUM=$(NAXES=1)")
+
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd
 

--- a/MCLEN/iocBoot/iocMCLEN-IOC-01/st-common.cmd
+++ b/MCLEN/iocBoot/iocMCLEN-IOC-01/st-common.cmd
@@ -63,7 +63,10 @@ epicsEnvSet("MCLENCONFIG","$(ICPCONFIGROOT)/mclennan")
 < motorExtensions.cmd
 
 ## motor util package
-dbLoadRecords("$(MOTOR)/db/motorUtil.db","P=$(MYPVPREFIX)$(IOCNAME):,$(IFIOC)= ,PVPREFIX=$(MYPVPREFIX),MTRCTRL=$(MTRCTRL)")
+dbLoadRecords("$(MOTOR)/db/motorUtil.db","P=$(MYPVPREFIX)$(IOCNAME):,$(IFIOC)= ,PVPREFIX=$(MYPVPREFIX)")
+
+## per controller PVs
+dbLoadRecords("$(MOTOR)/db/motorController.db","P=$(MYPVPREFIX),Q=MOT:MTR$(MTRCTRL):")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd

--- a/NWPRTXPS/iocBoot/iocNWPRTXPS-IOC-01/st-common.cmd
+++ b/NWPRTXPS/iocBoot/iocNWPRTXPS-IOC-01/st-common.cmd
@@ -44,6 +44,9 @@ epicsEnvSet("NEWPORTCONFIG","$(ICPCONFIGROOT)/newport")
 ## motor util package
 dbLoadRecords("$(MOTOR)/db/motorUtil.db","P=$(MYPVPREFIX)$(IOCNAME):,$(IFIOC)= ,PVPREFIX=$(MYPVPREFIX)")
 
+## per controller PVs
+dbLoadRecords("$(MOTOR)/db/motorController.db","P=$(MYPVPREFIX),Q=MOT:MTR$(MTRCTRL):")
+
 iocInit()
 
 motorUtilInit("$(MYPVPREFIX)$(IOCNAME):")

--- a/PIMOT/iocBoot/iocPIMOT-IOC-01/st-common.cmd
+++ b/PIMOT/iocBoot/iocPIMOT-IOC-01/st-common.cmd
@@ -63,6 +63,9 @@ autosaveBuild("$(IOCNAME)_$(PN)_built_settings.req", "_settings.req", 0)
 ## motor util package
 dbLoadRecords("$(MOTOR)/db/motorUtil.db","P=$(MYPVPREFIX)$(IOCNAME):,$(IFIOC)= ,PVPREFIX=$(MYPVPREFIX)")
 
+## per controller PVs
+dbLoadRecords("$(MOTOR)/db/motorController.db","P=$(MYPVPREFIX),Q=MOT:MTR$(MTRCTRL):")
+
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd
 

--- a/SM300/iocBoot/iocSM300-IOC-01/st-common.cmd
+++ b/SM300/iocBoot/iocSM300-IOC-01/st-common.cmd
@@ -77,6 +77,9 @@ epicsEnvSet("SM300CONFIG","$(ICPCONFIGROOT)/$(IOCNAME)")
 dbLoadRecords("$(MOTOR)/db/motorUtil.db","P=$(MYPVPREFIX)$(IOCNAME):,$(IFIOC)= ,PVPREFIX=$(MYPVPREFIX)")
 dbLoadRecords("$(MOTOR)/db/SM300_extra.db","P=$(MYPVPREFIX)$(IOCNAME):,$(IFIOC)= ,PVPREFIX=$(MYPVPREFIX), PORT=$(AMOTOR), ADDR=0")
 
+## per controller PVs
+dbLoadRecords("$(MOTOR)/db/motorController.db","P=$(MYPVPREFIX),Q=MOT:MTR$(MTRCTRL):,AXES_NUM=$(NAXES=1)")
+
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd
 

--- a/SMC100/iocBoot/iocSMC100-IOC-01/st-common.cmd
+++ b/SMC100/iocBoot/iocSMC100-IOC-01/st-common.cmd
@@ -35,6 +35,8 @@ epicsEnvSet(PN,8)
 ## motor util package
 dbLoadRecords("$(MOTOR)/db/motorUtil.db","P=$(MYPVPREFIX)$(IOCNAME):,$(IFIOC)= ,PVPREFIX=$(MYPVPREFIX)")
 
+## per controller PVs
+dbLoadRecords("$(MOTOR)/db/motorController.db","P=$(MYPVPREFIX),Q=MOT:MTR$(MTRCTRL):")
 
 epicsEnvSet("SMC100CONFIG","$(ICPCONFIGROOT)/$(IOCNAME)")
 

--- a/TWINCAT/iocBoot/iocTWINCAT-IOC-01/st-common.lua
+++ b/TWINCAT/iocBoot/iocTWINCAT-IOC-01/st-common.lua
@@ -32,8 +32,8 @@ function twincat_stcommon_main()
 	
 	autosave_file = io.open (ioc_name .. "_settings.req", "w")
 	
-	db_args = string.format("P=%s::,$(IFIOC)= ,PVPREFIX=%s,MTRCTRL=%02i,AXES_NUM=%s", pv_prefix, pv_prefix, os.getenv("MTRCTRL"), num_axes)
-	iocsh.dbLoadRecords("$(MOTOR)/db/motorUtil.db", db_args)
+	db_args = string.format("P=%s,Q=MOT:MTR%02i:,AXES_NUM=%s", pv_prefix, os.getenv("MTRCTRL"), num_axes)
+	iocsh.dbLoadRecords("$(MOTOR)/db/motorController.db", db_args)
 	
 	for axis_num=1,num_axes,1
 	do


### PR DESCRIPTION
### Description of work

Use new `motorController.db` for per controller PVs, `motorUtil.db` is per IOC not per controller 

### To test

See ISISComputingGroup/IBEX#6923

### Acceptance criteria

* Db Loads without error and `AXES_NUM` PV is available

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
