### PR TITLE
Add HVCAENSYSTYPE macro for crate type

### DIFF
--- a/HVCAEN/iocBoot/iocHVCAEN-IOC-01/config.xml
+++ b/HVCAEN/iocBoot/iocHVCAEN-IOC-01/config.xml
@@ -12,6 +12,14 @@
 			<macro name ="HVCAENIP5" pattern="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$" description="IP address of the sixth device." hasDefault="NO" />
 			<macro name ="HVCAENIP6" pattern="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$" description="IP address of the seventh device." hasDefault="NO" />
 			<macro name ="HVCAENIP7" pattern="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$" description="IP address of the eighth device." hasDefault="NO" />
+			<macro name ="HVCAENSYSTYPE0" pattern="^[A-Z0-9]+$" description="System type of the first device." defaultValue="SY1527" hasDefault="YES" />
+			<macro name ="HVCAENSYSTYPE1" pattern="^[A-Z0-9]+$" description="System type of the second device." defaultValue="SY1527" hasDefault="YES" />
+			<macro name ="HVCAENSYSTYPE2" pattern="^[A-Z0-9]+$" description="System type of the third device." defaultValue="SY1527" hasDefault="YES" />
+			<macro name ="HVCAENSYSTYPE3" pattern="^[A-Z0-9]+$" description="System type of the fourth device." defaultValue="SY1527" hasDefault="YES" />
+			<macro name ="HVCAENSYSTYPE4" pattern="^[A-Z0-9]+$" description="System type of the fifth device." defaultValue="SY1527" hasDefault="YES" />
+			<macro name ="HVCAENSYSTYPE5" pattern="^[A-Z0-9]+$" description="System type of the sixth device." defaultValue="SY1527" hasDefault="YES" />
+			<macro name ="HVCAENSYSTYPE6" pattern="^[A-Z0-9]+$" description="System type of the seventh device." defaultValue="SY1527" hasDefault="YES" />
+			<macro name ="HVCAENSYSTYPE7" pattern="^[A-Z0-9]+$" description="System type of the eighth device." defaultValue="SY1527" hasDefault="YES" />
 		</macros>
 	</config_part>
 </ioc_config>

--- a/HVCAEN/iocBoot/iocHVCAEN-IOC-01/st.cmd
+++ b/HVCAEN/iocBoot/iocHVCAEN-IOC-01/st.cmd
@@ -30,14 +30,14 @@ stringiftest("IP7Present", "$(HVCAENIP7="")", 13, "")
 
 ## arguments to CAENx527ConfigureCreate are: name, ip_address, username, password
 ## username, password are optional and the crate factory default is used if these are not specified
-$(IFIP0Present) CAENx527ConfigureCreate "hv0", "$(HVCAENIP0="")"
-$(IFIP1Present) CAENx527ConfigureCreate "hv1", "$(HVCAENIP1="")"
-$(IFIP2Present) CAENx527ConfigureCreate "hv2", "$(HVCAENIP2="")"
-$(IFIP3Present) CAENx527ConfigureCreate "hv3", "$(HVCAENIP3="")"
-$(IFIP4Present) CAENx527ConfigureCreate "hv4", "$(HVCAENIP4="")"
-$(IFIP5Present) CAENx527ConfigureCreate "hv5", "$(HVCAENIP5="")"
-$(IFIP6Present) CAENx527ConfigureCreate "hv6", "$(HVCAENIP6="")"
-$(IFIP7Present) CAENx527ConfigureCreate "hv7", "$(HVCAENIP7="")"
+$(IFIP0Present) CAENx527ConfigureCreate "hv0!$(HVCAENSYSTYPE0=SY1527)", "$(HVCAENIP0="")"
+$(IFIP1Present) CAENx527ConfigureCreate "hv1!$(HVCAENSYSTYPE1=SY1527)", "$(HVCAENIP1="")"
+$(IFIP2Present) CAENx527ConfigureCreate "hv2!$(HVCAENSYSTYPE2=SY1527)", "$(HVCAENIP2="")"
+$(IFIP3Present) CAENx527ConfigureCreate "hv3!$(HVCAENSYSTYPE3=SY1527)", "$(HVCAENIP3="")"
+$(IFIP4Present) CAENx527ConfigureCreate "hv4!$(HVCAENSYSTYPE4=SY1527)", "$(HVCAENIP4="")"
+$(IFIP5Present) CAENx527ConfigureCreate "hv5!$(HVCAENSYSTYPE5=SY1527)", "$(HVCAENIP5="")"
+$(IFIP6Present) CAENx527ConfigureCreate "hv6!$(HVCAENSYSTYPE6=SY1527)", "$(HVCAENIP6="")"
+$(IFIP7Present) CAENx527ConfigureCreate "hv7!$(HVCAENSYSTYPE7=SY1527)", "$(HVCAENIP7="")"
 
 
 ##ISIS## Load common DB records 


### PR DESCRIPTION
### Description of work

Add macros to allow specifying CAE crate type

### To test

See ISISComputingGroup/IBEX#6926

### Acceptance criteria

* specifying crate type fixes issue on SANS2D (where it has been hotfixed)

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
