### PR TITLE
EUROTHERM Extend Number of channels to 10

### DIFF
--- a/EUROTHRM/README.md
+++ b/EUROTHRM/README.md
@@ -1,0 +1,63 @@
+# Eurotherm IOC
+Eurotherm is a temperature controller. They come in a number of different configurations, namely crates with varying numbers of sensors. 
+
+## Eurotherm Useful Recources
+### Eurotherm2k support directory
+- [Eurotherm2k Support Directory](https://github.com/ISISComputingGroup/EPICS-eurotherm2k/) 
+
+### IOC System Tests
+- [Eurotherm System Tests](https://github.dev/ISISComputingGroup/EPICS-IOC_Test_Framework/blob/7026_eurotherm_7_plus_channel/tests/eurotherm.py)
+
+To run eurotherm system tests, open an EPICS terminal and run the following command from the EPICS-IOC_Test_Framework directory:
+`python run_tests.py -t eurotherm`
+
+This will run system tests for channel 1 by default. 
+To test other channels, modify `EPICS-IOC_Test_Framework/tests/eurotherm.py` to change the address variables. Below is an example of the changes needed to test channel 10:
+
+
+```python
+# Internal Address of device (must be 2 characters)
+ADDRESS = "A010" # Change this to the channel you want to test
+# Numerical address of the device
+ADDR_1 = 1 # Leave this value as 1 when changing the ADDRESS value above - hard coded in LEWIS emulator
+DEVICE = "EUROTHRM_01"
+PREFIX = "{}:{}".format(DEVICE, ADDRESS)
+
+# PV names
+RBV_PV = "RBV"
+
+EMULATOR_DEVICE = "eurotherm"
+
+IOCS = [
+    {
+        "name": DEVICE,
+        "directory": get_default_ioc_dir("EUROTHRM"),
+        "ioc_launcher_class": ProcServLauncher,
+        "macros": {
+            "ADDR": ADDRESS,
+            "ADDR_1": "",
+            "ADDR_2": "",
+            "ADDR_3": "",
+            "ADDR_4": "",
+            "ADDR_5": "",
+            "ADDR_6": "",
+            "ADDR_7": "",
+            "ADDR_8": "",
+            "ADDR_9": "",
+            "ADDR_10": ADDR_1 # Move ADDR_1 to the address you want to test
+        },
+        "emulator": EMULATOR_DEVICE,
+    },
+]
+```
+
+### Wiki Pages
+- [Eurotherm Wiki Page](https://github.com/ISISComputingGroup/IBEX/wiki/Eurotherms)
+
+## Useful Commands
+
+Single Eurotherm IOC:
+- `%MYPVPREFIX%EUROTHRM_01:<ADDRESS>:<PV>`
+
+Read current temperature for address 4:
+- `caget caget %MYPVPREFIX%EUROTHRM_01:A04:CURRENT_TEMP`

--- a/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/config.xml
+++ b/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/config.xml
@@ -17,6 +17,8 @@
 <macro name="ADDR_6" pattern="^[0-9]{1,2}$" description="Address for the 6th Eurotherm on this port e.g. 06. Blank for do not use." hasDefault="NO" />
 <macro name="ADDR_7" pattern="^[0-9]{1,2}$" description="Address for the 7th Eurotherm on this port e.g. 07. Blank for do not use." hasDefault="NO" />
 <macro name="ADDR_8" pattern="^[0-9]{1,2}$" description="Address for the 8th Eurotherm on this port e.g. 08. Blank for do not use." hasDefault="NO" />
+<macro name="ADDR_9" pattern="^[0-9]{1,2}$" description="Address for the 8th Eurotherm on this port e.g. 09. Blank for do not use." hasDefault="NO" />
+<macro name="ADDR_10" pattern="^[0-9]{1,2}$" description="Address for the 8th Eurotherm on this port e.g. 10. Blank for do not use." hasDefault="NO" />
 
 <macro name="LOCAL_CALIB" pattern="^(yes)|(no)$" description="Use local instrument calibration directory instead of common one? Default is no." defaultValue="no" hasDefault="YES" />
 </macros>

--- a/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/config.xml
+++ b/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/config.xml
@@ -16,6 +16,7 @@
 <macro name="ADDR_5" pattern="^[0-9]{1,2}$" description="Address for the 5th Eurotherm on this port e.g. 05. Blank for do not use." hasDefault="NO" />
 <macro name="ADDR_6" pattern="^[0-9]{1,2}$" description="Address for the 6th Eurotherm on this port e.g. 06. Blank for do not use." hasDefault="NO" />
 <macro name="ADDR_7" pattern="^[0-9]{1,2}$" description="Address for the 7th Eurotherm on this port e.g. 07. Blank for do not use." hasDefault="NO" />
+<macro name="ADDR_8" pattern="^[0-9]{1,2}$" description="Address for the 8th Eurotherm on this port e.g. 08. Blank for do not use." hasDefault="NO" />
 
 <macro name="LOCAL_CALIB" pattern="^(yes)|(no)$" description="Use local instrument calibration directory instead of common one? Default is no." defaultValue="no" hasDefault="YES" />
 </macros>

--- a/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-common.cmd
+++ b/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-common.cmd
@@ -72,6 +72,12 @@ epicsEnvSet(EURO_NUM,7)
 epicsEnvSet(EURO_NUM,8)
 < ${TOP}/iocBoot/iocEUROTHRM-IOC-01/st-euro.cmd
 
+epicsEnvSet(EURO_NUM,9)
+< ${TOP}/iocBoot/iocEUROTHRM-IOC-01/st-euro.cmd
+
+epicsEnvSet(EURO_NUM,10)
+< ${TOP}/iocBoot/iocEUROTHRM-IOC-01/st-euro.cmd
+
 < $(IOCSTARTUP)/preiocinit.cmd
 
 cd ${TOP}/iocBoot/${IOC}

--- a/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-common.cmd
+++ b/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-common.cmd
@@ -69,6 +69,8 @@ epicsEnvSet(EURO_NUM,6)
 epicsEnvSet(EURO_NUM,7)
 < ${TOP}/iocBoot/iocEUROTHRM-IOC-01/st-euro.cmd
 
+epicsEnvSet(EURO_NUM,8)
+< ${TOP}/iocBoot/iocEUROTHRM-IOC-01/st-euro.cmd
 
 < $(IOCSTARTUP)/preiocinit.cmd
 

--- a/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-timing.cmd
+++ b/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-timing.cmd
@@ -15,6 +15,9 @@ $(IFACTIVE) calc("NUM_SENSORS", "$(NUM_SENSORS)+1",1,1)
 stringiftest("ACTIVE", "$(ADDR_7=)")
 $(IFACTIVE) calc("NUM_SENSORS", "$(NUM_SENSORS)+1",1,1)
 
+stringiftest("ACTIVE", "$(ADDR_8=)")
+$(IFACTIVE) calc("NUM_SENSORS", "$(NUM_SENSORS)+1",1,1)
+
 epicsEnvSet "MAX_RECORDS_PER_READ" 3
 
 ## Edit this one if you want to tune the Eurotherm performance.

--- a/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-timing.cmd
+++ b/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-timing.cmd
@@ -18,6 +18,12 @@ $(IFACTIVE) calc("NUM_SENSORS", "$(NUM_SENSORS)+1",1,1)
 stringiftest("ACTIVE", "$(ADDR_8=)")
 $(IFACTIVE) calc("NUM_SENSORS", "$(NUM_SENSORS)+1",1,1)
 
+stringiftest("ACTIVE", "$(ADDR_9=)")
+$(IFACTIVE) calc("NUM_SENSORS", "$(NUM_SENSORS)+1",1,1)
+
+stringiftest("ACTIVE", "$(ADDR_10=)")
+$(IFACTIVE) calc("NUM_SENSORS", "$(NUM_SENSORS)+1",1,1)
+
 epicsEnvSet "MAX_RECORDS_PER_READ" 3
 
 ## Edit this one if you want to tune the Eurotherm performance.


### PR DESCRIPTION
### Description of work
This PR was created to complete work as part of [#7026](https://github.com/ISISComputingGroup/IBEX/issues/7026)

The changes made in this PR extend the number of channels from 7 to 10 for a single Eurotherm unit.

### To test
From the [EPICS-IOC_Test_Framework](https://github.com/ISISComputingGroup/EPICS-IOC_Test_Framework), checkout [THIS PR](https://github.com/ISISComputingGroup/EPICS-IOC_Test_Framework/pull/524) and run the eurotherm system test from an EPICS terminal to first test channel 1 by passing `python run_tests.py -t eurotherm` into your cmd. (*_channel 1 is still the default channel tested_*)

Repeat the system test for other channels by altering the address and IOC variable. I have provided an example below of the changes needed to test channel 10.

```python
# Internal Address of device (must be 2 characters)
ADDRESS = "A010" # Change this to the channel you want to test
# Numerical address of the device
ADDR_1 = 1 # Leave this value as 1 when changing the ADDRESS value above - hard coded in LEWIS emulator
DEVICE = "EUROTHRM_01"
PREFIX = "{}:{}".format(DEVICE, ADDRESS)

# PV names
RBV_PV = "RBV"

EMULATOR_DEVICE = "eurotherm"

IOCS = [
    {
        "name": DEVICE,
        "directory": get_default_ioc_dir("EUROTHRM"),
        "macros": {
            "ADDR": ADDRESS,
            "ADDR_1": "",
            "ADDR_2": "",
            "ADDR_3": "",
            "ADDR_4": "",
            "ADDR_5": "",
            "ADDR_6": "",
            "ADDR_7": "",
            "ADDR_8": "",
            "ADDR_9": "",
            "ADDR_10": ADDR_1 # Move ADDR_1 to the address you want to test
        },
        "emulator": EMULATOR_DEVICE,
        "ioc_launcher_class": ProcServLauncher,
    },
]
```

*Which ticket does this PR fix?*
- [#7026](https://github.com/ISISComputingGroup/IBEX/issues/7026)

### Acceptance criteria
*List the acceptance criteria for the PR*
- A single Eurotherm IOC can control at least 10 channels simultaneously
- [System tests](https://github.dev/ISISComputingGroup/EPICS-IOC_Test_Framework/blob/7026_eurotherm_7_plus_channel/tests/eurotherm.py) pass for all 10 channels
- README.md is descriptive and includes all relevant pages pointing to useful recourses.
- [WIKI Page](https://github.com/ISISComputingGroup/IBEX/wiki/Eurotherms) has been updated to include links to relevant repositories. 

---

## Testing
- Please follow testing instructions in [#7026](https://github.com/ISISComputingGroup/IBEX/issues/7026).

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
