### PR TITLE
TEKAFG3XXX: Add macro for IP address

### DIFF
--- a/TEKAFG3XXX/iocBoot/iocTEKAFG3XXX-IOC-01/config.xml
+++ b/TEKAFG3XXX/iocBoot/iocTEKAFG3XXX-IOC-01/config.xml
@@ -2,5 +2,8 @@
 <ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
 <config_part>
 <ioc_desc>Tektronix function generator</ioc_desc>
+<macros>
+<macro name="ADDR" pattern="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$" description="IP address of the device" hasDefault="NO" />
+</macros>
 </config_part>
 </ioc_config>

--- a/TEKAFG3XXX/iocBoot/iocTEKAFG3XXX-IOC-01/st-common.cmd
+++ b/TEKAFG3XXX/iocBoot/iocTEKAFG3XXX-IOC-01/st-common.cmd
@@ -12,7 +12,7 @@ $(IFDEVSIM) drvAsynIPPortConfigure("GPIB0", "localhost:$(EMULATOR_PORT=)")
 $(IFDEVSIM) asynOctetSetOutputEos("GPIB0", -1, "$(IEOS=\\n)")  # For testing set the output eos
 
 ## For real device use:
-$(IFNOTDEVSIM) $(IFNOTRECSIM) vxi11Configure("GPIB0", "130.246.50.169", 0, 0.0,"inst0", 0, 0)
+$(IFNOTDEVSIM) $(IFNOTRECSIM) vxi11Configure("GPIB0", $(ADDR), 0, 0.0,"inst0", 0, 0)
 
 #asynSetTraceIOMask("GPIB0",0,2)
 #asynSetTraceMask("GPIB0",0,255)


### PR DESCRIPTION
IP Address for this device was hardcoded. This is not always correct, e.g. INTER use a device with a different address, so I changed it to be configurable via macro.

How to test functionality:
1. Pull changes
2. Run `/EPICS/EPICSTerm.bat` and in it, run command `make iocstartups`
3. Start Server
4. Add a TEKAFG3XXX ioc, confirm there is an `ADDR` macro with sensible description
5. Set a value for it and save config. Confirm the macro gets set correctly: look for line `$(IFNOTDEVSIM) $(IFNOTRECSIM) vxi11Configure("GPIB0", $(ADDR), 0, 0.0,"inst0", 0, 0)` in `/instrument/var/logs/TEKAFG...`