### PR TITLE
Ticket5877 Added new records to be loaded

### DIFF
--- a/TPG300/iocBoot/iocTPG300-IOC-01/st-common.cmd
+++ b/TPG300/iocBoot/iocTPG300-IOC-01/st-common.cmd
@@ -40,8 +40,11 @@ stringiftest("PRESSURB2", $(PRESB2ON="Y"), 5, "Y")
 dbLoadRecords("$(TPG)/db/devTPG300.db","P=$(MYPVPREFIX)$(IOCNAME):, PORT=L0,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0)")
 dbLoadRecords("$(TPG)/db/TPG300_channels.db","P=$(MYPVPREFIX)$(IOCNAME):, PORT=L0,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0), IFPRESSURA1=$(IFPRESSURA1),IFPRESSURA2=$(IFPRESSURA2),IFPRESSURB1=$(IFPRESSURB1),IFPRESSURB2=$(IFPRESSURB2)")
 dbLoadRecords("$(TPG)/db/unit_setter.db","P=$(MYPVPREFIX)$(IOCNAME):")
-dbLoadRecordsList("$(TPG)/db/TPG300_switching_functions_rb.db","P=$(MYPVPREFIX)$(IOCNAME):,PORT=L0,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0)", "Q", "1;2;3;4;A;B", ";")
-dbLoadRecordsList("$(TPG)/db/TPG300_switching_functions.db","P=$(MYPVPREFIX)$(IOCNAME):,PORT=L0,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0)", "Q", "SEL;1;2;3;4;A;B", ";")
+dbLoadRecords("$(TPG)/db/TPG300_switching_functions_rb.db","P=$(MYPVPREFIX)$(IOCNAME):,PORT=L0,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0)")
+dbLoadRecords("$(TPG)/db/TPG300_switching_functions.db","P=$(MYPVPREFIX)$(IOCNAME):,PORT=L0,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0)")
+dbLoadRecords("$(TPG)/db/TPG300_function_statuses.db","P=$(MYPVPREFIX)$(IOCNAME):,PORT=L0,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0)")
+dbLoadRecords("$(TPG)/db/TPG300_switching_functions_rb_error_setter.db","P=$(MYPVPREFIX)$(IOCNAME):,PORT=L0,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0)")
+dbLoadRecords("$(TPG)/db/TPG300_function_statuses_error_setter.db","P=$(MYPVPREFIX)$(IOCNAME):,PORT=L0,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0)")
 
 ## Finished loading record instances
 #########################

--- a/TPG300/iocBoot/iocTPG300-IOC-01/st-common.cmd
+++ b/TPG300/iocBoot/iocTPG300-IOC-01/st-common.cmd
@@ -40,6 +40,8 @@ stringiftest("PRESSURB2", $(PRESB2ON="Y"), 5, "Y")
 dbLoadRecords("$(TPG)/db/devTPG300.db","P=$(MYPVPREFIX)$(IOCNAME):, PORT=L0,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0)")
 dbLoadRecords("$(TPG)/db/TPG300_channels.db","P=$(MYPVPREFIX)$(IOCNAME):, PORT=L0,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0), IFPRESSURA1=$(IFPRESSURA1),IFPRESSURA2=$(IFPRESSURA2),IFPRESSURB1=$(IFPRESSURB1),IFPRESSURB2=$(IFPRESSURB2)")
 dbLoadRecords("$(TPG)/db/unit_setter.db","P=$(MYPVPREFIX)$(IOCNAME):")
+dbLoadRecordsList("$(TPG)/db/TPG300_switching_functions_rb.db","P=$(MYPVPREFIX)$(IOCNAME):,PORT=L0,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0)", "Q", "1;2;3;4;A;B", ";")
+dbLoadRecordsList("$(TPG)/db/TPG300_switching_functions.db","P=$(MYPVPREFIX)$(IOCNAME):,PORT=L0,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0)", "Q", "SEL;1;2;3;4;A;B", ";")
 
 ## Finished loading record instances
 #########################


### PR DESCRIPTION
### Description of work

https://github.com/ISISComputingGroup/IBEX/issues/5877

### To test

*Which ticket does this PR fix?*

### Acceptance criteria

Acceptance Criteria

    The IOC supports a pressure threshhold setting
    The IOC reports the relay contact status of the TPG300 device (see Notes below)
    The OPI displays an indication if the pressure is below the threshhold setting (red LED, lit=BELOW/unlit=ABOVE)
    The OPI displays the relay contact status (green LED, lit=ON/unlit=OFF)
    I can query the pressure threshhold status via genie_python
    I can query the relay contact status via genie_python


---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
