### PR TITLE
added hasdefault=no to both troublesome IOCs

### DIFF
--- a/DG645/iocBoot/iocDG645-IOC-01/config.xml
+++ b/DG645/iocBoot/iocDG645-IOC-01/config.xml
@@ -4,7 +4,7 @@
 <ioc_desc>Stanford DG645 IOC</ioc_desc>
 <ioc_details></ioc_details>
 <macros>
-<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM port" />
+<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM port" hasDefault="NO" />
 <macro name="BAUD" pattern="^[0-9]+$" description="Port BAUD rate (default: 9600)" defaultValue="9600" hasDefault="YES" />
 </macros>
 <pvsets>

--- a/KHLY6517/iocBoot/iocKHLY6517-IOC-01/config.xml
+++ b/KHLY6517/iocBoot/iocKHLY6517-IOC-01/config.xml
@@ -4,7 +4,7 @@
 <ioc_desc>Keithley6517B</ioc_desc>
 <ioc_details>IOC for Keithley6517B</ioc_details>
 <macros>
-<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM port" />
+<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM port" hasDefault="NO" />
 </macros>
 <pvsets>
 </pvsets>


### PR DESCRIPTION
There was an alert being displayed in various places (for example when running make iocstartups) that those 2 IOCs dont have hasfault for their port macro so I fixed it here