### PR TITLE
Ticket 6898 allow 35 danfysiks at once

### DIFF
--- a/DFKPS/DFKPS-IOC-12App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-12App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-12App/Makefile
+++ b/DFKPS/DFKPS-IOC-12App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-12App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-12App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-12.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-12App/src/DFKPS-IOC-12Main.cpp
+++ b/DFKPS/DFKPS-IOC-12App/src/DFKPS-IOC-12Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-12Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-12App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-12App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-12
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/DFKPS-IOC-13App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-13App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-13App/Makefile
+++ b/DFKPS/DFKPS-IOC-13App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-13App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-13App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-13.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-13App/src/DFKPS-IOC-13Main.cpp
+++ b/DFKPS/DFKPS-IOC-13App/src/DFKPS-IOC-13Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-13Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-13App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-13App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-13
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/DFKPS-IOC-14App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-14App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-14App/Makefile
+++ b/DFKPS/DFKPS-IOC-14App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-14App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-14App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-14.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-14App/src/DFKPS-IOC-14Main.cpp
+++ b/DFKPS/DFKPS-IOC-14App/src/DFKPS-IOC-14Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-14Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-14App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-14App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-14
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/DFKPS-IOC-15App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-15App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-15App/Makefile
+++ b/DFKPS/DFKPS-IOC-15App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-15App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-15App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-15.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-15App/src/DFKPS-IOC-15Main.cpp
+++ b/DFKPS/DFKPS-IOC-15App/src/DFKPS-IOC-15Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-15Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-15App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-15App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-15
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/DFKPS-IOC-16App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-16App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-16App/Makefile
+++ b/DFKPS/DFKPS-IOC-16App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-16App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-16App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-16.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-16App/src/DFKPS-IOC-16Main.cpp
+++ b/DFKPS/DFKPS-IOC-16App/src/DFKPS-IOC-16Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-16Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-16App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-16App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-16
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/DFKPS-IOC-17App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-17App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-17App/Makefile
+++ b/DFKPS/DFKPS-IOC-17App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-17App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-17App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-17.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-17App/src/DFKPS-IOC-17Main.cpp
+++ b/DFKPS/DFKPS-IOC-17App/src/DFKPS-IOC-17Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-17Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-17App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-17App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-17
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/DFKPS-IOC-18App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-18App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-18App/Makefile
+++ b/DFKPS/DFKPS-IOC-18App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-18App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-18App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-18.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-18App/src/DFKPS-IOC-18Main.cpp
+++ b/DFKPS/DFKPS-IOC-18App/src/DFKPS-IOC-18Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-18Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-18App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-18App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-18
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/DFKPS-IOC-19App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-19App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-19App/Makefile
+++ b/DFKPS/DFKPS-IOC-19App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-19App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-19App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-19.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-19App/src/DFKPS-IOC-19Main.cpp
+++ b/DFKPS/DFKPS-IOC-19App/src/DFKPS-IOC-19Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-19Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-19App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-19App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-19
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/DFKPS-IOC-20App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-20App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-20App/Makefile
+++ b/DFKPS/DFKPS-IOC-20App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-20App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-20App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-20.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-20App/src/DFKPS-IOC-20Main.cpp
+++ b/DFKPS/DFKPS-IOC-20App/src/DFKPS-IOC-20Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-20Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-20App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-20App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-20
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/DFKPS-IOC-21App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-21App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-21App/Makefile
+++ b/DFKPS/DFKPS-IOC-21App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-21App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-21App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-21.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-21App/src/DFKPS-IOC-21Main.cpp
+++ b/DFKPS/DFKPS-IOC-21App/src/DFKPS-IOC-21Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-21Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-21App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-21App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-21
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/DFKPS-IOC-22App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-22App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-22App/Makefile
+++ b/DFKPS/DFKPS-IOC-22App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-22App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-22App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-22.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-22App/src/DFKPS-IOC-22Main.cpp
+++ b/DFKPS/DFKPS-IOC-22App/src/DFKPS-IOC-22Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-22Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-22App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-22App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-22
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/DFKPS-IOC-23App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-23App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-23App/Makefile
+++ b/DFKPS/DFKPS-IOC-23App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-23App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-23App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-23.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-23App/src/DFKPS-IOC-23Main.cpp
+++ b/DFKPS/DFKPS-IOC-23App/src/DFKPS-IOC-23Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-23Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-23App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-23App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-23
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/DFKPS-IOC-24App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-24App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-24App/Makefile
+++ b/DFKPS/DFKPS-IOC-24App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-24App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-24App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-24.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-24App/src/DFKPS-IOC-24Main.cpp
+++ b/DFKPS/DFKPS-IOC-24App/src/DFKPS-IOC-24Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-24Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-24App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-24App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-24
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/DFKPS-IOC-25App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-25App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-25App/Makefile
+++ b/DFKPS/DFKPS-IOC-25App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-25App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-25App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-25.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-25App/src/DFKPS-IOC-25Main.cpp
+++ b/DFKPS/DFKPS-IOC-25App/src/DFKPS-IOC-25Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-25Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-25App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-25App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-25
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/DFKPS-IOC-26App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-26App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-26App/Makefile
+++ b/DFKPS/DFKPS-IOC-26App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-26App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-26App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-26.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-26App/src/DFKPS-IOC-26Main.cpp
+++ b/DFKPS/DFKPS-IOC-26App/src/DFKPS-IOC-26Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-26Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-26App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-26App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-26
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/DFKPS-IOC-27App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-27App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-27App/Makefile
+++ b/DFKPS/DFKPS-IOC-27App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-27App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-27App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-27.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-27App/src/DFKPS-IOC-27Main.cpp
+++ b/DFKPS/DFKPS-IOC-27App/src/DFKPS-IOC-27Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-27Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-27App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-27App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-27
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/DFKPS-IOC-28App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-28App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-28App/Makefile
+++ b/DFKPS/DFKPS-IOC-28App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-28App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-28App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-28.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-28App/src/DFKPS-IOC-28Main.cpp
+++ b/DFKPS/DFKPS-IOC-28App/src/DFKPS-IOC-28Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-28Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-28App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-28App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-28
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/DFKPS-IOC-29App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-29App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-29App/Makefile
+++ b/DFKPS/DFKPS-IOC-29App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-29App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-29App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-29.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-29App/src/DFKPS-IOC-29Main.cpp
+++ b/DFKPS/DFKPS-IOC-29App/src/DFKPS-IOC-29Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-29Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-29App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-29App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-29
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/DFKPS-IOC-30App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-30App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-30App/Makefile
+++ b/DFKPS/DFKPS-IOC-30App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-30App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-30App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-30.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-30App/src/DFKPS-IOC-30Main.cpp
+++ b/DFKPS/DFKPS-IOC-30App/src/DFKPS-IOC-30Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-30Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-30App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-30App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-30
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/DFKPS-IOC-31App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-31App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-31App/Makefile
+++ b/DFKPS/DFKPS-IOC-31App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-31App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-31App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-31.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-31App/src/DFKPS-IOC-31Main.cpp
+++ b/DFKPS/DFKPS-IOC-31App/src/DFKPS-IOC-31Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-31Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-31App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-31App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-31
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/DFKPS-IOC-32App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-32App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-32App/Makefile
+++ b/DFKPS/DFKPS-IOC-32App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-32App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-32App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-32.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-32App/src/DFKPS-IOC-32Main.cpp
+++ b/DFKPS/DFKPS-IOC-32App/src/DFKPS-IOC-32Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-32Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-32App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-32App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-32
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/DFKPS-IOC-33App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-33App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-33App/Makefile
+++ b/DFKPS/DFKPS-IOC-33App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-33App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-33App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-33.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-33App/src/DFKPS-IOC-33Main.cpp
+++ b/DFKPS/DFKPS-IOC-33App/src/DFKPS-IOC-33Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-33Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-33App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-33App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-33
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/DFKPS-IOC-34App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-34App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-34App/Makefile
+++ b/DFKPS/DFKPS-IOC-34App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-34App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-34App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-34.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-34App/src/DFKPS-IOC-34Main.cpp
+++ b/DFKPS/DFKPS-IOC-34App/src/DFKPS-IOC-34Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-34Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-34App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-34App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-34
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/DFKPS-IOC-35App/Db/Makefile
+++ b/DFKPS/DFKPS-IOC-35App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-35App/Makefile
+++ b/DFKPS/DFKPS-IOC-35App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/DFKPS/DFKPS-IOC-35App/protocol/Makefile
+++ b/DFKPS/DFKPS-IOC-35App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += DANFYSIK8000-IOC-35.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/DFKPS/DFKPS-IOC-35App/src/DFKPS-IOC-35Main.cpp
+++ b/DFKPS/DFKPS-IOC-35App/src/DFKPS-IOC-35Main.cpp
@@ -1,0 +1,23 @@
+/* DANFYSIK8000-IOC-35Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/DFKPS/DFKPS-IOC-35App/src/Makefile
+++ b/DFKPS/DFKPS-IOC-35App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=DFKPS-IOC-35
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/DFKPS-IOC-01App/src/build.mak

--- a/DFKPS/iocBoot/iocDFKPS-IOC-12/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-12/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-12/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-12/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-12/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-12/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-12
+
+## You may have to change DFKPS-IOC-12 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_12"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-12.dbd"
+DFKPS_IOC_12_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST12", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd

--- a/DFKPS/iocBoot/iocDFKPS-IOC-13/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-13/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-13/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-13/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-13/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-13/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-13
+
+## You may have to change DFKPS-IOC-13 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_13"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-13.dbd"
+DFKPS_IOC_13_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST13", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd

--- a/DFKPS/iocBoot/iocDFKPS-IOC-14/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-14/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-14/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-14/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-14/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-14/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-14
+
+## You may have to change DFKPS-IOC-14 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_14"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-14.dbd"
+DFKPS_IOC_14_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST14", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd

--- a/DFKPS/iocBoot/iocDFKPS-IOC-15/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-15/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-15/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-15/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-15/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-15/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-15
+
+## You may have to change DFKPS-IOC-15 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_15"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-15.dbd"
+DFKPS_IOC_15_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST15", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd

--- a/DFKPS/iocBoot/iocDFKPS-IOC-16/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-16/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-16/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-16/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-16/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-16/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-16
+
+## You may have to change DFKPS-IOC-16 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_16"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-16.dbd"
+DFKPS_IOC_16_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST16", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd

--- a/DFKPS/iocBoot/iocDFKPS-IOC-17/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-17/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-17/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-17/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-17/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-17/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-17
+
+## You may have to change DFKPS-IOC-17 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_17"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-17.dbd"
+DFKPS_IOC_17_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST17", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd

--- a/DFKPS/iocBoot/iocDFKPS-IOC-18/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-18/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-18/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-18/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-18/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-18/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-18
+
+## You may have to change DFKPS-IOC-18 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_18"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-18.dbd"
+DFKPS_IOC_18_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST18", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd

--- a/DFKPS/iocBoot/iocDFKPS-IOC-19/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-19/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-19/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-19/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-19/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-19/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-19
+
+## You may have to change DFKPS-IOC-19 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_19"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-19.dbd"
+DFKPS_IOC_19_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST19", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd

--- a/DFKPS/iocBoot/iocDFKPS-IOC-20/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-20/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-20/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-20/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-20/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-20/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-20
+
+## You may have to change DFKPS-IOC-20 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_20"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-20.dbd"
+DFKPS_IOC_20_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST20", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd

--- a/DFKPS/iocBoot/iocDFKPS-IOC-21/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-21/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-21/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-21/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-21/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-21/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-21
+
+## You may have to change DFKPS-IOC-21 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_21"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-21.dbd"
+DFKPS_IOC_21_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST21", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd

--- a/DFKPS/iocBoot/iocDFKPS-IOC-22/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-22/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-22/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-22/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-22/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-22/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-22
+
+## You may have to change DFKPS-IOC-22 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_22"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-22.dbd"
+DFKPS_IOC_22_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST22", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd

--- a/DFKPS/iocBoot/iocDFKPS-IOC-23/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-23/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-23/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-23/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-23/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-23/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-23
+
+## You may have to change DFKPS-IOC-23 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_23"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-23.dbd"
+DFKPS_IOC_23_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST23", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd

--- a/DFKPS/iocBoot/iocDFKPS-IOC-24/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-24/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-24/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-24/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-24/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-24/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-24
+
+## You may have to change DFKPS-IOC-24 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_24"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-24.dbd"
+DFKPS_IOC_24_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST24", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd

--- a/DFKPS/iocBoot/iocDFKPS-IOC-25/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-25/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-25/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-25/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-25/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-25/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-25
+
+## You may have to change DFKPS-IOC-25 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_25"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-25.dbd"
+DFKPS_IOC_25_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST25", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd

--- a/DFKPS/iocBoot/iocDFKPS-IOC-26/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-26/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-26/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-26/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-26/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-26/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-26
+
+## You may have to change DFKPS-IOC-26 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_26"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-26.dbd"
+DFKPS_IOC_26_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST26", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd

--- a/DFKPS/iocBoot/iocDFKPS-IOC-27/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-27/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-27/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-27/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-27/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-27/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-27
+
+## You may have to change DFKPS-IOC-27 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_27"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-27.dbd"
+DFKPS_IOC_27_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST27", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd

--- a/DFKPS/iocBoot/iocDFKPS-IOC-28/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-28/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-28/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-28/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-28/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-28/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-28
+
+## You may have to change DFKPS-IOC-28 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_28"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-28.dbd"
+DFKPS_IOC_28_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST28", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd

--- a/DFKPS/iocBoot/iocDFKPS-IOC-29/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-29/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-29/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-29/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-29/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-29/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-29
+
+## You may have to change DFKPS-IOC-29 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_29"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-29.dbd"
+DFKPS_IOC_29_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST29", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd

--- a/DFKPS/iocBoot/iocDFKPS-IOC-30/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-30/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-30/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-30/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-30/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-30/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-30
+
+## You may have to change DFKPS-IOC-30 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_30"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-30.dbd"
+DFKPS_IOC_30_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST30", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd

--- a/DFKPS/iocBoot/iocDFKPS-IOC-31/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-31/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-31/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-31/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-31/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-31/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-31
+
+## You may have to change DFKPS-IOC-31 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_31"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-31.dbd"
+DFKPS_IOC_31_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST31", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd

--- a/DFKPS/iocBoot/iocDFKPS-IOC-32/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-32/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-32/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-32/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-32/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-32/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-32
+
+## You may have to change DFKPS-IOC-32 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_32"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-32.dbd"
+DFKPS_IOC_32_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST32", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd

--- a/DFKPS/iocBoot/iocDFKPS-IOC-33/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-33/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-33/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-33/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-33/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-33/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-33
+
+## You may have to change DFKPS-IOC-33 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_33"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-33.dbd"
+DFKPS_IOC_33_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST33", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd

--- a/DFKPS/iocBoot/iocDFKPS-IOC-34/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-34/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-34/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-34/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-34/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-34/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-34
+
+## You may have to change DFKPS-IOC-34 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_34"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-34.dbd"
+DFKPS_IOC_34_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST34", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd

--- a/DFKPS/iocBoot/iocDFKPS-IOC-35/Makefile
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-35/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/DFKPS/iocBoot/iocDFKPS-IOC-35/config.xml
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-35/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocDFKPS-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/DFKPS/iocBoot/iocDFKPS-IOC-35/st.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-35/st.cmd
@@ -1,0 +1,26 @@
+#!../../bin/linux-x86_64/DFKPS-IOC-35
+
+## You may have to change DFKPS-IOC-35 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+epicsEnvSet "IOCNAME" "DFKPS_35"
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/DFKPS-IOC-35.dbd"
+DFKPS_IOC_35_registerRecordDeviceDriver pdbbase
+
+## Load FileList
+## A seperate instance must be created for each danfysik
+epicsEnvSet "RAMP_DIR" "C:/Instrument/Settings"
+epicsEnvSet "RAMP_PAT" ".*"
+FileListConfigure("RAMPFILELIST35", $(RAMP_DIR), $(RAMP_PAT)) 
+
+## Load common st.cmd
+< iocBoot/iocDFKPS-IOC-01/st-common.cmd


### PR DESCRIPTION
### Description of work

Added Danfysiks 12 through 35

### To test
Run make iocstartups, then start the ibex server and ibex, check the iocstart tree, the danfysik section should now have 35 entries, make sure they can be started properly.

### Ticket
https://github.com/ISISComputingGroup/IBEX/issues/6898

### Acceptance criteria

35 danfysiks

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
