### PR TITLE
Removed extra colons from zoom vacuum db

### DIFF
--- a/FINS/FINS-IOC-01App/Db/zoom-vacuum-commands.template
+++ b/FINS/FINS-IOC-01App/Db/zoom-vacuum-commands.template
@@ -47,10 +47,10 @@ record(seq,"$(P)$(Q)$(NAME):CALC") {
     field(SELL, "$(P)$(Q)$(NAME):SP.RVAL NPP NMS")
     field(DLY1, "0")
     field(DOL1, "0")
-    field(LNK1, "$(P)$(Q):$(NAME):$(ZPV).VAL PP NMS")
+    field(LNK1, "$(P)$(Q)$(NAME):$(ZPV).VAL PP NMS")
     field(DLY2, "0")
     field(DOL2, "1")
-    field(LNK2, "$(P)$(Q):$(NAME):$(OPV).VAL PP NMS")
+    field(LNK2, "$(P)$(Q)$(NAME):$(OPV).VAL PP NMS")
 }
 
 record(bo, "$(P)$(Q)$(NAME):$(ZPV)")


### PR DESCRIPTION
### Description of work

When testing the new do_trans/sans scripts we noticed that the monitor for zoom was set differently so we updated it to use the equivalent pv as sans2d. When testing further we noticed that the monitor was now not being set. Investigation showed that there were some extra colons in the db so the address was slightly wrong. We have removed the colons and confirmed that now it works corretly.
 

