### PR TITLE
Remove `RETRYCNT` alarm from Eurotherm

### DIFF
--- a/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
+++ b/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
@@ -759,7 +759,6 @@ record(longout, "$(P)SP:RETRYCNT") {
     field(HIGH, "5")
     field(HSV, "MINOR")
     info(archive, "VAL")
-    info(alarm, "Euro")
 }
 
 ## difference between sent SP and readback SP to trigger a resend of SP


### PR DESCRIPTION
### Description of work

The alarm was appearing occasionally for users and scientists were
simply telling them to ignore it. If the error is not significant, we
don't want users ignoring more important alarms, so let's not display
this one. It'll still be logged, so we can always check that.

### To test

1. Check that this PV no longer appears in the list of alarms for the Eurotherm in the GUI. 

*Which ticket does this PR fix?*

Fixes ISISComputingGroup/IBEX#3019

### Acceptance criteria

The alarm no longer appears to our users. 

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
