### PR TITLE
NCINDG: add Iphlpapi for static link

### DIFF
--- a/NCINDG/NCINDG-IOC-01App/src/build.mak
+++ b/NCINDG/NCINDG-IOC-01App/src/build.mak
@@ -52,7 +52,7 @@ $(APPNAME)_LIBS_WIN32 += oncrpc ssleay32 libeay32
 $(APPNAME)_SYS_LIBS_Linux += ssl crypto
 $(APPNAME)_SYS_LIBS_Linux += sasl2
 
-$(APPNAME)_SYS_LIBS_WIN32 += psapi wldap32 ws2_32 crypt32 Normaliz # advapi32 user32 msxml2
+$(APPNAME)_SYS_LIBS_WIN32 += psapi wldap32 ws2_32 crypt32 Normaliz Iphlpapi
 
 # ISISDAE-IOC-01_registerRecordDeviceDriver.cpp derives from ISISDAE-IOC-01.dbd
 $(APPNAME)_SRCS += $(APPNAME)_registerRecordDeviceDriver.cpp


### PR DESCRIPTION
Add Iphlpapi.lib to fix static link error on static windows build
