### PR TITLE
Ticket 4735

### DIFF
--- a/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
+++ b/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
@@ -80,10 +80,10 @@ record(stringin, "$(P)RAMP_FILE")
     field(SCAN, "I/O Intr")
 }
 
-record(longin, "$(P)RAMP_FILE_CHANGED")
+record(longin, "$(P)RAMP_FILE_NOT_DEFAULT")
 {
     field(DTYP, "asynInt32")
-    field(INP,  "@asyn($(READ),0,1)LUTCG")
+    field(INP,  "@asyn($(READ),0,1)LUTNDF")
     field(SCAN, "I/O Intr")
 }
 

--- a/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
+++ b/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
@@ -80,6 +80,13 @@ record(stringin, "$(P)RAMP_FILE")
     field(SCAN, "I/O Intr")
 }
 
+record(longin, "$(P)RAMP_FILE_CHANGED")
+{
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(READ),0,1)LUTCG")
+    field(SCAN, "I/O Intr")
+}
+
 record(stringout, "$(P)RAMP_FILE:SP")
 {
     field(DTYP, "asynOctetWrite")


### PR DESCRIPTION
### Description of work

Added new PV (`RAMP_FILE_NOT_DEFAULT`) to be able to check whether DIP and max output lookup file for ramping has **changed from the** specified **default** file.


### To test

[*Link to Ticket #4735*](https://github.com/ISISComputingGroup/IBEX/issues/4735)

### Acceptance criteria

- A message to remind the user when they change the default file but have not yet to turned lookup on

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
