### PR TITLE
Added nine additional TPG300 IOCs using ioc_copier script

### DIFF
--- a/TPG300/TPG300-IOC-04App/Db/Makefile
+++ b/TPG300/TPG300-IOC-04App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/TPG300/TPG300-IOC-04App/Makefile
+++ b/TPG300/TPG300-IOC-04App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/TPG300/TPG300-IOC-04App/protocol/Makefile
+++ b/TPG300/TPG300-IOC-04App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += TPG300-IOC-04.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/TPG300/TPG300-IOC-04App/src/Makefile
+++ b/TPG300/TPG300-IOC-04App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=TPG300-IOC-04
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/TPG300-IOC-01App/src/build.mak

--- a/TPG300/TPG300-IOC-04App/src/TPG300-IOC-04Main.cpp
+++ b/TPG300/TPG300-IOC-04App/src/TPG300-IOC-04Main.cpp
@@ -1,0 +1,23 @@
+/* TPG300-IOC-04Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/TPG300/TPG300-IOC-05App/Db/Makefile
+++ b/TPG300/TPG300-IOC-05App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/TPG300/TPG300-IOC-05App/Makefile
+++ b/TPG300/TPG300-IOC-05App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/TPG300/TPG300-IOC-05App/protocol/Makefile
+++ b/TPG300/TPG300-IOC-05App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += TPG300-IOC-05.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/TPG300/TPG300-IOC-05App/src/Makefile
+++ b/TPG300/TPG300-IOC-05App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=TPG300-IOC-05
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/TPG300-IOC-01App/src/build.mak

--- a/TPG300/TPG300-IOC-05App/src/TPG300-IOC-05Main.cpp
+++ b/TPG300/TPG300-IOC-05App/src/TPG300-IOC-05Main.cpp
@@ -1,0 +1,23 @@
+/* TPG300-IOC-05Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/TPG300/TPG300-IOC-06App/Db/Makefile
+++ b/TPG300/TPG300-IOC-06App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/TPG300/TPG300-IOC-06App/Makefile
+++ b/TPG300/TPG300-IOC-06App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/TPG300/TPG300-IOC-06App/protocol/Makefile
+++ b/TPG300/TPG300-IOC-06App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += TPG300-IOC-06.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/TPG300/TPG300-IOC-06App/src/Makefile
+++ b/TPG300/TPG300-IOC-06App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=TPG300-IOC-06
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/TPG300-IOC-01App/src/build.mak

--- a/TPG300/TPG300-IOC-06App/src/TPG300-IOC-06Main.cpp
+++ b/TPG300/TPG300-IOC-06App/src/TPG300-IOC-06Main.cpp
@@ -1,0 +1,23 @@
+/* TPG300-IOC-06Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/TPG300/TPG300-IOC-07App/Db/Makefile
+++ b/TPG300/TPG300-IOC-07App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/TPG300/TPG300-IOC-07App/Makefile
+++ b/TPG300/TPG300-IOC-07App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/TPG300/TPG300-IOC-07App/protocol/Makefile
+++ b/TPG300/TPG300-IOC-07App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += TPG300-IOC-07.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/TPG300/TPG300-IOC-07App/src/Makefile
+++ b/TPG300/TPG300-IOC-07App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=TPG300-IOC-07
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/TPG300-IOC-01App/src/build.mak

--- a/TPG300/TPG300-IOC-07App/src/TPG300-IOC-07Main.cpp
+++ b/TPG300/TPG300-IOC-07App/src/TPG300-IOC-07Main.cpp
@@ -1,0 +1,23 @@
+/* TPG300-IOC-07Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/TPG300/TPG300-IOC-08App/Db/Makefile
+++ b/TPG300/TPG300-IOC-08App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/TPG300/TPG300-IOC-08App/Makefile
+++ b/TPG300/TPG300-IOC-08App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/TPG300/TPG300-IOC-08App/protocol/Makefile
+++ b/TPG300/TPG300-IOC-08App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += TPG300-IOC-08.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/TPG300/TPG300-IOC-08App/src/Makefile
+++ b/TPG300/TPG300-IOC-08App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=TPG300-IOC-08
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/TPG300-IOC-01App/src/build.mak

--- a/TPG300/TPG300-IOC-08App/src/TPG300-IOC-08Main.cpp
+++ b/TPG300/TPG300-IOC-08App/src/TPG300-IOC-08Main.cpp
@@ -1,0 +1,23 @@
+/* TPG300-IOC-08Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/TPG300/TPG300-IOC-09App/Db/Makefile
+++ b/TPG300/TPG300-IOC-09App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/TPG300/TPG300-IOC-09App/Makefile
+++ b/TPG300/TPG300-IOC-09App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/TPG300/TPG300-IOC-09App/protocol/Makefile
+++ b/TPG300/TPG300-IOC-09App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += TPG300-IOC-09.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/TPG300/TPG300-IOC-09App/src/Makefile
+++ b/TPG300/TPG300-IOC-09App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=TPG300-IOC-09
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/TPG300-IOC-01App/src/build.mak

--- a/TPG300/TPG300-IOC-09App/src/TPG300-IOC-09Main.cpp
+++ b/TPG300/TPG300-IOC-09App/src/TPG300-IOC-09Main.cpp
@@ -1,0 +1,23 @@
+/* TPG300-IOC-09Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/TPG300/TPG300-IOC-10App/Db/Makefile
+++ b/TPG300/TPG300-IOC-10App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/TPG300/TPG300-IOC-10App/Makefile
+++ b/TPG300/TPG300-IOC-10App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/TPG300/TPG300-IOC-10App/protocol/Makefile
+++ b/TPG300/TPG300-IOC-10App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += TPG300-IOC-10.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/TPG300/TPG300-IOC-10App/src/Makefile
+++ b/TPG300/TPG300-IOC-10App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=TPG300-IOC-10
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/TPG300-IOC-01App/src/build.mak

--- a/TPG300/TPG300-IOC-10App/src/TPG300-IOC-10Main.cpp
+++ b/TPG300/TPG300-IOC-10App/src/TPG300-IOC-10Main.cpp
@@ -1,0 +1,23 @@
+/* TPG300-IOC-10Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/TPG300/TPG300-IOC-11App/Db/Makefile
+++ b/TPG300/TPG300-IOC-11App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/TPG300/TPG300-IOC-11App/Makefile
+++ b/TPG300/TPG300-IOC-11App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/TPG300/TPG300-IOC-11App/protocol/Makefile
+++ b/TPG300/TPG300-IOC-11App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += TPG300-IOC-11.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/TPG300/TPG300-IOC-11App/src/Makefile
+++ b/TPG300/TPG300-IOC-11App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=TPG300-IOC-11
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/TPG300-IOC-01App/src/build.mak

--- a/TPG300/TPG300-IOC-11App/src/TPG300-IOC-11Main.cpp
+++ b/TPG300/TPG300-IOC-11App/src/TPG300-IOC-11Main.cpp
@@ -1,0 +1,23 @@
+/* TPG300-IOC-11Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/TPG300/TPG300-IOC-12App/Db/Makefile
+++ b/TPG300/TPG300-IOC-12App/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/TPG300/TPG300-IOC-12App/Makefile
+++ b/TPG300/TPG300-IOC-12App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/TPG300/TPG300-IOC-12App/protocol/Makefile
+++ b/TPG300/TPG300-IOC-12App/protocol/Makefile
@@ -1,0 +1,15 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#DATA += TPG300-IOC-12.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/TPG300/TPG300-IOC-12App/src/Makefile
+++ b/TPG300/TPG300-IOC-12App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=TPG300-IOC-12
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/TPG300-IOC-01App/src/build.mak

--- a/TPG300/TPG300-IOC-12App/src/TPG300-IOC-12Main.cpp
+++ b/TPG300/TPG300-IOC-12App/src/TPG300-IOC-12Main.cpp
@@ -1,0 +1,23 @@
+/* TPG300-IOC-12Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/TPG300/iocBoot/iocTPG300-IOC-04/Makefile
+++ b/TPG300/iocBoot/iocTPG300-IOC-04/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/TPG300/iocBoot/iocTPG300-IOC-04/config.xml
+++ b/TPG300/iocBoot/iocTPG300-IOC-04/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocTPG300-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/TPG300/iocBoot/iocTPG300-IOC-04/st.cmd
+++ b/TPG300/iocBoot/iocTPG300-IOC-04/st.cmd
@@ -1,0 +1,17 @@
+#!../../bin/windows-x64-debug/TPG300-IOC-04
+
+## You may have to change TPG300-IOC-04 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/TPG300-IOC-04.dbd"
+TPG300_IOC_04_registerRecordDeviceDriver pdbbase
+
+< ${TOP}/iocBoot/iocTPG300-IOC-01/st-common.cmd

--- a/TPG300/iocBoot/iocTPG300-IOC-05/Makefile
+++ b/TPG300/iocBoot/iocTPG300-IOC-05/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/TPG300/iocBoot/iocTPG300-IOC-05/config.xml
+++ b/TPG300/iocBoot/iocTPG300-IOC-05/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocTPG300-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/TPG300/iocBoot/iocTPG300-IOC-05/st.cmd
+++ b/TPG300/iocBoot/iocTPG300-IOC-05/st.cmd
@@ -1,0 +1,17 @@
+#!../../bin/windows-x64-debug/TPG300-IOC-05
+
+## You may have to change TPG300-IOC-05 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/TPG300-IOC-05.dbd"
+TPG300_IOC_05_registerRecordDeviceDriver pdbbase
+
+< ${TOP}/iocBoot/iocTPG300-IOC-01/st-common.cmd

--- a/TPG300/iocBoot/iocTPG300-IOC-06/Makefile
+++ b/TPG300/iocBoot/iocTPG300-IOC-06/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/TPG300/iocBoot/iocTPG300-IOC-06/config.xml
+++ b/TPG300/iocBoot/iocTPG300-IOC-06/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocTPG300-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/TPG300/iocBoot/iocTPG300-IOC-06/st.cmd
+++ b/TPG300/iocBoot/iocTPG300-IOC-06/st.cmd
@@ -1,0 +1,17 @@
+#!../../bin/windows-x64-debug/TPG300-IOC-06
+
+## You may have to change TPG300-IOC-06 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/TPG300-IOC-06.dbd"
+TPG300_IOC_06_registerRecordDeviceDriver pdbbase
+
+< ${TOP}/iocBoot/iocTPG300-IOC-01/st-common.cmd

--- a/TPG300/iocBoot/iocTPG300-IOC-07/Makefile
+++ b/TPG300/iocBoot/iocTPG300-IOC-07/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/TPG300/iocBoot/iocTPG300-IOC-07/config.xml
+++ b/TPG300/iocBoot/iocTPG300-IOC-07/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocTPG300-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/TPG300/iocBoot/iocTPG300-IOC-07/st.cmd
+++ b/TPG300/iocBoot/iocTPG300-IOC-07/st.cmd
@@ -1,0 +1,17 @@
+#!../../bin/windows-x64-debug/TPG300-IOC-07
+
+## You may have to change TPG300-IOC-07 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/TPG300-IOC-07.dbd"
+TPG300_IOC_07_registerRecordDeviceDriver pdbbase
+
+< ${TOP}/iocBoot/iocTPG300-IOC-01/st-common.cmd

--- a/TPG300/iocBoot/iocTPG300-IOC-08/Makefile
+++ b/TPG300/iocBoot/iocTPG300-IOC-08/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/TPG300/iocBoot/iocTPG300-IOC-08/config.xml
+++ b/TPG300/iocBoot/iocTPG300-IOC-08/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocTPG300-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/TPG300/iocBoot/iocTPG300-IOC-08/st.cmd
+++ b/TPG300/iocBoot/iocTPG300-IOC-08/st.cmd
@@ -1,0 +1,17 @@
+#!../../bin/windows-x64-debug/TPG300-IOC-08
+
+## You may have to change TPG300-IOC-08 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/TPG300-IOC-08.dbd"
+TPG300_IOC_08_registerRecordDeviceDriver pdbbase
+
+< ${TOP}/iocBoot/iocTPG300-IOC-01/st-common.cmd

--- a/TPG300/iocBoot/iocTPG300-IOC-09/Makefile
+++ b/TPG300/iocBoot/iocTPG300-IOC-09/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/TPG300/iocBoot/iocTPG300-IOC-09/config.xml
+++ b/TPG300/iocBoot/iocTPG300-IOC-09/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocTPG300-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/TPG300/iocBoot/iocTPG300-IOC-09/st.cmd
+++ b/TPG300/iocBoot/iocTPG300-IOC-09/st.cmd
@@ -1,0 +1,17 @@
+#!../../bin/windows-x64-debug/TPG300-IOC-09
+
+## You may have to change TPG300-IOC-09 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/TPG300-IOC-09.dbd"
+TPG300_IOC_09_registerRecordDeviceDriver pdbbase
+
+< ${TOP}/iocBoot/iocTPG300-IOC-01/st-common.cmd

--- a/TPG300/iocBoot/iocTPG300-IOC-10/Makefile
+++ b/TPG300/iocBoot/iocTPG300-IOC-10/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/TPG300/iocBoot/iocTPG300-IOC-10/config.xml
+++ b/TPG300/iocBoot/iocTPG300-IOC-10/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocTPG300-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/TPG300/iocBoot/iocTPG300-IOC-10/st.cmd
+++ b/TPG300/iocBoot/iocTPG300-IOC-10/st.cmd
@@ -1,0 +1,17 @@
+#!../../bin/windows-x64-debug/TPG300-IOC-10
+
+## You may have to change TPG300-IOC-10 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/TPG300-IOC-10.dbd"
+TPG300_IOC_10_registerRecordDeviceDriver pdbbase
+
+< ${TOP}/iocBoot/iocTPG300-IOC-01/st-common.cmd

--- a/TPG300/iocBoot/iocTPG300-IOC-11/Makefile
+++ b/TPG300/iocBoot/iocTPG300-IOC-11/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/TPG300/iocBoot/iocTPG300-IOC-11/config.xml
+++ b/TPG300/iocBoot/iocTPG300-IOC-11/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocTPG300-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/TPG300/iocBoot/iocTPG300-IOC-11/st.cmd
+++ b/TPG300/iocBoot/iocTPG300-IOC-11/st.cmd
@@ -1,0 +1,17 @@
+#!../../bin/windows-x64-debug/TPG300-IOC-11
+
+## You may have to change TPG300-IOC-11 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/TPG300-IOC-11.dbd"
+TPG300_IOC_11_registerRecordDeviceDriver pdbbase
+
+< ${TOP}/iocBoot/iocTPG300-IOC-01/st-common.cmd

--- a/TPG300/iocBoot/iocTPG300-IOC-12/Makefile
+++ b/TPG300/iocBoot/iocTPG300-IOC-12/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/TPG300/iocBoot/iocTPG300-IOC-12/config.xml
+++ b/TPG300/iocBoot/iocTPG300-IOC-12/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns="http://epics.isis.rl.ac.uk/schema/ioc_config/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocTPG300-IOC-01/config.xml"  />
+
+</ioc_config>

--- a/TPG300/iocBoot/iocTPG300-IOC-12/st.cmd
+++ b/TPG300/iocBoot/iocTPG300-IOC-12/st.cmd
@@ -1,0 +1,17 @@
+#!../../bin/windows-x64-debug/TPG300-IOC-12
+
+## You may have to change TPG300-IOC-12 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+cd ${TOP}
+
+## Register all support components
+dbLoadDatabase "dbd/TPG300-IOC-12.dbd"
+TPG300_IOC_12_registerRecordDeviceDriver pdbbase
+
+< ${TOP}/iocBoot/iocTPG300-IOC-01/st-common.cmd


### PR DESCRIPTION
### Description of work

Added nine additional TPG300 IOCs using ioc_copier script.  Required for RIKENFE machine.

### To test

Check IOC directories are present in the filesystem and that the build is successful.

### Acceptance criteria

A total of 12 TPG300 IOCs exist

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
