### PR TITLE
Add Tektronix Osc IOC and Additional Background Script IOC

### DIFF
--- a/BGRSCRPT/iocBoot/iocBGRSCRPT-IOC-03/config.xml
+++ b/BGRSCRPT/iocBoot/iocBGRSCRPT-IOC-03/config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<xi:include href="../iocBGRSCRPT-IOC-01/config.xml"  />
+</ioc_config>

--- a/BGRSCRPT/iocBoot/iocBGRSCRPT-IOC-03/dllPath.bat
+++ b/BGRSCRPT/iocBoot/iocBGRSCRPT-IOC-03/dllPath.bat
@@ -1,0 +1,2 @@
+@ECHO OFF
+SET "PATH=C:/Instrument/Apps/EPICS/support/icpconfig/master/bin/%EPICS_HOST_ARCH%;C:/Instrument/Apps/EPICS/support/pugixml/master/bin/%EPICS_HOST_ARCH%;C:/Instrument/Apps/EPICS/support/utilities/master/bin/%EPICS_HOST_ARCH%;C:/Instrument/Apps/EPICS/support/pcre/master/bin/%EPICS_HOST_ARCH%;C:/Instrument/Apps/EPICS/base/master/bin/%EPICS_HOST_ARCH%;%PATH%"

--- a/BGRSCRPT/iocBoot/iocBGRSCRPT-IOC-03/runIOC.bat
+++ b/BGRSCRPT/iocBoot/iocBGRSCRPT-IOC-03/runIOC.bat
@@ -1,0 +1,23 @@
+@echo off
+setlocal
+set MYDIRBLOCK=%~dp0
+call %~dp0..\..\..\..\..\config_env_base.bat
+call dllPath.bat
+%HIDEWINDOW% h
+
+set EPICS_CAS_INTF_ADDR_LIST=127.0.0.1
+set EPICS_CAS_BEACON_ADDR_LIST=127.255.255.255
+
+set PYTHONUNBUFFERED=TRUE
+
+set "GETMACRO=%EPICS_KIT_ROOT%\support\icpconfig\master\bin\%EPICS_HOST_ARCH%\icpconfigGetMacro.exe"
+set "MYIOCNAME=BGRSCRPT_03"
+
+REM for loop is used to capture the output
+for /f %%a in ( '%GETMACRO% "SCRIPT_PATH" %MYIOCNAME%'  ) do ( set "SCRIPT_PATH_MACRO=%%a" )
+
+if "%SCRIPT_PATH_MACRO%"=="" (
+    set "SCRIPT_PATH_MACRO=%ICPINSTSCRIPTROOT%/background_script3.py"
+)
+
+%PYTHON3W% %SCRIPT_PATH_MACRO%

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ IOCDIRS += B17TMAG
 IOCDIRS += NCINDG
 IOCDIRS += TJMPER
 IOCDIRS += INSTRONA
+IOCDIRS += TEKOSC
 
 ## check on missing directories
 IOCMAKES = $(wildcard */Makefile)

--- a/TEKOSC/Makefile
+++ b/TEKOSC/Makefile
@@ -1,0 +1,31 @@
+# Makefile at top of application tree
+TOP = .
+include $(TOP)/configure/CONFIG
+
+# Directories to build, any order
+DIRS += configure
+DIRS += $(wildcard *Sup)
+DIRS += $(wildcard *App)
+DIRS += $(wildcard *Top)
+DIRS += $(wildcard iocBoot)
+
+# The build order is controlled by these dependency rules:
+
+# All dirs except configure depend on configure
+$(foreach dir, $(filter-out configure, $(DIRS)), \
+    $(eval $(dir)_DEPEND_DIRS += configure))
+
+# Any *App dirs depend on all *Sup dirs
+$(foreach dir, $(filter %App, $(DIRS)), \
+    $(eval $(dir)_DEPEND_DIRS += $(filter %Sup, $(DIRS))))
+
+# Any *Top dirs depend on all *Sup and *App dirs
+$(foreach dir, $(filter %Top, $(DIRS)), \
+    $(eval $(dir)_DEPEND_DIRS += $(filter %Sup %App, $(DIRS))))
+
+# iocBoot depends on all *App dirs
+iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
+
+# Add any additional dependency rules here:
+
+include $(TOP)/configure/RULES_TOP

--- a/TEKOSC/TEKOSC-IOC-01App/Db/Makefile
+++ b/TEKOSC/TEKOSC-IOC-01App/Db/Makefile
@@ -1,0 +1,18 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/TEKOSC/TEKOSC-IOC-01App/Makefile
+++ b/TEKOSC/TEKOSC-IOC-01App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/TEKOSC/TEKOSC-IOC-01App/src/Makefile
+++ b/TEKOSC/TEKOSC-IOC-01App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=TEKOSC-IOC-01
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/TEKOSC-IOC-01App/src/build.mak

--- a/TEKOSC/TEKOSC-IOC-01App/src/TEKOSC-IOC-01Main.cpp
+++ b/TEKOSC/TEKOSC-IOC-01App/src/TEKOSC-IOC-01Main.cpp
@@ -1,0 +1,23 @@
+/* TEKOSC-IOC-01Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/TEKOSC/TEKOSC-IOC-01App/src/build.mak
+++ b/TEKOSC/TEKOSC-IOC-01App/src/build.mak
@@ -32,7 +32,8 @@ $(APPNAME)_DBD += drvAsynIPPort.dbd
 $(APPNAME)_DBD += luaSupport.dbd
 $(APPNAME)_DBD += stream.dbd
 ## add other dbd here ##
-#$(APPNAME)_DBD += xxx.dbd
+$(APPNAME)_DBD += drvVxi11.dbd
+$(APPNAME)_DBD += asubFunctions.dbd
 
 # Add all the support libraries needed by this IOC
 
@@ -54,6 +55,9 @@ $(APPNAME)_LIBS += utilities pugixml libjson zlib
 $(APPNAME)_LIBS += calc sscan
 $(APPNAME)_LIBS += pcrecpp pcre
 $(APPNAME)_LIBS += seq pv
+$(APPNAME)_LIBS += asubFunctions
+$(APPNAME)_LIBS_WIN32 += oncrpc
+
 
 # TEKOSC-IOC-01_registerRecordDeviceDriver.cpp derives from TEKOSC-IOC-01.dbd
 $(APPNAME)_SRCS += $(APPNAME)_registerRecordDeviceDriver.cpp

--- a/TEKOSC/TEKOSC-IOC-01App/src/build.mak
+++ b/TEKOSC/TEKOSC-IOC-01App/src/build.mak
@@ -1,0 +1,76 @@
+TOP=../..
+
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+#=============================
+
+### NOTE: there should only be one build.mak for a given IOC family and this should be located in the ###-IOC-01 directory
+
+#=============================
+# Build the IOC application TEKOSC-IOC-01
+# We actually use $(APPNAME) below so this file can be included by multiple IOCs
+
+PROD_IOC = $(APPNAME)
+# TEKOSC-IOC-01.dbd will be created and installed
+DBD += $(APPNAME).dbd
+
+# TEKOSC-IOC-01.dbd will be made up from these files:
+$(APPNAME)_DBD += base.dbd
+## ISIS standard dbd ##
+$(APPNAME)_DBD += icpconfig.dbd
+$(APPNAME)_DBD += pvdump.dbd
+$(APPNAME)_DBD += asSupport.dbd
+$(APPNAME)_DBD += devIocStats.dbd
+$(APPNAME)_DBD += caPutLog.dbd
+$(APPNAME)_DBD += utilities.dbd
+## Stream device support ##
+$(APPNAME)_DBD += calcSupport.dbd
+$(APPNAME)_DBD += asyn.dbd
+$(APPNAME)_DBD += drvAsynSerialPort.dbd
+$(APPNAME)_DBD += drvAsynIPPort.dbd
+$(APPNAME)_DBD += luaSupport.dbd
+$(APPNAME)_DBD += stream.dbd
+## add other dbd here ##
+#$(APPNAME)_DBD += xxx.dbd
+
+# Add all the support libraries needed by this IOC
+
+## Add additional libraries here ##
+#$(APPNAME)_LIBS += xxx
+
+## ISIS standard libraries ##
+## Stream device libraries ##
+$(APPNAME)_LIBS += stream
+$(APPNAME)_LIBS += lua
+$(APPNAME)_LIBS += asyn
+## other standard libraries here ##
+$(APPNAME)_LIBS += devIocStats 
+$(APPNAME)_LIBS += pvdump $(MYSQLLIB) easySQLite sqlite 
+$(APPNAME)_LIBS += caPutLog
+$(APPNAME)_LIBS += icpconfig
+$(APPNAME)_LIBS += autosave
+$(APPNAME)_LIBS += utilities pugixml libjson zlib
+$(APPNAME)_LIBS += calc sscan
+$(APPNAME)_LIBS += pcrecpp pcre
+$(APPNAME)_LIBS += seq pv
+
+# TEKOSC-IOC-01_registerRecordDeviceDriver.cpp derives from TEKOSC-IOC-01.dbd
+$(APPNAME)_SRCS += $(APPNAME)_registerRecordDeviceDriver.cpp
+
+# Build the main IOC entry point on workstation OSs.
+$(APPNAME)_SRCS_DEFAULT += $(APPNAME)Main.cpp
+$(APPNAME)_SRCS_vxWorks += -nil-
+
+# Add support from base/src/vxWorks if needed
+#$(APPNAME)_OBJS_vxWorks += $(EPICS_BASE_BIN)/vxComLibrary
+
+# Finally link to the EPICS Base libraries
+$(APPNAME)_LIBS += $(EPICS_BASE_IOC_LIBS)
+
+#===========================
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/TEKOSC/configure/CONFIG
+++ b/TEKOSC/configure/CONFIG
@@ -1,0 +1,29 @@
+# CONFIG - Load build configuration data
+#
+# Do not make changes to this file!
+
+# Allow user to override where the build rules come from
+RULES = $(EPICS_BASE)
+
+# RELEASE files point to other application tops
+include $(TOP)/configure/RELEASE
+-include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).Common
+ifdef T_A
+-include $(TOP)/configure/RELEASE.Common.$(T_A)
+-include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).$(T_A)
+endif
+
+CONFIG = $(RULES)/configure
+include $(CONFIG)/CONFIG
+
+# Override the Base definition:
+INSTALL_LOCATION = $(TOP)
+
+# CONFIG_SITE files contain other build configuration settings
+include $(TOP)/configure/CONFIG_SITE
+-include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+ifdef T_A
+ -include $(TOP)/configure/CONFIG_SITE.Common.$(T_A)
+ -include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+endif
+

--- a/TEKOSC/configure/CONFIG_SITE
+++ b/TEKOSC/configure/CONFIG_SITE
@@ -1,0 +1,43 @@
+# CONFIG_SITE
+
+# Make any application-specific changes to the EPICS build
+#   configuration variables in this file.
+#
+# Host/target specific settings can be specified in files named
+#   CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+#   CONFIG_SITE.Common.$(T_A)
+#   CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+
+# CHECK_RELEASE controls the consistency checking of the support
+#   applications pointed to by the RELEASE* files.
+# Normally CHECK_RELEASE should be set to YES.
+# Set CHECK_RELEASE to NO to disable checking completely.
+# Set CHECK_RELEASE to WARN to perform consistency checking but
+#   continue building even if conflicts are found.
+CHECK_RELEASE = YES
+
+# Set this when you only want to compile this application
+#   for a subset of the cross-compiled target architectures
+#   that Base is built for.
+#CROSS_COMPILER_TARGET_ARCHS = vxWorks-ppc32
+
+# To install files into a location other than $(TOP) define
+#   INSTALL_LOCATION here.
+#INSTALL_LOCATION=</absolute/path/to/install/top>
+
+# Set this when the IOC and build host use different paths
+#   to the install location. This may be needed to boot from
+#   a Microsoft FTP server say, or on some NFS configurations.
+#IOCS_APPL_TOP = </IOC's/absolute/path/to/install/top>
+
+# For application debugging purposes, override the HOST_OPT and/
+#   or CROSS_OPT settings from base/configure/CONFIG_SITE
+#HOST_OPT = NO
+#CROSS_OPT = NO
+
+# These allow developers to override the CONFIG_SITE variable
+# settings without having to modify the configure/CONFIG_SITE
+# file itself.
+-include $(TOP)/../CONFIG_SITE.local
+-include $(TOP)/configure/CONFIG_SITE.local
+

--- a/TEKOSC/configure/Makefile
+++ b/TEKOSC/configure/Makefile
@@ -1,0 +1,8 @@
+TOP=..
+
+include $(TOP)/configure/CONFIG
+
+TARGETS = $(CONFIG_TARGETS)
+CONFIGS += $(subst ../,,$(wildcard $(CONFIG_INSTALLS)))
+
+include $(TOP)/configure/RULES

--- a/TEKOSC/configure/RELEASE
+++ b/TEKOSC/configure/RELEASE
@@ -1,0 +1,74 @@
+# RELEASE - Location of external support modules
+#
+# IF YOU CHANGE ANY PATHS in this file or make API changes to
+# any modules it refers to, you should do a "make rebuild" in
+# this application's top level directory.
+#
+# The EPICS build process does not check dependencies against
+# any files from outside the application, so it is safest to
+# rebuild it completely if any modules it depends on change.
+#
+# Host- or target-specific settings can be given in files named
+#  RELEASE.$(EPICS_HOST_ARCH).Common
+#  RELEASE.Common.$(T_A)
+#  RELEASE.$(EPICS_HOST_ARCH).$(T_A)
+#
+# This file is parsed by both GNUmake and an EPICS Perl script,
+# so it may ONLY contain definititions of paths to other support
+# modules, variable definitions that are used in module paths,
+# and include statements that pull in other RELEASE files.
+# Variables may be used before their values have been set.
+# Build variables that are NOT used in paths should be set in
+# the CONFIG_SITE file.
+
+# Variables and paths to dependent modules:
+#MODULES = /path/to/modules
+#MYMODULE = $(MODULES)/my-module
+
+# If using the sequencer, point SNCSEQ at its top directory:
+#SNCSEQ = $(MODULES)/seq-ver
+
+# EPICS_BASE should appear last so earlier modules can override stuff:
+EPICS_BASE = C:/Instrument/Apps/EPICS/base/master
+
+# Set RULES here if you want to use build rules from somewhere
+# other than EPICS_BASE:
+#RULES = $(MODULES)/build-rules
+
+# These lines allow developers to override these RELEASE settings
+# without having to modify this file directly.
+-include $(TOP)/../RELEASE.local
+-include $(TOP)/../RELEASE.$(EPICS_HOST_ARCH).local
+-include $(TOP)/configure/RELEASE.local
+
+# Macros required for basic ioc/stream device
+ACCESSSECURITY=$(SUPPORT)/AccessSecurity/master
+ASUBFUNCTIONS=$(SUPPORT)/asubFunctions/master
+ASYN=$(SUPPORT)/asyn/master
+AUTOSAVE=$(SUPPORT)/autosave/master
+CALC=$(SUPPORT)/calc/master
+CAPUTLOG=$(SUPPORT)/caPutLog/master
+DEVIOCSTATS=$(SUPPORT)/devIocStats/master
+ICPCONFIG=$(SUPPORT)/icpconfig/master
+LIBJSON=$(SUPPORT)/libjson/master
+LUA=$(SUPPORT)/lua/master
+MYSQL=$(SUPPORT)/MySQL/master
+ONCRPC=$(SUPPORT)/oncrpc/master
+PCRE=$(SUPPORT)/pcre/master
+PUGIXML=$(SUPPORT)/pugixml/master
+PVDUMP=$(SUPPORT)/pvdump/master
+SNCSEQ=$(SUPPORT)/seq/master
+SQLITE=$(SUPPORT)/sqlite/master
+SSCAN=$(SUPPORT)/sscan/master
+STREAMDEVICE=$(SUPPORT)/StreamDevice/master
+UTILITIES=$(SUPPORT)/utilities/master
+ZLIB=$(SUPPORT)/zlib/master
+
+# optional extra local definitions here
+-include $(TOP)/configure/RELEASE.private
+
+include $(TOP)/../../../ISIS_CONFIG
+-include $(TOP)/../../../ISIS_CONFIG.$(EPICS_HOST_ARCH)
+
+# IOC-specific support module
+TEKOSC=$(SUPPORT)/Tektronix_Osc/master

--- a/TEKOSC/configure/RULES
+++ b/TEKOSC/configure/RULES
@@ -1,0 +1,6 @@
+# RULES
+
+include $(CONFIG)/RULES
+
+# Library should be rebuilt because LIBOBJS may have changed.
+$(LIBNAME): ../Makefile

--- a/TEKOSC/configure/RULES.ioc
+++ b/TEKOSC/configure/RULES.ioc
@@ -1,0 +1,2 @@
+#RULES.ioc
+include $(CONFIG)/RULES.ioc

--- a/TEKOSC/configure/RULES_DIRS
+++ b/TEKOSC/configure/RULES_DIRS
@@ -1,0 +1,2 @@
+#RULES_DIRS
+include $(CONFIG)/RULES_DIRS

--- a/TEKOSC/configure/RULES_TOP
+++ b/TEKOSC/configure/RULES_TOP
@@ -1,0 +1,3 @@
+#RULES_TOP
+include $(CONFIG)/RULES_TOP
+

--- a/TEKOSC/iocBoot/Makefile
+++ b/TEKOSC/iocBoot/Makefile
@@ -1,0 +1,6 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS += $(wildcard *ioc*)
+DIRS += $(wildcard as*)
+include $(CONFIG)/RULES_DIRS
+

--- a/TEKOSC/iocBoot/iocTEKOSC-IOC-01/Makefile
+++ b/TEKOSC/iocBoot/iocTEKOSC-IOC-01/Makefile
@@ -1,0 +1,6 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+#ARCH = windows-x64
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/TEKOSC/iocBoot/iocTEKOSC-IOC-01/config.xml
+++ b/TEKOSC/iocBoot/iocTEKOSC-IOC-01/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<config_part>
+<ioc_desc>Tektronix Oscilloscopes, 3000 series+</ioc_desc>
+<macros>
+<macro name="ADDR" pattern="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$" description="Device IP Address" defaultValue="" hasDefault="NO" />
+</macros>
+<pvsets>
+</pvsets>
+</config_part>
+</ioc_config>

--- a/TEKOSC/iocBoot/iocTEKOSC-IOC-01/st-common.cmd
+++ b/TEKOSC/iocBoot/iocTEKOSC-IOC-01/st-common.cmd
@@ -1,0 +1,44 @@
+epicsEnvSet "STREAM_PROTOCOL_PATH" "$(TEKOSC)/data"
+epicsEnvSet "DEVICE" "L0"
+
+##ISIS## Run IOC initialisation 
+< $(IOCSTARTUP)/init.cmd
+
+## For recsim:
+$(IFRECSIM) drvAsynSerialPortConfigure("$(DEVICE)", "$(PORT=NUL)", 0, 1, 0, 0)
+
+# For dev sim devices
+$(IFDEVSIM) drvAsynIPPortConfigure("$(DEVICE)", "localhost:$(EMULATOR_PORT=57677)")
+
+## For real device use:
+$(IFNOTDEVSIM) $(IFNOTRECSIM) vxi11Configure("$(DEVICE)", "$(ADDR=)", 0, 0.0,"inst0", 0, 0)
+
+#asynSetTraceIOMask("$(DEVICE)",0,2)
+#asynSetTraceMask("$(DEVICE)",0,255)
+
+
+##ISIS## Load common DB records 
+< $(IOCSTARTUP)/dbload.cmd
+
+## Load record instances
+
+##ISIS## Load common DB records 
+< $(IOCSTARTUP)/dbload.cmd
+
+############################
+## Load our record instances
+############################
+
+dbLoadRecords("$(TEKOSC)/db/tektronixOsc.db","P=$(MYPVPREFIX)$(IOCNAME),PORT=$(DEVICE),RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0)")
+
+##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
+< $(IOCSTARTUP)/preiocinit.cmd
+
+cd ${TOP}/iocBoot/${IOC}
+iocInit
+
+## Start any sequence programs
+#seq sncxxx,"user=mkq48465"
+
+##ISIS## Stuff that needs to be done after iocInit is called e.g. sequence programs 
+< $(IOCSTARTUP)/postiocinit.cmd

--- a/TEKOSC/iocBoot/iocTEKOSC-IOC-01/st.cmd
+++ b/TEKOSC/iocBoot/iocTEKOSC-IOC-01/st.cmd
@@ -1,0 +1,18 @@
+#!../../bin/windows-x64/TEKOSC-IOC-01
+
+## You may have to change TEKOSC-IOC-01 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+cd "${TOP}"
+
+## Register all support components
+dbLoadDatabase "dbd/TEKOSC-IOC-01.dbd"
+TEKOSC_IOC_01_registerRecordDeviceDriver pdbbase
+
+## calling common command file in ioc 01 boot dir
+< ${TOP}/iocBoot/iocTEKOSC-IOC-01/st-common.cmd


### PR DESCRIPTION
### Description of work
Adds the non-support stuff for the Tektronix IOC. The device connects through an IP address provided via a macro. 

This PR also adds an 3rd background script IOC, which is just a copy of the second one. This is due to EMU already using two background scripts and therefore needing a 3rd if they want to collect images using the new script

### To test

ISISComputingGroup/IBEX#7318

### Acceptance criteria

1. The preamble and raw waveform data for each channel is accessible through blocks. 
2. The address of the device can be changed (it's common for its IP to have changed if it's been switched off for a while)


Note: There's a real device on my desk, ping me for the IP if testing remotely or just go and have a look at it. (Utility -> Utility Page -> I/O -> Ethernet Network Settings -> Change Instrument Settings)

Partially Resolves ISISComputingGroup/IBEX#7318

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
