### PR TITLE
Avoid a file copy race condition

### DIFF
--- a/ASTRIUM/ASTRIUM-IOC-01App/src/Makefile
+++ b/ASTRIUM/ASTRIUM-IOC-01App/src/Makefile
@@ -9,6 +9,9 @@ TOP=../..
 # this definition is used in build.mak
 APPNAME=ASTRIUM-IOC-01
 
+## need to put here and not build.mak or will get executed multiple times and error
+BIN_INSTALLS_WIN32 += $(wildcard $(SUPPORT)/astriumchopper/master/bin/$(EPICS_HOST_ARCH)/*.dll)
+
 # If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
 # there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
 include $(TOP)/ASTRIUM-IOC-01App/src/build.mak

--- a/ASTRIUM/ASTRIUM-IOC-01App/src/build.mak
+++ b/ASTRIUM/ASTRIUM-IOC-01App/src/build.mak
@@ -44,8 +44,6 @@ $(APPNAME)_SRCS_vxWorks += -nil-
 # Finally link to the EPICS Base libraries
 $(APPNAME)_LIBS += $(EPICS_BASE_IOC_LIBS)
 
-BIN_INSTALLS_WIN32 += $(wildcard $(SUPPORT)/astriumchopper/master/bin/$(EPICS_HOST_ARCH)/*.dll)
-
 #===========================
 
 include $(TOP)/configure/RULES

--- a/HVCAEN/HVCAEN-IOC-01App/src/Makefile
+++ b/HVCAEN/HVCAEN-IOC-01App/src/Makefile
@@ -4,6 +4,10 @@ TOP=../..
 # this definition is used in build.mak
 APPNAME=HVCAEN-IOC-01
 
+# copy in the caenhvwrapper we used - this is so we do not pick up a system installed one
+# need to do here and not build.mak to avoid copy conflict
+BIN_INSTALLS_WIN32 += $(HVCAEN)/bin/$(EPICS_HOST_ARCH)/CAENHVWrapper.dll
+
 # If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
 # there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
 include $(TOP)/HVCAEN-IOC-01App/src/build.mak

--- a/HVCAEN/HVCAEN-IOC-01App/src/build.mak
+++ b/HVCAEN/HVCAEN-IOC-01App/src/build.mak
@@ -71,9 +71,6 @@ $(APPNAME)_SRCS_vxWorks += -nil-
 # Finally link to the EPICS Base libraries
 $(APPNAME)_LIBS += $(EPICS_BASE_IOC_LIBS)
 
-# copy in the caenhvwrapper we used - this is so we do not pick up a system installed one
-BIN_INSTALLS_WIN32 += $(HVCAEN)/bin/$(EPICS_HOST_ARCH)/CAENHVWrapper.dll
-
 #===========================
 
 include $(TOP)/configure/RULES

--- a/HVCAENA/HVCAENA-IOC-01App/src/Makefile
+++ b/HVCAENA/HVCAENA-IOC-01App/src/Makefile
@@ -4,6 +4,10 @@ TOP=../..
 # this definition is used in build.mak
 APPNAME=HVCAENA-IOC-01
 
+# copy in the caenhvwrapper we used - this is so we do not pick up a system installed one
+# need to do here to avoid parallel copy failure
+BIN_INSTALLS_WIN32 += $(HVCAEN)/bin/$(EPICS_HOST_ARCH)/CAENHVWrapper.dll
+
 # If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
 # there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
 include $(TOP)/HVCAENA-IOC-01App/src/build.mak

--- a/HVCAENA/HVCAENA-IOC-01App/src/build.mak
+++ b/HVCAENA/HVCAENA-IOC-01App/src/build.mak
@@ -60,9 +60,6 @@ $(APPNAME)_SRCS_vxWorks += -nil-
 # Finally link to the EPICS Base libraries
 $(APPNAME)_LIBS += $(EPICS_BASE_IOC_LIBS)
 
-# copy in the caenhvwrapper we used - this is so we do not pick up a system installed one
-BIN_INSTALLS_WIN32 += $(HVCAEN)/bin/$(EPICS_HOST_ARCH)/CAENHVWrapper.dll
-
 #===========================
 
 include $(TOP)/configure/RULES

--- a/MK3CHOPR/MK3CHOPR-IOC-01App/src/Makefile
+++ b/MK3CHOPR/MK3CHOPR-IOC-01App/src/Makefile
@@ -4,6 +4,9 @@ TOP=../..
 # this definition is used in build.mak
 APPNAME=MK3CHOPR-IOC-01
 
+# need to do here and not build.mak to avoid parallel copy comflict 
+BIN_INSTALLS_WIN32 += $(wildcard $(SUPPORT)/mk3Chopper/master/bin/$(EPICS_HOST_ARCH)/*.dll)
+
 # If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
 # there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
 include $(TOP)/MK3CHOPR-IOC-01App/src/build.mak

--- a/MK3CHOPR/MK3CHOPR-IOC-01App/src/build.mak
+++ b/MK3CHOPR/MK3CHOPR-IOC-01App/src/build.mak
@@ -44,8 +44,6 @@ $(APPNAME)_SRCS_vxWorks += -nil-
 # Finally link to the EPICS Base libraries
 $(APPNAME)_LIBS += $(EPICS_BASE_IOC_LIBS)
 
-BIN_INSTALLS_WIN32 += $(wildcard $(SUPPORT)/mk3Chopper/master/bin/$(EPICS_HOST_ARCH)/*.dll)
-
 #===========================
 
 include $(TOP)/configure/RULES


### PR DESCRIPTION
As ioc builds execute in parallel, a copy in of an external file must only be executed in the 01 IOC
