### PR TITLE
Add record to coerce heater status, edit comments and DESC fields

### DIFF
--- a/IPS/IPS-IOC-01App/Db/ips.db
+++ b/IPS/IPS-IOC-01App/Db/ips.db
@@ -654,13 +654,12 @@ record(bo, "$(P)HEATER:STATUS:SP") {
   field(SDIS, "$(P)DISABLE")
 }
 
-# Amount of time to wait for heater to warm up/cool down.
-# CAN CAUSE MAGNET TO QUENCH IF SET TOO LOW
-# Oxford Instruments labview driver uses 30s
-# ISIS cryogenics have asked us to increase this to 60s,
+# Amount of time to wait for heater to warm up/cool down.  **CAN CAUSE MAGNET TO QUENCH IF SET TOO LOW**
+# Oxford Instruments labview driver uses 30s.  ISIS cryogenics have asked us to increase this to 60s,
 # which is more conservative.
-# The HEATER_WAITTIME IOC macro, which is _not_ user-facing, 
-# has a default of 60s
+# The HEATER_WAITTIME IOC macro, which is _not_ user-facing, has a default of 60s.
+# Configurable to lower values to shorten time for IOC tests.
+
 record(ao, "$(P)HEATER:WAITTIME") {
   field(DESC, "Time to wait for heater")
   field(VAL, "$(HEATER_WAITTIME)")
@@ -668,11 +667,23 @@ record(ao, "$(P)HEATER:WAITTIME") {
   info(archive, "VAL")
 }
 
+# CALC record to coerce heater status values.  Heater can be off in states 0 or 2, and in error in states 5 or 8, 
+# and circular buffer (N to 1 Low Value) only looks for lowest (0).
+# Output 1 only if heater is on, 0 if off and all other states, including errors.
+
+record(calc, "$(P)HEATER:_STATUS_CALC") {
+    field(DESC, "Binary Heater Status")
+    field(INPA, "$(P)HEATER:STATUS CP MS")
+    field(CALC, "(A=1)?1:0")                # If heater is on, output 1, otherwise 0
+    info(archive, "VAL")
+}
+
 # COMPRESS Record with circular buffer to store $(HEATER_WAITTIME) worth of HEATER:STATUS values
 # Used with second COMPRESS record below to check heater has been on for at least $(HEATER_WAITTIME) after starting IOC
 
 record(compress, "$(P)HEATER:_STATUS_BUFFER") {
-  field(INP, "$(P)HEATER:STATUS.VAL")
+  field(DESC, "Buffer of heater status values")
+  field(INP, "$(P)HEATER:_STATUS_CALC.VAL")
   field(ALG, "Circular Buffer")
   field(NSAM, "$(HEATER_WAITTIME)")
   field(SCAN, "1 second")
@@ -684,6 +695,7 @@ record(compress, "$(P)HEATER:_STATUS_BUFFER") {
 # If '0' then heater has been OFF at some point in $(HEATER_WAITTIME)
 
 record(compress, "$(P)HEATER:_STATUS_BUFFER_LOWEST") {
+  field(DESC, "Lowest value of heater status buffer")
   field(INP, "$(P)HEATER:_STATUS_BUFFER")
   field(ALG, "N to 1 Low Value")
   field(NSAM, "1")
@@ -695,7 +707,7 @@ record(compress, "$(P)HEATER:_STATUS_BUFFER_LOWEST") {
 # BO record to indicate whether or not heater been on for at least $(HEATER_WAITTIME). Monitored by statemachine to determine whether or not OK to set field.
 
 record(bo, "$(P)HEATER:ONTIME_OK") {
-  field(DESC, "Heater on for at least WAITTIME")
+  field(DESC, "Heater on for at least $(HEATER_WAITTIME)s")
   field(DTYP, "Soft Channel")
   field(SCAN, "Passive")
   field(OMSL, "closed_loop")
@@ -706,7 +718,7 @@ record(bo, "$(P)HEATER:ONTIME_OK") {
 }
 
 
-# # Readback from m of Mmn part of Examine command return.
+# Readback from m of Mmn part of Examine command return.
 # The Display is in Amps or Tesla.  The Magnet Sweep is fast or slow.
 record(mbbi, "$(P)SWEEPMODE:PARAMS") {
   field(DESC, "Mode status")


### PR DESCRIPTION
### Description of work

Heater off in more than one state.  Need binary value for check.  Added record to coerce status.

### To test

Flash review

### Acceptance criteria

*List the acceptance criteria for the PR*

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
