### PR TITLE
Fixed macro having no 'hasDefault' value

### DIFF
--- a/RZBRP100/iocBoot/iocRZBRP100-IOC-01/config.xml
+++ b/RZBRP100/iocBoot/iocRZBRP100-IOC-01/config.xml
@@ -4,7 +4,7 @@
 <ioc_desc>Razorbill RP100 Strain Cell PSU</ioc_desc>
 <ioc_details></ioc_details>
 <macros>
-<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM port" />
+<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM port" hasDefault="NO" />
 </macros>
 <pvsets>
 </pvsets>


### PR DESCRIPTION
### Description of work

RZBRP100 was returning an error when trying to run `make iocstartups` from EPICS terminal, with a message saying that its PORT macro has no "hasDefault" attribute. This was added into RZBRP100-01's config.xml
