### PR TITLE
Area, speed, and pressure macros

### DIFF
--- a/NIMATRO/NIMATRO-IOC-01App/Db/controls.db
+++ b/NIMATRO/NIMATRO-IOC-01App/Db/controls.db
@@ -52,8 +52,8 @@ record(ao, "$(P)SPEED:SP")
     field(OUT,  "@asyn(lvfp,0,0)Speed")
     field(PREC, "3")
     field(EGU, "cm^2/min")
-	field(DRVH, "174.2")  # Device high limit
-	field(DRVL, "-174.2") # Device low limit
+	field(DRVH, $(SPEED_HIGH_LIMIT))  # Device high limit
+	field(DRVL, $(SPEED_LOW_LIMIT)) # Device low limit
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:SPEED:SP")
     field(SDIS, "$(P)DISABLE")
@@ -99,8 +99,8 @@ record(ao, "$(P)PRESSURE:SP")
     field(OUT,  "@asyn(lvfp,0,0)Target_Pressure")
     field(PREC, "3")
     field(EGU, "mN/m")
-	field(DRVH, "75.0")  # Device high limit
-	field(DRVL, "-75.0") # Device low limit
+	field(DRVH, $(PRESSURE_HIGH_LIMIT))  # Device high limit
+	field(DRVL, $(PRESSURE_LOW_LIMIT)) # Device low limit
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:PRESSURE:SP")
     field(SDIS, "$(P)DISABLE")
@@ -147,8 +147,8 @@ record(ao, "$(P)AREA:SP")
     field(OUT,  "@asyn(lvfp,0,0)Target__Area")
     field(PREC, "3")
     field(EGU, "cm^2")
-	field(DRVH, "247.0") # Device high limit
-    field(DRVL, "36.0")	 # Device low limit
+	field(DRVH, $(AREA_HIGH_LIMIT)) # Device high limit
+    field(DRVL, $(AREA_LOW_LIMIT))	 # Device low limit
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:AREA:SP")
     field(SDIS, "$(P)DISABLE")

--- a/NIMATRO/iocBoot/iocNIMATRO-IOC-01/config.xml
+++ b/NIMATRO/iocBoot/iocNIMATRO-IOC-01/config.xml
@@ -6,6 +6,13 @@
     <macro name="LVDCOM_OPTIONS" pattern="^\d?\d?$" description="Options that define how the VI is started. Add selected options together to make the final value. 1 - warn if idle, 2 - start if idle, 4 - stop VIs if started on exit, 8 - stop VI on exit. (Default 2)" defaultValue="2" hasDefault="YES" />
     <macro name="LVDCOM_HOST" pattern="^.*$" description="Host on which the vi is running, blank for localhost (Default '')" defaultValue="" hasDefault="YES" />
     <macro name="LVDCOM_PROGID" pattern="^.*$" description="DCOM ProgID, required if connecting to a compiled LabVIEW application (Default '')" defaultValue="" hasDefault="YES" />
+	<macro name="AREA_HIGH_LIMIT" pattern="^-?[0-9]+\.?[0-9]*$" description="The high area limit of the Nima trough" defaultValue="247.0" hasDefault="YES" />
+	<macro name="AREA_LOW_LIMIT" pattern="^-?[0-9]+\.?[0-9]*$" description="The low area limit of the Nima trough" defaultValue="36.0" hasDefault="YES" />
+	<macro name="PRESSURE_HIGH_LIMIT" pattern="^-?[0-9]+\.?[0-9]*$" description="The pressure high limit of the Nima trough" defaultValue="75.0" hasDefault="YES" />
+	<macro name="PRESSURE_LOW_LIMIT" pattern="^-?[0-9]+\.?[0-9]*$" description="The pressure low limit of the Nima trough" defaultValue="-75.0" hasDefault="YES" />
+	<macro name="SPEED_HIGH_LIMIT" pattern="^-?[0-9]+\.?[0-9]*$" description="The speed high limit of the Nima trough" defaultValue="174.2" hasDefault="YES" />
+	<macro name="SPEED_LOW_LIMIT" pattern="^-?[0-9]+\.?[0-9]*$" description="The speed low limit of the Nima trough" defaultValue="-174.2" hasDefault="YES" />
+	
 </macros>
 </config_part>
 </ioc_config>

--- a/NIMATRO/iocBoot/iocNIMATRO-IOC-01/st-common.cmd
+++ b/NIMATRO/iocBoot/iocNIMATRO-IOC-01/st-common.cmd
@@ -1,4 +1,4 @@
-epicsEnvSet "DEVICE" "L0"
+epicsEnvSet "DEVICE" "L0
 
 ##ISIS## Run IOC initialisation 
 < $(IOCSTARTUP)/init.cmd
@@ -13,7 +13,7 @@ lvDCOMConfigure("lvfp", "frontpanel", "${TOP}/data/lv_controls.xml", "$(LVDCOM_H
 < $(IOCSTARTUP)/dbload.cmd
 
 ## Load our record instances
-dbLoadRecords("${TOP}/db/controls.db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX)$(IOCNAME):,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0)")
+dbLoadRecords("${TOP}/db/controls.db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX)$(IOCNAME):,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),AREA_HIGH_LIMIT=$(AREA_HIGH_LIMIT=247.0),AREA_LOW_LIMIT=$(AREA_LOW_LIMIT=36.0),PRESSURE_HIGH_LIMIT=$(PRESSURE_HIGH_LIMIT=75.0),PRESSURE_LOW_LIMIT=$(PRESSURE_LOW_LIMIT=-75.0),SPEED_HIGH_LIMIT=$(SPEED_HIGH_LIMIT=174.2),SPEED_LOW_LIMIT=$(SPEED_LOW_LIMIT=-174.2)")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd


### PR DESCRIPTION
### Description of work

Added Area, Speed, and Pressure macros to controls.db, config.xml, and st-common.cmd for the NIMA Trough, so that scientists using IBEX can set their own high and low limits for all three. If they do not specify their own limits, they will default to the current default highs and lows for those three respective values. 

### To test

*Which ticket does this PR fix?*
https://github.com/ISISComputingGroup/IBEX/issues/7141

### Acceptance criteria

- [ ] Make the area limit a macro that defaults to the current value in the db

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
