### PR TITLE
Refactor LSI startup

### DIFF
--- a/LSICORR/iocBoot/iocLSICORR-IOC-01/Makefile
+++ b/LSICORR/iocBoot/iocLSICORR-IOC-01/Makefile
@@ -1,6 +1,0 @@
-TOP = ../..
-include $(TOP)/configure/CONFIG
-#ARCH = windows-x64
-ARCH = $(EPICS_HOST_ARCH)
-TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
-include $(TOP)/configure/RULES.ioc

--- a/LSICORR/iocBoot/iocLSICORR-IOC-01/dllPath.bat
+++ b/LSICORR/iocBoot/iocLSICORR-IOC-01/dllPath.bat
@@ -1,2 +1,2 @@
 @ECHO OFF
-SET "PATH=%EPICS_KIT_ROOT%/support/icpconfig/master/bin/%EPICS_HOST_ARCH%;%EPICS_KIT_ROOT%/support/pugixml/master/bin/%EPICS_HOST_ARCH%;%EPICS_KIT_ROOT%/support/utilities/master/bin/%EPICS_HOST_ARCH%;%EPICS_KIT_ROOT%/support/pcre/master/bin/%EPICS_HOST_ARCH%;%EPICS_BASE%/bin/%EPICS_HOST_ARCH%;%PATH%"
+SET "PATH=%EPICS_KIT_ROOT%\support\icpconfig\master\bin\%EPICS_HOST_ARCH%;%EPICS_KIT_ROOT%\support\pugixml\master\bin\%EPICS_HOST_ARCH%;%EPICS_KIT_ROOT%\support\pcre\master\bin\%EPICS_HOST_ARCH%;%PATH%"

--- a/LSICORR/iocBoot/iocLSICORR-IOC-01/runIOC.bat
+++ b/LSICORR/iocBoot/iocLSICORR-IOC-01/runIOC.bat
@@ -1,8 +1,11 @@
 @echo off
 setlocal
-set MYDIRBLOCK=%~dp0
-call C:\Instrument\Apps\EPICS\config_env_base.bat
-call dllPath.bat
+if exist "%~dp0..\..\..\..\..\config_env_base.bat" (
+    call %~dp0..\..\..\..\..\config_env_base.bat
+) else (
+    call C:\Instrument\Apps\EPICS\config_env_base.bat
+)
+call %~dp0dllPath.bat
 %HIDEWINDOW% h
 
 set EPICS_CAS_INTF_ADDR_LIST=127.0.0.1
@@ -10,8 +13,8 @@ set EPICS_CAS_BEACON_ADDR_LIST=127.255.255.255
 
 set PYTHONUNBUFFERED=TRUE
 
-set "GETMACROS=C:\Instrument\Apps\EPICS\support\icpconfig\master\bin\%EPICS_HOST_ARCH%\icpconfigGetMacros.exe"
-set "MYIOCNAME=LSICORR_01"
+set "GETMACROS=%EPICS_KIT_ROOT%\support\icpconfig\master\bin\%EPICS_HOST_ARCH%\icpconfigGetMacros.exe"
+if "%MYIOCNAME%" == "" set "MYIOCNAME=LSICORR_01"
 
 if "%MACROS%"=="" (
     REM need this funny syntax to be able to set eol correctly - see google
@@ -21,4 +24,6 @@ if "%MACROS%"=="" (
     echo Macros already defined
 )
 
-%PYTHON3W% %EPICS_KIT_ROOT%/support/lsicorr/master/correlator_pcaspy.py --pv_prefix %MYPVPREFIX% --ioc_name %MYIOCNAME%
+echo Macros are %MACROS%
+
+"%PYTHON3W%" -u "%EPICS_KIT_ROOT%\support\lsicorr\master\correlator_pcaspy.py" --pv_prefix %MYPVPREFIX% --ioc_name %MYIOCNAME%

--- a/LSICORR/iocBoot/iocLSICORR-IOC-02/Makefile
+++ b/LSICORR/iocBoot/iocLSICORR-IOC-02/Makefile
@@ -1,6 +1,0 @@
-TOP = ../..
-include $(TOP)/configure/CONFIG
-#ARCH = windows-x64
-ARCH = $(EPICS_HOST_ARCH)
-TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
-include $(TOP)/configure/RULES.ioc

--- a/LSICORR/iocBoot/iocLSICORR-IOC-02/dllPath.bat
+++ b/LSICORR/iocBoot/iocLSICORR-IOC-02/dllPath.bat
@@ -1,2 +1,0 @@
-@ECHO OFF
-SET "PATH=%EPICS_KIT_ROOT%/support/icpconfig/master/bin/%EPICS_HOST_ARCH%;%EPICS_KIT_ROOT%/support/pugixml/master/bin/%EPICS_HOST_ARCH%;%EPICS_KIT_ROOT%/support/utilities/master/bin/%EPICS_HOST_ARCH%;%EPICS_KIT_ROOT%/support/pcre/master/bin/%EPICS_HOST_ARCH%;%EPICS_BASE%/bin/%EPICS_HOST_ARCH%;%PATH%"

--- a/LSICORR/iocBoot/iocLSICORR-IOC-02/runIOC.bat
+++ b/LSICORR/iocBoot/iocLSICORR-IOC-02/runIOC.bat
@@ -1,24 +1,4 @@
 @echo off
 setlocal
-set MYDIRBLOCK=%~dp0
-call C:\Instrument\Apps\EPICS\config_env_base.bat
-call dllPath.bat
-%HIDEWINDOW% h
-
-set EPICS_CAS_INTF_ADDR_LIST=127.0.0.1
-set EPICS_CAS_BEACON_ADDR_LIST=127.255.255.255
-
-set PYTHONUNBUFFERED=TRUE
-
-set "GETMACROS=C:\Instrument\Apps\EPICS\support\icpconfig\master\bin\%EPICS_HOST_ARCH%\icpconfigGetMacros.exe"
 set "MYIOCNAME=LSICORR_02"
-
-if "%MACROS%"=="" (
-    REM need this funny syntax to be able to set eol correctly - see google
-    for /f usebackq^ tokens^=*^ delims^=^ eol^= %%a in ( `%GETMACROS% %MYIOCNAME%`  ) do ( set "MACROS=%%a" )
-    echo Defining macros
-) else (
-    echo Macros already defined
-)
-
-%PYTHON3W% %EPICS_KIT_ROOT%/support/lsicorr/master/correlator_pcaspy.py --pv_prefix %MYPVPREFIX% --ioc_name %MYIOCNAME%
+call %~dp0..\iocLSICORR-IOC-01\runIOC.bat


### PR DESCRIPTION
### Description of work

Refactor LSI startup - there have been recent startup errors in system tests, amongst other things this change reduces the amount of items added to PATH that may have become an issue    

### To test

`run_all_tests.bat -t lsicorr` in `support\IOCSystemTests\master`

### Acceptance criteria

tests pass

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
