### PR TITLE
Fix Macro in ZFCNTRL

### DIFF
--- a/ZFCNTRL/iocBoot/iocZFCNTRL-IOC-01/config.xml
+++ b/ZFCNTRL/iocBoot/iocZFCNTRL-IOC-01/config.xml
@@ -26,7 +26,7 @@
     <macro name="AMPS_PER_MG_Y" pattern="^-?[0-9]+\.?[0-9]*$" description="Amps per mG calibration factor, axis Y" hasDefault="YES" defaultValue="0" />
     <macro name="AMPS_PER_MG_Z" pattern="^-?[0-9]+\.?[0-9]*$" description="Amps per mG calibration factor, axis Z" hasDefault="YES" defaultValue="0" />
 
-    <macro name="FEEDBACK" pattern="^-?[0-9]+\.?[0-9]_*$" description="Feedback factor" hasDefault="YES" defaultValue="0" />
+    <macro name="FEEDBACK" pattern="^-?[0-9]+\.?[0-9]*$" description="Feedback factor" hasDefault="YES" defaultValue="0" />
   </macros>
  </config_part>
 </ioc_config>


### PR DESCRIPTION
### Description of work

Macro was using incorrect regex for optional decimal places due to typo'd underscore.

---


### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
