### PR TITLE
Added IOC for remote interaction with labview

### DIFF
--- a/LVREMOTE/LVREMOTE-IOC-01App/Db/Makefile
+++ b/LVREMOTE/LVREMOTE-IOC-01App/Db/Makefile
@@ -1,0 +1,18 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+DB += lvremotetest.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/LVREMOTE/LVREMOTE-IOC-01App/Db/lvremote_binary.template
+++ b/LVREMOTE/LVREMOTE-IOC-01App/Db/lvremote_binary.template
@@ -57,3 +57,5 @@ record(bo, "$(P)SIM:$(DEVICE):$(NAME)")
 }
 
 $(READONLY)alias("$(P)SIM:$(DEVICE):$(NAME)","$(P)SIM:$(DEVICE):$(NAME):SP")
+
+

--- a/LVREMOTE/LVREMOTE-IOC-01App/Db/lvremote_binary.template
+++ b/LVREMOTE/LVREMOTE-IOC-01App/Db/lvremote_binary.template
@@ -1,0 +1,59 @@
+# Template file for remote labview services binary values (e.g. buttons or LEDs)
+# Substitutions
+# DEVICE - The Device name
+# P - The PV prefix (This should usually be substituted for $(P))
+# NAME - The name of the pv
+# IND - The indicator of the value to read from labview
+# CONTROL - The control to write to, can be left out of substitution if readonly
+# ZERO - The name of the value to read on 0
+# ONE - The name of the value to read on 0
+# VI - The path to the VI on the host computer as a string.
+# PORT - The Port to read (by default, L0 for Strings and L1 for Binary)
+# READONLY - Whether or not a value is readonly, should be "#" when true and "" when false.
+# DESCRIPTION - The description of the PV, will be appended to "Readback for " and "Setpoint for " 
+# SCAN - Scan rate for the readback
+
+
+record(bi, "$(P)$(DEVICE):$(NAME)") {
+    field(DESC, "Readback for $(DESCRIPTION)")
+    field(DTYP, "stream")
+    field(INP,  "@lvremote_num.proto getBoolVal($(VI),$(IND)) $(PORT)")
+    field(SCAN, "$(SCAN)")
+    field(ZNAM, "$(ZERO)")
+    field(ONAM, "$(ONE)")
+
+    field(SIML, "$(P)SIM")
+    field(SIOL, "$(P)SIM:$(DEVICE):$(NAME) PP")
+}
+
+$(READONLY)record(bo, "$(P)$(DEVICE):$(NAME):SP") {
+$(READONLY)    field(DESC, "Setpoint for $(DESCRIPTION)")
+$(READONLY)    field(DTYP, "stream")
+$(READONLY)    field(OUT,  "@lvremote_num.proto setBoolVal($(VI),$(CONTROL="")) $(PORT)")
+$(READONLY)    field(SCAN, "Passive")
+$(READONLY)    field(ZNAM, "$(ZERO)")
+$(READONLY)    field(ONAM, "$(ONE)")
+
+$(READONLY)    field(SIML, "$(P)SIM")
+$(READONLY)    field(SIOL, "$(P)SIM:$(DEVICE):$(NAME):SP PP")
+$(READONLY)}
+
+$(READONLY)record(bi, "$(P)$(DEVICE):$(NAME):SP:RBV") {
+$(READONLY)    field(DESC, "Setpoint Readback for $(DESCRIPTION)")
+$(READONLY)    field(DTYP, "stream")
+$(READONLY)    field(INP,  "@lvremote_num.proto getBoolVal($(VI),$(CONTROL="")) $(PORT)")
+$(READONLY)    field(SCAN, "$(SCAN)")
+$(READONLY)    field(ZNAM, "$(ZERO)")
+$(READONLY)    field(ONAM, "$(ONE)")
+
+$(READONLY)    field(SIML, "$(P)SIM")
+$(READONLY)    field(SIOL, "$(P)SIM:$(DEVICE):$(NAME) PP")
+$(READONLY)}
+
+record(bo, "$(P)SIM:$(DEVICE):$(NAME)") 
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+}
+
+$(READONLY)alias("$(P)SIM:$(DEVICE):$(NAME)","$(P)SIM:$(DEVICE):$(NAME):SP")

--- a/LVREMOTE/LVREMOTE-IOC-01App/Db/lvremote_double.template
+++ b/LVREMOTE/LVREMOTE-IOC-01App/Db/lvremote_double.template
@@ -1,0 +1,51 @@
+# Template file for remote labview services binary values (e.g. buttons or LEDs)
+# Substitutions
+# DEVICE - The Device name
+# P - The PV prefix (This should usually be substituted for $(P))
+# NAME - The name of the pv
+# IND - The indicator of the value to read from labview
+# CONTROL - The control to write to, can be left out of substitution if readonly
+# VI - The path to the VI on the host computer as a string.
+# PORT - The Port to read (by default, L0 for Strings and L1 for Binary)
+# READONLY - Whether or not a value is readonly, should be "#" when true and "" when false.
+# DESCRIPTION - The description of the PV, will be appended to "Readback for " and "Setpoint for " 
+# SCAN - Scan rate for the readback
+
+
+record(ai, "$(P)$(DEVICE):$(NAME)") {
+    field(DESC, "Readback for $(DESCRIPTION)")
+    field(DTYP, "stream")
+    field(INP,  "@lvremote_num.proto getBoolVal($(VI),$(IND)) $(PORT)")
+    field(SCAN, "$(SCAN)")
+
+    field(SIML, "$(P)SIM")
+    field(SIOL, "$(P)SIM:$(DEVICE):$(NAME) PP")
+}
+
+$(READONLY)record(ao, "$(P)$(DEVICE):$(NAME):SP") {
+$(READONLY)    field(DESC, "Setpoint for $(DESCRIPTION)")
+$(READONLY)    field(DTYP, "stream")
+$(READONLY)    field(OUT,  "@lvremote_num.proto setBoolVal($(VI),$(CONTROL="")) $(PORT)")
+$(READONLY)    field(SCAN, "Passive")
+
+$(READONLY)    field(SIML, "$(P)SIM")
+$(READONLY)    field(SIOL, "$(P)SIM:$(DEVICE):$(NAME):SP PP")
+$(READONLY)}
+
+$(READONLY)record(ai, "$(P)$(DEVICE):$(NAME):SP:RBV") {
+$(READONLY)    field(DESC, "Setpoint Readback for $(DESCRIPTION)")
+$(READONLY)    field(DTYP, "stream")
+$(READONLY)    field(INP,  "@lvremote_num.proto getBoolVal($(VI),$(CONTROL="")) $(PORT)")
+$(READONLY)    field(SCAN, "$(SCAN)")
+
+$(READONLY)    field(SIML, "$(P)SIM")
+$(READONLY)    field(SIOL, "$(P)SIM:$(DEVICE):$(NAME) PP")
+$(READONLY)}
+
+record(bo, "$(P)SIM:$(DEVICE):$(NAME)") 
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+}
+
+$(READONLY)alias("$(P)SIM:$(DEVICE):$(NAME)","$(P)SIM:$(DEVICE):$(NAME):SP")

--- a/LVREMOTE/LVREMOTE-IOC-01App/Db/lvremote_double.template
+++ b/LVREMOTE/LVREMOTE-IOC-01App/Db/lvremote_double.template
@@ -1,4 +1,4 @@
-# Template file for remote labview services binary values (e.g. buttons or LEDs)
+# Template file for remote labview services Double values (e.g. buttons or LEDs)
 # Substitutions
 # DEVICE - The Device name
 # P - The PV prefix (This should usually be substituted for $(P))
@@ -15,7 +15,7 @@
 record(ai, "$(P)$(DEVICE):$(NAME)") {
     field(DESC, "Readback for $(DESCRIPTION)")
     field(DTYP, "stream")
-    field(INP,  "@lvremote_num.proto getBoolVal($(VI),$(IND)) $(PORT)")
+    field(INP,  "@lvremote_num.proto getDoubleVal($(VI),$(IND)) $(PORT)")
     field(SCAN, "$(SCAN)")
 
     field(SIML, "$(P)SIM")
@@ -25,7 +25,7 @@ record(ai, "$(P)$(DEVICE):$(NAME)") {
 $(READONLY)record(ao, "$(P)$(DEVICE):$(NAME):SP") {
 $(READONLY)    field(DESC, "Setpoint for $(DESCRIPTION)")
 $(READONLY)    field(DTYP, "stream")
-$(READONLY)    field(OUT,  "@lvremote_num.proto setBoolVal($(VI),$(CONTROL="")) $(PORT)")
+$(READONLY)    field(OUT,  "@lvremote_num.proto setDoubleVal($(VI),$(CONTROL="")) $(PORT)")
 $(READONLY)    field(SCAN, "Passive")
 
 $(READONLY)    field(SIML, "$(P)SIM")
@@ -35,7 +35,7 @@ $(READONLY)}
 $(READONLY)record(ai, "$(P)$(DEVICE):$(NAME):SP:RBV") {
 $(READONLY)    field(DESC, "Setpoint Readback for $(DESCRIPTION)")
 $(READONLY)    field(DTYP, "stream")
-$(READONLY)    field(INP,  "@lvremote_num.proto getBoolVal($(VI),$(CONTROL="")) $(PORT)")
+$(READONLY)    field(INP,  "@lvremote_num.proto getDoubleVal($(VI),$(CONTROL="")) $(PORT)")
 $(READONLY)    field(SCAN, "$(SCAN)")
 
 $(READONLY)    field(SIML, "$(P)SIM")
@@ -49,3 +49,5 @@ record(bo, "$(P)SIM:$(DEVICE):$(NAME)")
 }
 
 $(READONLY)alias("$(P)SIM:$(DEVICE):$(NAME)","$(P)SIM:$(DEVICE):$(NAME):SP")
+
+

--- a/LVREMOTE/LVREMOTE-IOC-01App/Db/lvremote_enum.template
+++ b/LVREMOTE/LVREMOTE-IOC-01App/Db/lvremote_enum.template
@@ -1,0 +1,190 @@
+# Template file for remote labview services binary values (e.g. buttons or LEDs)
+# Substitutions
+# DEVICE - The Device name
+# P - The PV prefix (This should usually be substituted for $(P))
+# NAME - The name of the pv
+# IND - The indicator of the value to read from labview
+# CONTROL - The control to write to, can be left out of substitution if readonly
+# VI - The path to the VI on the host computer as a string.
+# PORT - The Port to read (by default, L0 for Strings and L1 for Binary)
+# PORT2 - An additional port macro used when both are needed.
+# READONLY - Whether or not a value is readonly, should be "#" when true and "" when false.
+# DESCRIPTION - The description of the PV, will be appended to "Readback for " and "Setpoint for " 
+# SCAN - Scan rate for the readback
+####################################
+# ZRVL - The 0 value
+# ONVL - The 1 value
+# TWVL - The 2 value
+# THVL - The 3 value
+# FRVL - The 4 value
+# FVVL - The 5 value
+# SXVL - The 6 value
+# SVVL - The 7 value
+# EIVL - The 8 value
+# NIVL - The 9 value
+# TEVL - The 10 value
+# ELVL - The 11 value
+# TVVL - The 12 value
+# TTVL - The 13 value
+# FTVL - The 14 value
+# FFVL - The 15 value
+####################################
+# ZRST - The 0 string
+# ONST - The 1 string
+# TWST - The 2 string
+# THST - The 3 string
+# FRST - The 4 string
+# FVST - The 5 string
+# SXST - The 6 string
+# SVST - The 7 string
+# EIST - The 8 string
+# NIST - The 9 string
+# TEST - The 10 string
+# ELST - The 11 string
+# TVST - The 12 string
+# TTST - The 13 string
+# FTST - The 14 string
+# FFST - The 15 string
+####################################
+
+record(mbbi, "$(P)$(DEVICE):$(NAME)") {
+    field(DESC, "Readback for $(DESCRIPTION)")
+    field(DTYP, "stream")
+    field(INP,  "@lvremote_string.proto getString($(VI),$(IND)) $(PORT2)")
+    field(SCAN, "$(SCAN)")
+
+    field(ZRVL, "$(ZRVL=0)")
+    field(ONVL, "$(ONVL=0)")
+    field(TWVL, "$(TWVL=0)")
+    field(THVL, "$(THVL=0)")
+    field(FRVL, "$(FRVL=0)")
+    field(FVVL, "$(FVVL=0)")
+    field(SXVL, "$(SXVL=0)")
+    field(SVVL, "$(SVVL=0)")
+    field(EIVL, "$(EIVL=0)")
+    field(NIVL, "$(NIVL=0)")
+    field(TEVL, "$(TEVL=0)")
+    field(ELVL, "$(ELVL=0)")
+    field(TVVL, "$(TVVL=0)")
+    field(TTVL, "$(TTVL=0)")
+    field(FTVL, "$(FTVL=0)")
+    field(FFVL, "$(FFVL=0)")
+
+    field(ZRST, "$(ZRST='')")
+    field(ONST, "$(ONST='')")
+    field(TWST, "$(TWST='')")
+    field(THST, "$(THST='')")
+    field(FRST, "$(FRST='')")
+    field(FVST, "$(FVST='')")
+    field(SXST, "$(SXST='')")
+    field(SVST, "$(SVST='')")
+    field(EIST, "$(EIST='')")
+    field(NIST, "$(NIST='')")
+    field(TEST, "$(TEST='')")
+    field(ELST, "$(ELST='')")
+    field(TVST, "$(TVST='')")
+    field(TTST, "$(TTST='')")
+    field(FTST, "$(FTST='')")
+    field(FFST, "$(FFST='')")
+
+    field(SIML, "$(P)SIM")
+    field(SIOL, "$(P)SIM:$(DEVICE):$(NAME) PP")
+}
+
+$(READONLY)record(mbbo, "$(P)$(DEVICE):$(NAME):SP") {
+$(READONLY)    field(DESC, "Setpoint for $(DESCRIPTION)")
+$(READONLY)    field(DTYP, "stream")
+$(READONLY)    field(OUT,  "@lvremote_num.proto setEnumVal($(VI),$(CONTROL="")) $(PORT)")
+$(READONLY)    field(SCAN, "Passive")
+
+$(READONLY)    field(ZRVL, "$(ZRVL=0)")
+$(READONLY)    field(ONVL, "$(ONVL=0)")
+$(READONLY)    field(TWVL, "$(TWVL=0)")
+$(READONLY)    field(THVL, "$(THVL=0)")
+$(READONLY)    field(FRVL, "$(FRVL=0)")
+$(READONLY)    field(FVVL, "$(FVVL=0)")
+$(READONLY)    field(SXVL, "$(SXVL=0)")
+$(READONLY)    field(SVVL, "$(SVVL=0)")
+$(READONLY)    field(EIVL, "$(EIVL=0)")
+$(READONLY)    field(NIVL, "$(NIVL=0)")
+$(READONLY)    field(TEVL, "$(TEVL=0)")
+$(READONLY)    field(ELVL, "$(ELVL=0)")
+$(READONLY)    field(TVVL, "$(TVVL=0)")
+$(READONLY)    field(TTVL, "$(TTVL=0)")
+$(READONLY)    field(FTVL, "$(FTVL=0)")
+$(READONLY)    field(FFVL, "$(FFVL=0)")
+
+$(READONLY)    field(ZRST, "$(ZRST='')")
+$(READONLY)    field(ONST, "$(ONST='')")
+$(READONLY)    field(TWST, "$(TWST='')")
+$(READONLY)    field(THST, "$(THST='')")
+$(READONLY)    field(FRST, "$(FRST='')")
+$(READONLY)    field(FVST, "$(FVST='')")
+$(READONLY)    field(SXST, "$(SXST='')")
+$(READONLY)    field(SVST, "$(SVST='')")
+$(READONLY)    field(EIST, "$(EIST='')")
+$(READONLY)    field(NIST, "$(NIST='')")
+$(READONLY)    field(TEST, "$(TEST='')")
+$(READONLY)    field(ELST, "$(ELST='')")
+$(READONLY)    field(TVST, "$(TVST='')")
+$(READONLY)    field(TTST, "$(TTST='')")
+$(READONLY)    field(FTST, "$(FTST='')")
+$(READONLY)    field(FFST, "$(FFST='')")
+
+$(READONLY)    field(SIML, "$(P)SIM")
+$(READONLY)    field(SIOL, "$(P)SIM:$(DEVICE):$(NAME):SP PP")
+$(READONLY)}
+
+$(READONLY)record(mbbi, "$(P)$(DEVICE):$(NAME):SP:RBV") {
+$(READONLY)    field(DESC, "Setpoint Readback for $(DESCRIPTION)")
+$(READONLY)    field(DTYP, "stream")
+$(READONLY)    field(INP,  "@lvremote_num.proto getEnumVal($(VI),$(CONTROL="")) $(PORT)")
+$(READONLY)    field(SCAN, "$(SCAN)")
+
+$(READONLY)    field(ZRVL, "$(ZRVL=0)")
+$(READONLY)    field(ONVL, "$(ONVL=0)")
+$(READONLY)    field(TWVL, "$(TWVL=0)")
+$(READONLY)    field(THVL, "$(THVL=0)")
+$(READONLY)    field(FRVL, "$(FRVL=0)")
+$(READONLY)    field(FVVL, "$(FVVL=0)")
+$(READONLY)    field(SXVL, "$(SXVL=0)")
+$(READONLY)    field(SVVL, "$(SVVL=0)")
+$(READONLY)    field(EIVL, "$(EIVL=0)")
+$(READONLY)    field(NIVL, "$(NIVL=0)")
+$(READONLY)    field(TEVL, "$(TEVL=0)")
+$(READONLY)    field(ELVL, "$(ELVL=0)")
+$(READONLY)    field(TVVL, "$(TVVL=0)")
+$(READONLY)    field(TTVL, "$(TTVL=0)")
+$(READONLY)    field(FTVL, "$(FTVL=0)")
+$(READONLY)    field(FFVL, "$(FFVL=0)")
+
+$(READONLY)    field(ZRST, "$(ZRST='')")
+$(READONLY)    field(ONST, "$(ONST='')")
+$(READONLY)    field(TWST, "$(TWST='')")
+$(READONLY)    field(THST, "$(THST='')")
+$(READONLY)    field(FRST, "$(FRST='')")
+$(READONLY)    field(FVST, "$(FVST='')")
+$(READONLY)    field(SXST, "$(SXST='')")
+$(READONLY)    field(SVST, "$(SVST='')")
+$(READONLY)    field(EIST, "$(EIST='')")
+$(READONLY)    field(NIST, "$(NIST='')")
+$(READONLY)    field(TEST, "$(TEST='')")
+$(READONLY)    field(ELST, "$(ELST='')")
+$(READONLY)    field(TVST, "$(TVST='')")
+$(READONLY)    field(TTST, "$(TTST='')")
+$(READONLY)    field(FTST, "$(FTST='')")
+$(READONLY)    field(FFST, "$(FFST='')")
+
+$(READONLY)    field(SIML, "$(P)SIM")
+$(READONLY)    field(SIOL, "$(P)SIM:$(DEVICE):$(NAME) PP")
+$(READONLY)}
+
+record(bo, "$(P)SIM:$(DEVICE):$(NAME)") 
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+}
+
+$(READONLY)alias("$(P)SIM:$(DEVICE):$(NAME)","$(P)SIM:$(DEVICE):$(NAME):SP")
+
+

--- a/LVREMOTE/LVREMOTE-IOC-01App/Db/lvremote_string.template
+++ b/LVREMOTE/LVREMOTE-IOC-01App/Db/lvremote_string.template
@@ -1,0 +1,53 @@
+# Template file for remote labview services string values
+# Substitutions
+# DEVICE - The Device name
+# P - The PV prefix (This should usually be substituted for $(P))
+# NAME - The name of the pv
+# IND - The indicator of the value to read from labview
+# CONTROL - The control to write to, can be left out of substitution if readonly
+# VI - The path to the VI on the host computer as a string.
+# PORT - The Port to read (by default, L0 for Strings and L1 for Binary)
+# READONLY - Whether or not a value is readonly, should be "#" when true and "" when false.
+# DESCRIPTION - The description of the PV, will be appended to "Readback for " and "Setpoint for " 
+# SCAN - Scan rate for the readback
+
+
+record(stringin, "$(P)$(DEVICE):$(NAME)") {
+    field(DESC, "Readback for $(DESCRIPTION)")
+    field(DTYP, "stream")
+    field(INP,  "@lvremote_string.proto getString($(VI),$(IND)) $(PORT)")
+    field(SCAN, "$(SCAN)")
+
+    field(SIML, "$(P)SIM")
+    field(SIOL, "$(P)SIM:$(DEVICE):$(NAME) PP")
+}
+
+$(READONLY)record(stringout, "$(P)$(DEVICE):$(NAME):SP") {
+$(READONLY)    field(DESC, "Setpoint for $(DESCRIPTION)")
+$(READONLY)    field(DTYP, "stream")
+$(READONLY)    field(OUT,  "@lvremote_string.proto sendString($(VI),$(CONTROL="")) $(PORT)")
+$(READONLY)    field(SCAN, "Passive")
+
+$(READONLY)    field(SIML, "$(P)SIM")
+$(READONLY)    field(SIOL, "$(P)SIM:$(DEVICE):$(NAME):SP PP")
+$(READONLY)}
+
+$(READONLY)record(stringin, "$(P)$(DEVICE):$(NAME):SP:RBV") {
+$(READONLY)    field(DESC, "Setpoint Readback for $(DESCRIPTION)")
+$(READONLY)    field(DTYP, "stream")
+$(READONLY)    field(INP,  "@lvremote_string.proto getString($(VI),$(CONTROL="")) $(PORT)")
+$(READONLY)    field(SCAN, "$(SCAN)")
+
+$(READONLY)    field(SIML, "$(P)SIM")
+$(READONLY)    field(SIOL, "$(P)SIM:$(DEVICE):$(NAME) PP")
+$(READONLY)}
+
+record(bo, "$(P)SIM:$(DEVICE):$(NAME)") 
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+}
+
+$(READONLY)alias("$(P)SIM:$(DEVICE):$(NAME)","$(P)SIM:$(DEVICE):$(NAME):SP")
+
+

--- a/LVREMOTE/LVREMOTE-IOC-01App/Db/lvremotetest.substitutions
+++ b/LVREMOTE/LVREMOTE-IOC-01App/Db/lvremotetest.substitutions
@@ -9,5 +9,5 @@ file  lvremote_double.template {
   pattern 
     {DEVICE, P, NAME, IND, CONTROL, VI, PORT, READONLY, DESCRIPTION, SCAN}
     
-    {"TEST_VI", "\$(P)", "BUTTON", "Double Ind", "Double Control", "C:/Instrument/Dev/ibex_vis/VIsForTesting/Labview Remote Service Test VI.vi", "\$(NUM_PORT)", "", "Test Double", "1 second"}
+    {"TEST_VI", "\$(P)", "DOUBLE", "Double Ind", "Double Control", "C:/Instrument/Dev/ibex_vis/VIsForTesting/Labview Remote Service Test VI.vi", "\$(NUM_PORT)", "", "Test Double", "1 second"}
 }

--- a/LVREMOTE/LVREMOTE-IOC-01App/Db/lvremotetest.substitutions
+++ b/LVREMOTE/LVREMOTE-IOC-01App/Db/lvremotetest.substitutions
@@ -1,0 +1,13 @@
+file  lvremote_binary.template { 
+  pattern 
+    {DEVICE, P, NAME, IND, CONTROL, ZERO, ONE, VI, PORT, READONLY, DESCRIPTION, SCAN}
+    
+    {"TEST_VI", "\$(P)", "BUTTON", "Boolean Ind", "Button", "Off", "On", "C:/Instrument/Dev/ibex_vis/VIsForTesting/Labview Remote Service Test VI.vi", "\$(NUM_PORT)", "", "Test Boolean", "1 second"}
+}
+
+file  lvremote_double.template { 
+  pattern 
+    {DEVICE, P, NAME, IND, CONTROL, VI, PORT, READONLY, DESCRIPTION, SCAN}
+    
+    {"TEST_VI", "\$(P)", "BUTTON", "Double Ind", "Double Control", "C:/Instrument/Dev/ibex_vis/VIsForTesting/Labview Remote Service Test VI.vi", "\$(NUM_PORT)", "", "Test Double", "1 second"}
+}

--- a/LVREMOTE/LVREMOTE-IOC-01App/Db/lvremotetest.substitutions
+++ b/LVREMOTE/LVREMOTE-IOC-01App/Db/lvremotetest.substitutions
@@ -11,3 +11,17 @@ file  lvremote_double.template {
     
     {"TEST_VI", "\$(P)", "DOUBLE", "Double Ind", "Double Control", "C:/Instrument/Dev/ibex_vis/VIsForTesting/Labview Remote Service Test VI.vi", "\$(NUM_PORT)", "", "Test Double", "1 second"}
 }
+
+file  lvremote_enum.template { 
+  pattern 
+    {DEVICE, P, NAME, IND, CONTROL, VI, PORT, PORT2, READONLY, DESCRIPTION, SCAN, ZRST, ONST, TWST, THST, ZRVL, ONVL, TWVL, THVL}
+    
+    {"TEST_VI", "\$(P)", "ENUM", "Enum String", "Enum", "C:/Instrument/Dev/ibex_vis/VIsForTesting/Labview Remote Service Test VI.vi", "\$(NUM_PORT)", "\$(STRING_PORT)", "", "Test Enum", "1 second", "EnumVal1", "EnumVal2", "EnumVal3", "EnumVal4", "0", "1", "2", "3"}
+}
+
+file lvremote_string.template {
+  pattern
+  {DEVICE, P, NAME, IND, CONTROL, VI, PORT, READONLY, DESCRIPTION, SCAN}
+
+  {"TEST_VI", "\$(P)", "STRING", "String Ind","String Control", "C:/Instrument/Dev/ibex_vis/VIsForTesting/Labview Remote Service Test VI.vi", "\$(STRING_PORT)", "", "Test String", "1 second"}
+}

--- a/LVREMOTE/LVREMOTE-IOC-01App/Makefile
+++ b/LVREMOTE/LVREMOTE-IOC-01App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/LVREMOTE/LVREMOTE-IOC-01App/protocol/Makefile
+++ b/LVREMOTE/LVREMOTE-IOC-01App/protocol/Makefile
@@ -1,0 +1,16 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+DATA += lvremote_num.proto
+DATA += lvremote_string.proto
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_TEMPLATE = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/LVREMOTE/LVREMOTE-IOC-01App/protocol/lvremote_num.proto
+++ b/LVREMOTE/LVREMOTE-IOC-01App/protocol/lvremote_num.proto
@@ -1,0 +1,34 @@
+# changes '/' to '\' in paths to avoid excessive escape characters 
+path="%#/\//\\/";
+VARIABLES = "\$1" ${path} ",\$2";
+LVGET ="LVGET " ${VARIABLES} "%l";
+LVPUT ="LVPUT " ${VARIABLES};
+
+getDoubleVal {
+    out ${LVGET};
+    in "%l%8R";
+}
+setDoubleVal {
+    out ${LVPUT} ",%8R%l";
+    @init { getDoubleVal }
+}
+
+getBoolVal {
+    out ${LVGET};
+    in "%l%r"
+}
+setBoolVal {
+    out ${LVPUT} ",%r%l";
+    @init { getBoolVal }
+}
+
+getEnumVal {
+    out ${LVGET};
+    in "%l%2r";
+}
+
+setEnumVal {
+    out ${LVPUT} ",%2r%l";
+    @init { getEnumVal }
+}
+

--- a/LVREMOTE/LVREMOTE-IOC-01App/protocol/lvremote_string.proto
+++ b/LVREMOTE/LVREMOTE-IOC-01App/protocol/lvremote_string.proto
@@ -1,0 +1,12 @@
+Terminator = CR LF;
+path="%#/\//\\/";
+
+getString {
+    out "LVGET \${1}" ${path} ",\$2";
+    in "%#s";
+}
+sendString {
+    out "LVPUT \$1" ${path} ",\$2,%s";
+    @init { getString; }
+}
+

--- a/LVREMOTE/LVREMOTE-IOC-01App/src/LVREMOTE-IOC-01Main.cpp
+++ b/LVREMOTE/LVREMOTE-IOC-01App/src/LVREMOTE-IOC-01Main.cpp
@@ -1,0 +1,23 @@
+/* LVREMOTE-IOC-01Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/LVREMOTE/LVREMOTE-IOC-01App/src/Makefile
+++ b/LVREMOTE/LVREMOTE-IOC-01App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=LVREMOTE-IOC-01
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/LVREMOTE-IOC-01App/src/build.mak

--- a/LVREMOTE/LVREMOTE-IOC-01App/src/build.mak
+++ b/LVREMOTE/LVREMOTE-IOC-01App/src/build.mak
@@ -1,0 +1,76 @@
+TOP=../..
+
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+#=============================
+
+### NOTE: there should only be one build.mak for a given IOC family and this should be located in the ###-IOC-01 directory
+
+#=============================
+# Build the IOC application LVREMOTE-IOC-01
+# We actually use $(APPNAME) below so this file can be included by multiple IOCs
+
+PROD_IOC = $(APPNAME)
+# LVREMOTE-IOC-01.dbd will be created and installed
+DBD += $(APPNAME).dbd
+
+# LVREMOTE-IOC-01.dbd will be made up from these files:
+$(APPNAME)_DBD += base.dbd
+## ISIS standard dbd ##
+$(APPNAME)_DBD += icpconfig.dbd
+$(APPNAME)_DBD += pvdump.dbd
+$(APPNAME)_DBD += asSupport.dbd
+$(APPNAME)_DBD += devIocStats.dbd
+$(APPNAME)_DBD += caPutLog.dbd
+$(APPNAME)_DBD += utilities.dbd
+## Stream device support ##
+$(APPNAME)_DBD += calcSupport.dbd
+$(APPNAME)_DBD += asyn.dbd
+$(APPNAME)_DBD += drvAsynSerialPort.dbd
+$(APPNAME)_DBD += drvAsynIPPort.dbd
+$(APPNAME)_DBD += luaSupport.dbd
+$(APPNAME)_DBD += stream.dbd
+## add other dbd here ##
+#$(APPNAME)_DBD += xxx.dbd
+
+# Add all the support libraries needed by this IOC
+
+## Add additional libraries here ##
+#$(APPNAME)_LIBS += xxx
+
+## ISIS standard libraries ##
+## Stream device libraries ##
+$(APPNAME)_LIBS += stream
+$(APPNAME)_LIBS += lua
+$(APPNAME)_LIBS += asyn
+## other standard libraries here ##
+$(APPNAME)_LIBS += devIocStats 
+$(APPNAME)_LIBS += pvdump $(MYSQLLIB) easySQLite sqlite 
+$(APPNAME)_LIBS += caPutLog
+$(APPNAME)_LIBS += icpconfig
+$(APPNAME)_LIBS += autosave
+$(APPNAME)_LIBS += utilities pugixml libjson zlib
+$(APPNAME)_LIBS += calc sscan
+$(APPNAME)_LIBS += pcrecpp pcre
+$(APPNAME)_LIBS += seq pv
+
+# LVREMOTE-IOC-01_registerRecordDeviceDriver.cpp derives from LVREMOTE-IOC-01.dbd
+$(APPNAME)_SRCS += $(APPNAME)_registerRecordDeviceDriver.cpp
+
+# Build the main IOC entry point on workstation OSs.
+$(APPNAME)_SRCS_DEFAULT += $(APPNAME)Main.cpp
+$(APPNAME)_SRCS_vxWorks += -nil-
+
+# Add support from base/src/vxWorks if needed
+#$(APPNAME)_OBJS_vxWorks += $(EPICS_BASE_BIN)/vxComLibrary
+
+# Finally link to the EPICS Base libraries
+$(APPNAME)_LIBS += $(EPICS_BASE_IOC_LIBS)
+
+#===========================
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/LVREMOTE/LVREMOTE-IOC-02App/Db/Makefile
+++ b/LVREMOTE/LVREMOTE-IOC-02App/Db/Makefile
@@ -1,0 +1,18 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/LVREMOTE/LVREMOTE-IOC-02App/Makefile
+++ b/LVREMOTE/LVREMOTE-IOC-02App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/LVREMOTE/LVREMOTE-IOC-02App/src/LVREMOTE-IOC-02Main.cpp
+++ b/LVREMOTE/LVREMOTE-IOC-02App/src/LVREMOTE-IOC-02Main.cpp
@@ -1,0 +1,23 @@
+/* LVREMOTE-IOC-02Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/LVREMOTE/LVREMOTE-IOC-02App/src/Makefile
+++ b/LVREMOTE/LVREMOTE-IOC-02App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=LVREMOTE-IOC-02
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/LVREMOTE-IOC-01App/src/build.mak

--- a/LVREMOTE/Makefile
+++ b/LVREMOTE/Makefile
@@ -1,0 +1,31 @@
+# Makefile at top of application tree
+TOP = .
+include $(TOP)/configure/CONFIG
+
+# Directories to build, any order
+DIRS += configure
+DIRS += $(wildcard *Sup)
+DIRS += $(wildcard *App)
+DIRS += $(wildcard *Top)
+DIRS += $(wildcard iocBoot)
+
+# The build order is controlled by these dependency rules:
+
+# All dirs except configure depend on configure
+$(foreach dir, $(filter-out configure, $(DIRS)), \
+    $(eval $(dir)_DEPEND_DIRS += configure))
+
+# Any *App dirs depend on all *Sup dirs
+$(foreach dir, $(filter %App, $(DIRS)), \
+    $(eval $(dir)_DEPEND_DIRS += $(filter %Sup, $(DIRS))))
+
+# Any *Top dirs depend on all *Sup and *App dirs
+$(foreach dir, $(filter %Top, $(DIRS)), \
+    $(eval $(dir)_DEPEND_DIRS += $(filter %Sup %App, $(DIRS))))
+
+# iocBoot depends on all *App dirs
+iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
+
+# Add any additional dependency rules here:
+
+include $(TOP)/configure/RULES_TOP

--- a/LVREMOTE/configure/CONFIG
+++ b/LVREMOTE/configure/CONFIG
@@ -1,0 +1,29 @@
+# CONFIG - Load build configuration data
+#
+# Do not make changes to this file!
+
+# Allow user to override where the build rules come from
+RULES = $(EPICS_BASE)
+
+# RELEASE files point to other application tops
+include $(TOP)/configure/RELEASE
+-include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).Common
+ifdef T_A
+-include $(TOP)/configure/RELEASE.Common.$(T_A)
+-include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).$(T_A)
+endif
+
+CONFIG = $(RULES)/configure
+include $(CONFIG)/CONFIG
+
+# Override the Base definition:
+INSTALL_LOCATION = $(TOP)
+
+# CONFIG_SITE files contain other build configuration settings
+include $(TOP)/configure/CONFIG_SITE
+-include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+ifdef T_A
+ -include $(TOP)/configure/CONFIG_SITE.Common.$(T_A)
+ -include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+endif
+

--- a/LVREMOTE/configure/CONFIG_SITE
+++ b/LVREMOTE/configure/CONFIG_SITE
@@ -1,0 +1,43 @@
+# CONFIG_SITE
+
+# Make any application-specific changes to the EPICS build
+#   configuration variables in this file.
+#
+# Host/target specific settings can be specified in files named
+#   CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+#   CONFIG_SITE.Common.$(T_A)
+#   CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+
+# CHECK_RELEASE controls the consistency checking of the support
+#   applications pointed to by the RELEASE* files.
+# Normally CHECK_RELEASE should be set to YES.
+# Set CHECK_RELEASE to NO to disable checking completely.
+# Set CHECK_RELEASE to WARN to perform consistency checking but
+#   continue building even if conflicts are found.
+CHECK_RELEASE = YES
+
+# Set this when you only want to compile this application
+#   for a subset of the cross-compiled target architectures
+#   that Base is built for.
+#CROSS_COMPILER_TARGET_ARCHS = vxWorks-ppc32
+
+# To install files into a location other than $(TOP) define
+#   INSTALL_LOCATION here.
+#INSTALL_LOCATION=</absolute/path/to/install/top>
+
+# Set this when the IOC and build host use different paths
+#   to the install location. This may be needed to boot from
+#   a Microsoft FTP server say, or on some NFS configurations.
+#IOCS_APPL_TOP = </IOC's/absolute/path/to/install/top>
+
+# For application debugging purposes, override the HOST_OPT and/
+#   or CROSS_OPT settings from base/configure/CONFIG_SITE
+#HOST_OPT = NO
+#CROSS_OPT = NO
+
+# These allow developers to override the CONFIG_SITE variable
+# settings without having to modify the configure/CONFIG_SITE
+# file itself.
+-include $(TOP)/../CONFIG_SITE.local
+-include $(TOP)/configure/CONFIG_SITE.local
+

--- a/LVREMOTE/configure/Makefile
+++ b/LVREMOTE/configure/Makefile
@@ -1,0 +1,8 @@
+TOP=..
+
+include $(TOP)/configure/CONFIG
+
+TARGETS = $(CONFIG_TARGETS)
+CONFIGS += $(subst ../,,$(wildcard $(CONFIG_INSTALLS)))
+
+include $(TOP)/configure/RULES

--- a/LVREMOTE/configure/RELEASE
+++ b/LVREMOTE/configure/RELEASE
@@ -1,0 +1,74 @@
+# RELEASE - Location of external support modules
+#
+# IF YOU CHANGE ANY PATHS in this file or make API changes to
+# any modules it refers to, you should do a "make rebuild" in
+# this application's top level directory.
+#
+# The EPICS build process does not check dependencies against
+# any files from outside the application, so it is safest to
+# rebuild it completely if any modules it depends on change.
+#
+# Host- or target-specific settings can be given in files named
+#  RELEASE.$(EPICS_HOST_ARCH).Common
+#  RELEASE.Common.$(T_A)
+#  RELEASE.$(EPICS_HOST_ARCH).$(T_A)
+#
+# This file is parsed by both GNUmake and an EPICS Perl script,
+# so it may ONLY contain definititions of paths to other support
+# modules, variable definitions that are used in module paths,
+# and include statements that pull in other RELEASE files.
+# Variables may be used before their values have been set.
+# Build variables that are NOT used in paths should be set in
+# the CONFIG_SITE file.
+
+# Variables and paths to dependent modules:
+#MODULES = /path/to/modules
+#MYMODULE = $(MODULES)/my-module
+
+# If using the sequencer, point SNCSEQ at its top directory:
+#SNCSEQ = $(MODULES)/seq-ver
+
+# EPICS_BASE should appear last so earlier modules can override stuff:
+EPICS_BASE = C:/Instrument/Apps/EPICS/base/master
+
+# Set RULES here if you want to use build rules from somewhere
+# other than EPICS_BASE:
+#RULES = $(MODULES)/build-rules
+
+# These lines allow developers to override these RELEASE settings
+# without having to modify this file directly.
+-include $(TOP)/../RELEASE.local
+-include $(TOP)/../RELEASE.$(EPICS_HOST_ARCH).local
+-include $(TOP)/configure/RELEASE.local
+
+# Macros required for basic ioc/stream device
+ACCESSSECURITY=$(SUPPORT)/AccessSecurity/master
+ASUBFUNCTIONS=$(SUPPORT)/asubFunctions/master
+ASYN=$(SUPPORT)/asyn/master
+AUTOSAVE=$(SUPPORT)/autosave/master
+CALC=$(SUPPORT)/calc/master
+CAPUTLOG=$(SUPPORT)/caPutLog/master
+DEVIOCSTATS=$(SUPPORT)/devIocStats/master
+ICPCONFIG=$(SUPPORT)/icpconfig/master
+LIBJSON=$(SUPPORT)/libjson/master
+LUA=$(SUPPORT)/lua/master
+MYSQL=$(SUPPORT)/MySQL/master
+ONCRPC=$(SUPPORT)/oncrpc/master
+PCRE=$(SUPPORT)/pcre/master
+PUGIXML=$(SUPPORT)/pugixml/master
+PVDUMP=$(SUPPORT)/pvdump/master
+SNCSEQ=$(SUPPORT)/seq/master
+SQLITE=$(SUPPORT)/sqlite/master
+SSCAN=$(SUPPORT)/sscan/master
+STREAMDEVICE=$(SUPPORT)/StreamDevice/master
+UTILITIES=$(SUPPORT)/utilities/master
+ZLIB=$(SUPPORT)/zlib/master
+
+# optional extra local definitions here
+-include $(TOP)/configure/RELEASE.private
+
+include $(TOP)/../../../ISIS_CONFIG
+-include $(TOP)/../../../ISIS_CONFIG.$(EPICS_HOST_ARCH)
+
+# IOC-specific support module
+LVREMOTE=$(SUPPORT)/lvremote/master

--- a/LVREMOTE/configure/RELEASE
+++ b/LVREMOTE/configure/RELEASE
@@ -69,6 +69,3 @@ ZLIB=$(SUPPORT)/zlib/master
 
 include $(TOP)/../../../ISIS_CONFIG
 -include $(TOP)/../../../ISIS_CONFIG.$(EPICS_HOST_ARCH)
-
-# IOC-specific support module
-LVREMOTE=$(SUPPORT)/lvremote/master

--- a/LVREMOTE/configure/RULES
+++ b/LVREMOTE/configure/RULES
@@ -1,0 +1,6 @@
+# RULES
+
+include $(CONFIG)/RULES
+
+# Library should be rebuilt because LIBOBJS may have changed.
+$(LIBNAME): ../Makefile

--- a/LVREMOTE/configure/RULES.ioc
+++ b/LVREMOTE/configure/RULES.ioc
@@ -1,0 +1,2 @@
+#RULES.ioc
+include $(CONFIG)/RULES.ioc

--- a/LVREMOTE/configure/RULES_DIRS
+++ b/LVREMOTE/configure/RULES_DIRS
@@ -1,0 +1,2 @@
+#RULES_DIRS
+include $(CONFIG)/RULES_DIRS

--- a/LVREMOTE/configure/RULES_TOP
+++ b/LVREMOTE/configure/RULES_TOP
@@ -1,0 +1,3 @@
+#RULES_TOP
+include $(CONFIG)/RULES_TOP
+

--- a/LVREMOTE/iocBoot/Makefile
+++ b/LVREMOTE/iocBoot/Makefile
@@ -1,0 +1,6 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS += $(wildcard *ioc*)
+DIRS += $(wildcard as*)
+include $(CONFIG)/RULES_DIRS
+

--- a/LVREMOTE/iocBoot/iocLVREMOTE-IOC-01/Makefile
+++ b/LVREMOTE/iocBoot/iocLVREMOTE-IOC-01/Makefile
@@ -1,0 +1,6 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+#ARCH = windows-x64
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/LVREMOTE/iocBoot/iocLVREMOTE-IOC-01/config.xml
+++ b/LVREMOTE/iocBoot/iocLVREMOTE-IOC-01/config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<config_part>
+<ioc_desc>This is a template description</ioc_desc>
+<ioc_details>These are template details</ioc_details>
+<macros>
+<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM port" hasDefault="NO" />
+</macros>
+<pvsets>
+</pvsets>
+</config_part>
+</ioc_config>

--- a/LVREMOTE/iocBoot/iocLVREMOTE-IOC-01/config.xml
+++ b/LVREMOTE/iocBoot/iocLVREMOTE-IOC-01/config.xml
@@ -4,7 +4,8 @@
 <ioc_desc>This is a template description</ioc_desc>
 <ioc_details>These are template details</ioc_details>
 <macros>
-<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM port" hasDefault="NO" />
+<macro name="IPADDR" pattern="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$" description="IP Address of machine running VI" hasDefault="NO" />
+<macro name="DEVCMD1" pattern="^[A-Za-z0-9]+$" description="CMD file base name in devices subdirectory to load" defaultValue="missing" hasDefault="YES" />
 </macros>
 <pvsets>
 </pvsets>

--- a/LVREMOTE/iocBoot/iocLVREMOTE-IOC-01/devices/lvremotetest.cmd
+++ b/LVREMOTE/iocBoot/iocLVREMOTE-IOC-01/devices/lvremotetest.cmd
@@ -1,0 +1,16 @@
+
+
+## create STRING_PORT (Required for String and Enum template)
+drvAsynIPPortConfigure("$(STRING_PORT)", "$(IPADDR):64008 TCP")
+asynOctetConnect("STRINGINIT","$(STRING_PORT)")
+asynOctetWrite("STRINGINIT" "*IDN? ")
+
+## create NUM_PORT (Requred for binary, enum and double template)
+drvAsynIPPortConfigure("$(NUM_PORT)", "$(IPADDR):64009 TCP")
+asynOctetConnect("NUMINIT","$(NUM_PORT)")
+asynOctetWrite("NUMINIT" "*IDN? ")
+# Wait for labview to initalise
+epicsThreadSleep(5)
+
+## Load our record instances
+dbLoadRecords("$(TOP)/db/lvremotetest.db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX)$(IOCNAME):,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),STRING_PORT=$(STRING_PORT),NUM_PORT=$(NUM_PORT)")

--- a/LVREMOTE/iocBoot/iocLVREMOTE-IOC-01/devices/missing.cmd
+++ b/LVREMOTE/iocBoot/iocLVREMOTE-IOC-01/devices/missing.cmd
@@ -1,0 +1,3 @@
+##
+msgBox("ERROR: $(IOCNAME) - no device is defined", "See https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Labview-Remote")
+##

--- a/LVREMOTE/iocBoot/iocLVREMOTE-IOC-01/st-common.cmd
+++ b/LVREMOTE/iocBoot/iocLVREMOTE-IOC-01/st-common.cmd
@@ -5,34 +5,18 @@ epicsEnvSet "NUM_PORT" "L1"
 ##ISIS## Run IOC initialisation 
 < $(IOCSTARTUP)/init.cmd
 
-
-## For STRING_PORT:
-drvAsynIPPortConfigure("$(STRING_PORT)", "LOCALHOST:64008 TCP")
-asynOctetConnect("STRINGINIT","$(STRING_PORT)")
-asynOctetWrite("STRINGINIT" "*IDN? ")
-## For NUM_PORT:
-drvAsynIPPortConfigure("$(NUM_PORT)", "LOCALHOST:64009 TCP")
-asynOctetConnect("NUMINIT","$(NUM_PORT)")
-asynOctetWrite("NUMINIT" "*IDN? ")
-# Wait for labview to initalise
-epicsThreadSleep(5)
-## Load record instances
-asynSetTraceIOMask("L1", -1, 0x2)
-asynSetTraceMask("L1", -1, 0x9)
-asynSetTraceIOTruncateSize("L1", -1, 1024)
+cd "${TOP}/iocBoot/${IOC}"
 ##ISIS## Load common DB records 
 < $(IOCSTARTUP)/dbload.cmd
 
+## Startup for specific devices: DB files, Ports etc.
+< devices/$(DEVCMD1=missing).cmd
 
-## Load our record instances
-dbLoadRecords("$(TOP)/db/lvremotetest.db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX)$(IOCNAME):,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),STRING_PORT=$(STRING_PORT),NUM_PORT=$(NUM_PORT)")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd
 
-cd "${TOP}/iocBoot/${IOC}"
 iocInit
-
 
 ##ISIS## Stuff that needs to be done after iocInit is called e.g. sequence programs 
 < $(IOCSTARTUP)/postiocinit.cmd

--- a/LVREMOTE/iocBoot/iocLVREMOTE-IOC-01/st-common.cmd
+++ b/LVREMOTE/iocBoot/iocLVREMOTE-IOC-01/st-common.cmd
@@ -1,0 +1,39 @@
+epicsEnvSet "STREAM_PROTOCOL_PATH" "$(LVREMOTE)/data"
+epicsEnvSet "STRING_PORT" "L0"
+epicsEnvSet "NUM_PORT" "L1"
+
+##ISIS## Run IOC initialisation 
+< $(IOCSTARTUP)/init.cmd
+
+
+## For STRING_PORT:
+drvAsynIPPortConfigure("$(STRING_PORT)", "LOCALHOST:64008 TCP")
+asynOctetConnect("STRINGINIT","$(STRING_PORT)")
+asynOctetWrite("STRINGINIT" "*IDN? ")
+## For NUM_PORT:
+drvAsynIPPortConfigure("$(NUM_PORT)", "LOCALHOST:64009 TCP")
+asynOctetConnect("NUMINIT","$(NUM_PORT)")
+asynOctetWrite("NUMINIT" "*IDN? ")
+# Wait for labview to initalise
+epicsThreadSleep(5)
+## Load record instances
+asynSetTraceIOMask("L1", -1, 0x2)
+asynSetTraceMask("L1", -1, 0x9)
+asynSetTraceIOTruncateSize("L1", -1, 1024)
+##ISIS## Load common DB records 
+< $(IOCSTARTUP)/dbload.cmd
+
+
+## Load our record instances
+dbLoadRecords("$(TOP)/db/lvremotetest.db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX)$(IOCNAME):,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),STRING_PORT=$(STRING_PORT),NUM_PORT=$(NUM_PORT)")
+
+##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
+< $(IOCSTARTUP)/preiocinit.cmd
+
+cd "${TOP}/iocBoot/${IOC}"
+iocInit
+
+
+##ISIS## Stuff that needs to be done after iocInit is called e.g. sequence programs 
+< $(IOCSTARTUP)/postiocinit.cmd
+

--- a/LVREMOTE/iocBoot/iocLVREMOTE-IOC-01/st-common.cmd
+++ b/LVREMOTE/iocBoot/iocLVREMOTE-IOC-01/st-common.cmd
@@ -1,4 +1,4 @@
-epicsEnvSet "STREAM_PROTOCOL_PATH" "$(LVREMOTE)/data"
+epicsEnvSet "STREAM_PROTOCOL_PATH" "$(TOP)/data"
 epicsEnvSet "STRING_PORT" "L0"
 epicsEnvSet "NUM_PORT" "L1"
 

--- a/LVREMOTE/iocBoot/iocLVREMOTE-IOC-01/st.cmd
+++ b/LVREMOTE/iocBoot/iocLVREMOTE-IOC-01/st.cmd
@@ -1,0 +1,18 @@
+#!../../bin/windows-x64/LVREMOTE-IOC-01
+
+## You may have to change LVREMOTE-IOC-01 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+cd "${TOP}"
+
+## Register all support components
+dbLoadDatabase "dbd/LVREMOTE-IOC-01.dbd"
+LVREMOTE_IOC_01_registerRecordDeviceDriver pdbbase
+
+## calling common command file in ioc 01 boot dir
+< ${TOP}/iocBoot/iocLVREMOTE-IOC-01/st-common.cmd

--- a/LVREMOTE/iocBoot/iocLVREMOTE-IOC-02/Makefile
+++ b/LVREMOTE/iocBoot/iocLVREMOTE-IOC-02/Makefile
@@ -1,0 +1,6 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+#ARCH = windows-x64
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/LVREMOTE/iocBoot/iocLVREMOTE-IOC-02/config.xml
+++ b/LVREMOTE/iocBoot/iocLVREMOTE-IOC-02/config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+    <xi:include href="../iocLVREMOTE-IOC-01/config.xml"  />
+</ioc_config>

--- a/LVREMOTE/iocBoot/iocLVREMOTE-IOC-02/st.cmd
+++ b/LVREMOTE/iocBoot/iocLVREMOTE-IOC-02/st.cmd
@@ -1,0 +1,18 @@
+#!../../bin/windows-x64/LVREMOTE-IOC-02
+
+## You may have to change LVREMOTE-IOC-02 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+cd "${TOP}"
+
+## Register all support components
+dbLoadDatabase "dbd/LVREMOTE-IOC-02.dbd"
+LVREMOTE_IOC_02_registerRecordDeviceDriver pdbbase
+
+## calling common command file in ioc 01 boot dir
+< ${TOP}/iocBoot/iocLVREMOTE-IOC-01/st-common.cmd

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ IOCDIRS += ANDOR ANDOR3
 IOCDIRS += GENICAM
 IOCDIRS += PS300
 IOCDIRS += HE3NMR
+IOCDIRS += LVREMOTE
 
 ## check on missing directories
 IOCMAKES = $(wildcard */Makefile)


### PR DESCRIPTION
### Description of work
Created templates for use with Labview remote.
Created a test ioc for use with the test VI.

### To test
https://github.com/ISISComputingGroup/IBEX/issues/8264

### Acceptance criteria
_requires the labview test vi's_
Start the Test VI and _then_ start the IOC, check that all the VI's controls can be written to from the IOC and that all indicators are being read correctly (Except for the array, which is not currently needed).

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
