### PR TITLE
Add check_read record to periodically check RBV record, make read_restart a calcout to not proc READ record if RBV is in alarm

### DIFF
--- a/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
+++ b/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
@@ -402,9 +402,12 @@ record(seq, "$(P)READ") {
     field(SELM, "All")
 }
 
-record(seq, "$(P)READ_RESTART"){
+record(calcout, "$(P)READ_RESTART"){
+    field(INPA, $(P)RBV MS)
     field(SCAN, "1 second")
-    field(LNK1, "$(P)READ.PROC")
+    field(CALC "A")
+    field(IVOA, "Don't drive outputs")
+    field(OUT, "$(P)READ.PROC")
 }
 
 record(seq, "$(P)READ_FAST") {
@@ -472,6 +475,11 @@ record(seq, "$(P)READ_SLOW4") {
 	$(IFNEEDLE_VALVE) field(LNK7, "$(P)FLOW_SP_MODE_SELECT.PROC")
 	$(IFNEEDLE_VALVE) field(LNK8, "$(P)VALVE_DIR.PROC")
 	$(IFNEEDLE_VALVE) field(LNK9, "$(P)NEEDLE_VALVE_STOP.PROC")
+}
+
+record(ai, "$(P)CHECK_READ") {
+    field(FLNK, "$(P)RBV")
+    field(SCAN, "10 second")
 }
 
 ####


### PR DESCRIPTION
### Description of work

Adding a record called check_read, which forward links to the RBV record every 10 seconds, in order to periodically scan if that record is disconnected. READ_RESTART record has also been changed to inherit the alarm severity of RBV record, so if it is disconnected, READ_RESTART will go into alarm, instead of continually trying to proc the READ record, thus causing communication block for other potential eurotherm IOCs wanting to connect. The IVOA field is meant to stop record outputs of a calcout, so that it won't process the READ record.

### To test

- https://github.com/ISISComputingGroup/IBEX/issues/8310

### Acceptance criteria

*List the acceptance criteria for the PR*

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
