### PR TITLE
Corrected macro name in DAQMX startup file, changed default CJC source

### DIFF
--- a/PRLTHERM/iocBoot/iocPRLTHERM-IOC-01/config.xml
+++ b/PRLTHERM/iocBoot/iocPRLTHERM-IOC-01/config.xml
@@ -10,7 +10,7 @@
             <macro name="TC_TYPE"       pattern="^(J_Type_TC|K_Type_TC|N_Type_TC|R_Type_TC|S_Type_TC|T_Type_TC|B_Type_TC|E_Type_TC)?$" description="Thermocouple type (Default: K Type)"         defaultValue="K_Type_TC"   hasDefault="YES" />
             <macro name="MIN_TEMP"      pattern="^-?[0-9]+\.?[0-9]*$"                                                                  description="Minimum TC temperature (Default for K Type)" defaultValue="73.15"       hasDefault="YES" />
             <macro name="MAX_TEMP"      pattern="^-?[0-9]+\.?[0-9]*$"                                                                  description="Maximum TC temperature (Default for K Type)" defaultValue="1645.15"     hasDefault="YES" />
-            <macro name="CJC_SOURCE"    pattern="^(BuiltIn|ConstVal|Chan)?$"                                                           description="CJC Source"                                  defaultValue="ConstVal"    hasDefault="YES" />
+            <macro name="CJC_SOURCE"    pattern="^(BuiltIn|ConstVal|Chan)?$"                                                           description="CJC Source"                                  defaultValue="BuiltIn"     hasDefault="YES" />
             <macro name="CJC_VAL"       pattern="^-?[0-9]+\.?[0-9]*$"                                                                  description="CJC Constant Value"                          defaultValue="25.0"        hasDefault="YES" />
             <macro name="CJC_CHANNEL"   pattern="^[0-9]+$"                                                                             description="CJC Channel (if CJC Source is 'Chan')"                                  hasDefault="NO" />
         </macros>

--- a/PRLTHERM/iocBoot/iocPRLTHERM-IOC-01/st-daq.cmd
+++ b/PRLTHERM/iocBoot/iocPRLTHERM-IOC-01/st-daq.cmd
@@ -12,7 +12,7 @@ epicsEnvSet("CDAQ","$(HOST=localhost)Mod1") # cDAQ chassis address (appended 'Mo
 # By default, all channels configured for units of Kelvin and K-Type thermocouples (values from VI: m=73.15 M=1645.15)
 # Number of samples (N)=2; Sampling Frequency (F)=1; Minumum Value (m)=73.15; Maximum Value (M)=1645.15
 
-epicsEnvSet("DAQMX_OPTIONS", "N=2 F=1 m=$(MIN_TEMP=73.15) M=$(MAX_TEMP=1645.15) U=$(UNITS=Kelvins) thermocoupleType=$(TC_TYPE=K_Type_TC) cjcSource=$(CJC_SOURCE=ConstVal) cjcVal=$(CJC_VAL=25.0) cjcChannel=$(CJC_CHANNEL=0) AIADCTimingMode=HighResolution AIAutoZeroMode=Once")
+epicsEnvSet("DAQMX_OPTIONS", "N=2 F=1 m=$(MIN_TEMP=73.15) M=$(MAX_TEMP=1645.15) U=$(UNITS_DAQMX=Kelvins) thermocoupleType=$(TC_TYPE=K_Type_TC) cjcSource=$(CJC_SOURCE=ConstVal) cjcVal=$(CJC_VAL=25.0) cjcChannel=$(CJC_CHANNEL=0) AIADCTimingMode=HighResolution AIAutoZeroMode=Once")
 
 $(IFNOTRECSIM) DAQmxConfig("$(DEVICE)", "$(CDAQ)/ai0",   0, "AITC", "$(DAQMX_OPTIONS)")      # Channel  0
 $(IFNOTRECSIM) DAQmxConfig("$(DEVICE)", "$(CDAQ)/ai1",   1, "AITC", "$(DAQMX_OPTIONS)")      # Channel  1


### PR DESCRIPTION
### Description of work

Missed error in DAQMx units macro name during testing and review.

Also changed default CJC (Cold Junction Compensation) value to match original VI.

### To test

Check units can be selected by changing IOC macro value.

Check values returned are plausible.

### Acceptance criteria

Units selectable and returned values reflect change (and reality)

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
