### PR TITLE
Added alarm field & default emulator port

### DIFF
--- a/DFKPS/DFKPS-IOC-01App/Db/DFKPS_common.db
+++ b/DFKPS/DFKPS-IOC-01App/Db/DFKPS_common.db
@@ -191,6 +191,7 @@ record(calcout, "$(P)CURR")
     info(INTEREST, "HIGH")
     info(archive, "VAL")
     info(autosaveFields, "HIGH LOW")
+    info(alarm, "DFKPS")
 }
 alias("$(P)CURR", "$(P)CURR:RBV")
 

--- a/DFKPS/iocBoot/iocDFKPS-IOC-01/st-common.cmd
+++ b/DFKPS/iocBoot/iocDFKPS-IOC-01/st-common.cmd
@@ -16,7 +16,7 @@ $(IFLOCALCALIB) epicsEnvSet "CALIB_DIR" "calib/magnets"
 epicsEnvSet "STREAM_PROTOCOL_PATH" "$(DANFYSIK8000)/master/danfysikMps8000App/protocol/;$(DANFYSIK8000)/master/danfysikMps8000App/protocol/DFK$(PROTO_OVERRIDE=$(DEV_TYPE=8000))/"
 
 ## use with emulator
-$(IFDEVSIM) drvAsynIPPortConfigure("L0", "localhost:$(EMULATOR_PORT)")
+$(IFDEVSIM) drvAsynIPPortConfigure("L0", "localhost:$(EMULATOR_PORT=57677)")
 
 ## use with real device
 


### PR DESCRIPTION
### Description of work

- Added the alarm field to Danfysik current PV so now shows up in alarm perspective.
- There was no default emulator port in Danfysik IOC startup file, added this.

### To test

[#8342](https://github.com/ISISComputingGroup/IBEX/issues/8342)

- Add and run Danfysik IOC in devsim mode and check that the Current PV e.g `*:DFKPS_01:CURR` gets added to the alarm tree.
- Run Danfysik emulator without supplying an emulator port and check that it successfully connects.

### Acceptance criteria

See ticket info

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
