### PR TITLE
Add default value of cards0 in caenv895

### DIFF
--- a/CAENV895/iocBoot/iocCAENV895-IOC-01/config.xml
+++ b/CAENV895/iocBoot/iocCAENV895-IOC-01/config.xml
@@ -4,7 +4,7 @@
 <ioc_desc>CAEN V895 Discriminator</ioc_desc>
 <ioc_details>CAEN V895 Discriminator IOC</ioc_details>
 <macros>
-<macro name="CARDS0" pattern="^[0-9]+$" description="Number of cards in crate 0, leave blank if this crate does not exist" hasDefault="YES" defaultValue="" />
+<macro name="CARDS0" pattern="^[0-9]+$" description="Number of cards in crate 0, leave blank if this crate does not exist" hasDefault="YES" defaultValue="6" />
 <macro name="CARDS1" pattern="^[0-9]+$" description="Number of cards in crate 1, leave blank if this crate does not exist" hasDefault="YES" defaultValue="" />
 <macro name="CARDS2" pattern="^[0-9]+$" description="Number of cards in crate 2, leave blank if this crate does not exist" hasDefault="YES" defaultValue="" />
 <macro name="MY_BOARD_NUMBER_0" pattern="^0x[0-9]+$" description="Local crate index, crate 0" hasDefault="YES" defaultValue="0x1" />

--- a/CAENV895/iocBoot/iocCAENV895-IOC-01/st-common.cmd
+++ b/CAENV895/iocBoot/iocCAENV895-IOC-01/st-common.cmd
@@ -11,7 +11,7 @@
 $(IFDEVSIM) CAENVMEConfigure("CRATE0", 0, 0, 0, 0x10000, 1)
 $(IFRECSIM) CAENVMEConfigure("CRATE0", 0, 0, 0, 0x10000, 1)
 
-stringiftest("CRATE0", "$(CARDS0=)")
+stringiftest("CRATE0", "$(CARDS0=6)")
 stringiftest("CRATE1", "$(CARDS1=)")
 stringiftest("CRATE2", "$(CARDS2=)")
 
@@ -29,7 +29,7 @@ set_pass1_restoreFile("auto_settings.sav")
 
 
 $(IFCRATE0) dbLoadRecords("$(CAENVME)/db/v895Crate.db","P=$(MYPVPREFIX),Q=$(IOCNAME):,CRATE=0,PORT=CRATE0,CARDS=$(CARDS0)")
-$(IFCRATE0) dbLoadRecordsLoop("$(CAENVME)/db/v895Card.db","P=$(MYPVPREFIX),Q=$(IOCNAME):,CRATE=0,PORT=CRATE0,C=\$(CARD)", "CARD", 0, $(CARDS0))
+$(IFCRATE0) dbLoadRecordsLoop("$(CAENVME)/db/v895Card.db","P=$(MYPVPREFIX),Q=$(IOCNAME):,CRATE=0,PORT=CRATE0,C=\$(CARD)", "CARD", 0, $(CARDS0=6))
 
 $(IFCRATE1) dbLoadRecords("$(CAENVME)/db/v895Crate.db","P=$(MYPVPREFIX),Q=$(IOCNAME):,CRATE=1,PORT=CRATE1,CARDS=$(CARDS1)")
 $(IFCRATE1) dbLoadRecordsLoop("$(CAENVME)/db/v895Card.db","P=$(MYPVPREFIX),Q=$(IOCNAME):,CRATE=1,PORT=CRATE1,C=\$(CARD)", "CARD", 0, $(CARDS1))


### PR DESCRIPTION
### Description of work

Restores the default value of 6 cards in crate 1 for all existing instances of the CAENV895.

#### Code Review

- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
