### PR TITLE
 add 4 more lindy IOCs

### DIFF
--- a/LNDYISW/LNDYISW-IOC-03App/Db/Makefile
+++ b/LNDYISW/LNDYISW-IOC-03App/Db/Makefile
@@ -1,0 +1,18 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/LNDYISW/LNDYISW-IOC-03App/Makefile
+++ b/LNDYISW/LNDYISW-IOC-03App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/LNDYISW/LNDYISW-IOC-03App/src/LNDYISW-IOC-03Main.cpp
+++ b/LNDYISW/LNDYISW-IOC-03App/src/LNDYISW-IOC-03Main.cpp
@@ -1,0 +1,23 @@
+/* LNDYISW-IOC-03Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/LNDYISW/LNDYISW-IOC-03App/src/Makefile
+++ b/LNDYISW/LNDYISW-IOC-03App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=LNDYISW-IOC-03
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/LNDYISW-IOC-01App/src/build.mak

--- a/LNDYISW/LNDYISW-IOC-04App/Db/Makefile
+++ b/LNDYISW/LNDYISW-IOC-04App/Db/Makefile
@@ -1,0 +1,18 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/LNDYISW/LNDYISW-IOC-04App/Makefile
+++ b/LNDYISW/LNDYISW-IOC-04App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/LNDYISW/LNDYISW-IOC-04App/src/LNDYISW-IOC-04Main.cpp
+++ b/LNDYISW/LNDYISW-IOC-04App/src/LNDYISW-IOC-04Main.cpp
@@ -1,0 +1,23 @@
+/* LNDYISW-IOC-04Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/LNDYISW/LNDYISW-IOC-04App/src/Makefile
+++ b/LNDYISW/LNDYISW-IOC-04App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=LNDYISW-IOC-04
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/LNDYISW-IOC-01App/src/build.mak

--- a/LNDYISW/LNDYISW-IOC-05App/Db/Makefile
+++ b/LNDYISW/LNDYISW-IOC-05App/Db/Makefile
@@ -1,0 +1,18 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/LNDYISW/LNDYISW-IOC-05App/Makefile
+++ b/LNDYISW/LNDYISW-IOC-05App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/LNDYISW/LNDYISW-IOC-05App/src/LNDYISW-IOC-05Main.cpp
+++ b/LNDYISW/LNDYISW-IOC-05App/src/LNDYISW-IOC-05Main.cpp
@@ -1,0 +1,23 @@
+/* LNDYISW-IOC-05Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/LNDYISW/LNDYISW-IOC-05App/src/Makefile
+++ b/LNDYISW/LNDYISW-IOC-05App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=LNDYISW-IOC-05
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/LNDYISW-IOC-01App/src/build.mak

--- a/LNDYISW/LNDYISW-IOC-06App/Db/Makefile
+++ b/LNDYISW/LNDYISW-IOC-06App/Db/Makefile
@@ -1,0 +1,18 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/LNDYISW/LNDYISW-IOC-06App/Makefile
+++ b/LNDYISW/LNDYISW-IOC-06App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/LNDYISW/LNDYISW-IOC-06App/src/LNDYISW-IOC-06Main.cpp
+++ b/LNDYISW/LNDYISW-IOC-06App/src/LNDYISW-IOC-06Main.cpp
@@ -1,0 +1,23 @@
+/* LNDYISW-IOC-06Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/LNDYISW/LNDYISW-IOC-06App/src/Makefile
+++ b/LNDYISW/LNDYISW-IOC-06App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=LNDYISW-IOC-06
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/LNDYISW-IOC-01App/src/build.mak

--- a/LNDYISW/iocBoot/iocLNDYISW-IOC-03/Makefile
+++ b/LNDYISW/iocBoot/iocLNDYISW-IOC-03/Makefile
@@ -1,0 +1,6 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+#ARCH = windows-x64
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/LNDYISW/iocBoot/iocLNDYISW-IOC-03/config.xml
+++ b/LNDYISW/iocBoot/iocLNDYISW-IOC-03/config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+    <xi:include href="../iocLNDYISW-IOC-01/config.xml"  />
+</ioc_config>

--- a/LNDYISW/iocBoot/iocLNDYISW-IOC-03/st.cmd
+++ b/LNDYISW/iocBoot/iocLNDYISW-IOC-03/st.cmd
@@ -1,0 +1,18 @@
+#!../../bin/windows-x64/LNDYISW-IOC-03
+
+## You may have to change LNDYISW-IOC-03 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+cd "${TOP}"
+
+## Register all support components
+dbLoadDatabase "dbd/LNDYISW-IOC-03.dbd"
+LNDYISW_IOC_03_registerRecordDeviceDriver pdbbase
+
+## calling common command file in ioc 01 boot dir
+< ${TOP}/iocBoot/iocLNDYISW-IOC-01/st-common.cmd

--- a/LNDYISW/iocBoot/iocLNDYISW-IOC-04/Makefile
+++ b/LNDYISW/iocBoot/iocLNDYISW-IOC-04/Makefile
@@ -1,0 +1,6 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+#ARCH = windows-x64
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/LNDYISW/iocBoot/iocLNDYISW-IOC-04/config.xml
+++ b/LNDYISW/iocBoot/iocLNDYISW-IOC-04/config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+    <xi:include href="../iocLNDYISW-IOC-01/config.xml"  />
+</ioc_config>

--- a/LNDYISW/iocBoot/iocLNDYISW-IOC-04/st.cmd
+++ b/LNDYISW/iocBoot/iocLNDYISW-IOC-04/st.cmd
@@ -1,0 +1,18 @@
+#!../../bin/windows-x64/LNDYISW-IOC-04
+
+## You may have to change LNDYISW-IOC-04 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+cd "${TOP}"
+
+## Register all support components
+dbLoadDatabase "dbd/LNDYISW-IOC-04.dbd"
+LNDYISW_IOC_04_registerRecordDeviceDriver pdbbase
+
+## calling common command file in ioc 01 boot dir
+< ${TOP}/iocBoot/iocLNDYISW-IOC-01/st-common.cmd

--- a/LNDYISW/iocBoot/iocLNDYISW-IOC-05/Makefile
+++ b/LNDYISW/iocBoot/iocLNDYISW-IOC-05/Makefile
@@ -1,0 +1,6 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+#ARCH = windows-x64
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/LNDYISW/iocBoot/iocLNDYISW-IOC-05/config.xml
+++ b/LNDYISW/iocBoot/iocLNDYISW-IOC-05/config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+    <xi:include href="../iocLNDYISW-IOC-01/config.xml"  />
+</ioc_config>

--- a/LNDYISW/iocBoot/iocLNDYISW-IOC-05/st.cmd
+++ b/LNDYISW/iocBoot/iocLNDYISW-IOC-05/st.cmd
@@ -1,0 +1,18 @@
+#!../../bin/windows-x64/LNDYISW-IOC-05
+
+## You may have to change LNDYISW-IOC-05 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+cd "${TOP}"
+
+## Register all support components
+dbLoadDatabase "dbd/LNDYISW-IOC-05.dbd"
+LNDYISW_IOC_05_registerRecordDeviceDriver pdbbase
+
+## calling common command file in ioc 01 boot dir
+< ${TOP}/iocBoot/iocLNDYISW-IOC-01/st-common.cmd

--- a/LNDYISW/iocBoot/iocLNDYISW-IOC-06/Makefile
+++ b/LNDYISW/iocBoot/iocLNDYISW-IOC-06/Makefile
@@ -1,0 +1,6 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+#ARCH = windows-x64
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/LNDYISW/iocBoot/iocLNDYISW-IOC-06/config.xml
+++ b/LNDYISW/iocBoot/iocLNDYISW-IOC-06/config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+    <xi:include href="../iocLNDYISW-IOC-01/config.xml"  />
+</ioc_config>

--- a/LNDYISW/iocBoot/iocLNDYISW-IOC-06/st.cmd
+++ b/LNDYISW/iocBoot/iocLNDYISW-IOC-06/st.cmd
@@ -1,0 +1,18 @@
+#!../../bin/windows-x64/LNDYISW-IOC-06
+
+## You may have to change LNDYISW-IOC-06 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+cd "${TOP}"
+
+## Register all support components
+dbLoadDatabase "dbd/LNDYISW-IOC-06.dbd"
+LNDYISW_IOC_06_registerRecordDeviceDriver pdbbase
+
+## calling common command file in ioc 01 boot dir
+< ${TOP}/iocBoot/iocLNDYISW-IOC-01/st-common.cmd


### PR DESCRIPTION
### Description of work

Adds 4 more LNDYISW IOCs. 

### To test

https://github.com/ISISComputingGroup/IBEX/issues/8516

To review, `make` in ioc\master\lndyisw and then go to support\lndyisw\master\system_tests\, change the DEVICE_PREFIX to 3, add iocnum=3 in the call to get_default_ioc_dir() and check all tests pass. 

### Acceptance criteria

*List the acceptance criteria for the PR*

---

#### Code Review

- [x] A copy of the manual has been placed on the shared drive
- [x] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [x] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [x] Devsim mode
    - [x] Recsim mode
    - [ ] Real device, if available
- [x] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [x] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
