### PR TITLE
Remove use of MASTER_RELEASE

### DIFF
--- a/INSTETC/configure/RELEASE
+++ b/INSTETC/configure/RELEASE
@@ -1,8 +1,26 @@
-# top level master release and local private options 
-include $(TOP)/../../../configure/MASTER_RELEASE
--include $(TOP)/../../../configure/MASTER_RELEASE.$(EPICS_HOST_ARCH)
--include $(TOP)/../../../configure/MASTER_RELEASE.private
--include $(TOP)/../../../configure/MASTER_RELEASE.private.$(EPICS_HOST_ARCH)
+TEMPLATE_TOP=$(EPICS_BASE)/templates/makeBaseApp/top
+
+ACCESSSECURITY=$(SUPPORT)/AccessSecurity/master
+ASUBFUNCTIONS=$(SUPPORT)/asubFunctions/master
+ASYN=$(SUPPORT)/asyn/master
+AUTOSAVE=$(SUPPORT)/autosave/master
+BUSY=$(SUPPORT)/busy/master
+ONCRPC=$(SUPPORT)/oncrpc/master
+ICPCONFIG=$(SUPPORT)/icpconfig/master
+PVDUMP=$(SUPPORT)/pvdump/master
+UTILITIES=$(SUPPORT)/utilities/master
+PROCSERVCONTROL=$(SUPPORT)/procServControl/master
+CAPUTLOG=$(SUPPORT)/caPutLog/master
+DEVIOCSTATS=$(SUPPORT)/devIocStats/master
+MYSQL=$(SUPPORT)/MySQL/master
+PCRE=$(SUPPORT)/pcre/master
+PUGIXML=$(SUPPORT)/pugixml/master
+SNCSEQ=$(SUPPORT)/seq/master
+SQLITE=$(SUPPORT)/sqlite/master
+ZLIB=$(SUPPORT)/zlib/master
+OPENSSL=$(SUPPORT)/OpenSSL/master
+CALC=$(SUPPORT)/calc/master
+SSCAN=$(SUPPORT)/sscan/master
 
 # optional extra local definitions here
 -include $(TOP)/configure/RELEASE.private

--- a/PSCTRL/PSCTRL-IOC-01App/src/build.mak
+++ b/PSCTRL/PSCTRL-IOC-01App/src/build.mak
@@ -27,8 +27,8 @@ $(APPNAME)_DBD += caPutLog.dbd
 $(APPNAME)_DBD += asyn.dbd
 $(APPNAME)_DBD += drvAsynIPPort.dbd
 $(APPNAME)_DBD += busySupport.dbd
-$(APPNAME)_DBD += utilities.dbd
 $(APPNAME)_DBD += procServControl.dbd
+$(APPNAME)_DBD += utilities.dbd
 $(APPNAME)_DBD += asubFunctions.dbd 
 
 # Add all the support libraries needed by this IOC
@@ -41,7 +41,8 @@ $(APPNAME)_LIBS += pvdump $(MYSQLLIB) easySQLite sqlite
 $(APPNAME)_LIBS += caPutLog
 $(APPNAME)_LIBS += icpconfig pugixml
 $(APPNAME)_LIBS += autosave
-$(APPNAME)_LIBS += utilities pcrecpp pcre
+$(APPNAME)_LIBS += utilities
+$(APPNAME)_LIBS += pcrecpp pcre
 
 # PSCTRL-IOC-01_registerRecordDeviceDriver.cpp derives from PSCTRL-IOC-01.dbd
 $(APPNAME)_SRCS += $(APPNAME)_registerRecordDeviceDriver.cpp
@@ -60,6 +61,8 @@ include $(CONFIG)/CONFIG_PVA_ISIS
 endif
 
 $(APPNAME)_LIBS += $(EPICS_BASE_IOC_LIBS)
+
+$(APPNAME)_SYS_LIBS_WIN32 += Userenv
 
 #===========================
 

--- a/PSCTRL/configure/RELEASE
+++ b/PSCTRL/configure/RELEASE
@@ -1,8 +1,24 @@
-# top level master release and local private options 
-include $(TOP)/../../../configure/MASTER_RELEASE
--include $(TOP)/../../../configure/MASTER_RELEASE.$(EPICS_HOST_ARCH)
--include $(TOP)/../../../configure/MASTER_RELEASE.private
--include $(TOP)/../../../configure/MASTER_RELEASE.private.$(EPICS_HOST_ARCH)
+TEMPLATE_TOP=$(EPICS_BASE)/templates/makeBaseApp/top
+
+ACCESSSECURITY=$(SUPPORT)/AccessSecurity/master
+ASUBFUNCTIONS=$(SUPPORT)/asubFunctions/master
+ASYN=$(SUPPORT)/asyn/master
+AUTOSAVE=$(SUPPORT)/autosave/master
+BUSY=$(SUPPORT)/busy/master
+ONCRPC=$(SUPPORT)/oncrpc/master
+ICPCONFIG=$(SUPPORT)/icpconfig/master
+PVDUMP=$(SUPPORT)/pvdump/master
+UTILITIES=$(SUPPORT)/utilities/master
+PROCSERVCONTROL=$(SUPPORT)/procServControl/master
+CAPUTLOG=$(SUPPORT)/caPutLog/master
+DEVIOCSTATS=$(SUPPORT)/devIocStats/master
+MYSQL=$(SUPPORT)/MySQL/master
+PCRE=$(SUPPORT)/pcre/master
+PUGIXML=$(SUPPORT)/pugixml/master
+SNCSEQ=$(SUPPORT)/seq/master
+SQLITE=$(SUPPORT)/sqlite/master
+ZLIB=$(SUPPORT)/zlib/master
+OPENSSL=$(SUPPORT)/OpenSSL/master
 
 # optional extra local definitions here
 -include $(TOP)/configure/RELEASE.private

--- a/RUNCTRL/configure/RELEASE
+++ b/RUNCTRL/configure/RELEASE
@@ -1,13 +1,36 @@
 # top level master release and local private options 
-include $(TOP)/../../../configure/MASTER_RELEASE
--include $(TOP)/../../../configure/MASTER_RELEASE.$(EPICS_HOST_ARCH)
--include $(TOP)/../../../configure/MASTER_RELEASE.private
--include $(TOP)/../../../configure/MASTER_RELEASE.private.$(EPICS_HOST_ARCH)
+
+TEMPLATE_TOP=$(EPICS_BASE)/templates/makeBaseApp/top
+
+ACCESSSECURITY=$(SUPPORT)/AccessSecurity/master
+ASUBFUNCTIONS=$(SUPPORT)/asubFunctions/master
+ASYN=$(SUPPORT)/asyn/master
+AUTOSAVE=$(SUPPORT)/autosave/master
+BUSY=$(SUPPORT)/busy/master
+CALC=$(SUPPORT)/calc/master
+CAPUTLOG=$(SUPPORT)/caPutLog/master
+CURL=$(SUPPORT)/curl/master
+DEVIOCSTATS=$(SUPPORT)/devIocStats/master
+HTMLTIDY=$(SUPPORT)/htmltidy/master
+ICPCONFIG=$(SUPPORT)/icpconfig/master
+LIBJSON=$(SUPPORT)/libjson/master
+MYSQL=$(SUPPORT)/MySQL/master
+ONCRPC=$(SUPPORT)/oncrpc/master
+OPENSSL=$(SUPPORT)/OpenSSL/master
+PCRE=$(SUPPORT)/pcre/master
+PUGIXML=$(SUPPORT)/pugixml/master
+PVDUMP=$(SUPPORT)/pvdump/master
+RUNCONTROL=$(SUPPORT)/RunControl/master
+SLACKING=$(EPICS_ROOT)/libraries/master/slacking
+SNCSEQ=$(SUPPORT)/seq/master
+SQLITE=$(SUPPORT)/sqlite/master
+SSCAN=$(SUPPORT)/sscan/master
+UTILITIES=$(SUPPORT)/utilities/master
+WEBGET=$(SUPPORT)/webget/master
+ZLIB=$(SUPPORT)/zlib/master
 
 # optional extra local definitions here
 -include $(TOP)/configure/RELEASE.private
 
 include $(TOP)/../../../ISIS_CONFIG
 -include $(TOP)/../../../ISIS_CONFIG.$(EPICS_HOST_ARCH)
-
-GSL=$(SUPPORT)/gsl/master


### PR DESCRIPTION
### Description of work

Remove use of MASTER_RELEASE in some IOCs, this can lead to very long PATHs and sometimes IOC start failure

### To test

See ISISComputingGroup/IBEX#8558

### Acceptance criteria

* iocs build as before

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
