### PR TITLE
add quotation marks in eurotherm db to fix system tests

### DIFF
--- a/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
+++ b/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
@@ -402,7 +402,7 @@ record(seq, "$(P)READ") {
 }
 
 record(calcout, "$(P)READ_RESTART"){
-    field(INPA, $(P)RBV MS)
+    field(INPA, "$(P)RBV MS")
     field(SCAN, "1 second")
     field(CALC "A")
     field(IVOA, "Don't drive outputs")


### PR DESCRIPTION
Add quotation marks around a field value so that the file gets loaded