### PR TITLE
Added ioc for the new focus intellgient picometer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ IOCDIRS += ENVMON
 IOCDIRS += DDSSTRES
 IOCDIRS += TLFW102C
 IOCDIRS += G3HALLPR
+IOCDIRS += NFIPM
 
 ## check on missing directories
 IOCMAKES = $(wildcard */Makefile)

--- a/NFIPM/Makefile
+++ b/NFIPM/Makefile
@@ -1,0 +1,31 @@
+# Makefile at top of application tree
+TOP = .
+include $(TOP)/configure/CONFIG
+
+# Directories to build, any order
+DIRS += configure
+DIRS += $(wildcard *Sup)
+DIRS += $(wildcard *App)
+DIRS += $(wildcard *Top)
+DIRS += $(wildcard iocBoot)
+
+# The build order is controlled by these dependency rules:
+
+# All dirs except configure depend on configure
+$(foreach dir, $(filter-out configure, $(DIRS)), \
+    $(eval $(dir)_DEPEND_DIRS += configure))
+
+# Any *App dirs depend on all *Sup dirs
+$(foreach dir, $(filter %App, $(DIRS)), \
+    $(eval $(dir)_DEPEND_DIRS += $(filter %Sup, $(DIRS))))
+
+# Any *Top dirs depend on all *Sup and *App dirs
+$(foreach dir, $(filter %Top, $(DIRS)), \
+    $(eval $(dir)_DEPEND_DIRS += $(filter %Sup %App, $(DIRS))))
+
+# iocBoot depends on all *App dirs
+iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
+
+# Add any additional dependency rules here:
+
+include $(TOP)/configure/RULES_TOP

--- a/NFIPM/NFIPM-IOC-01App/Makefile
+++ b/NFIPM/NFIPM-IOC-01App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *protocol*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/NFIPM/NFIPM-IOC-01App/db/Makefile
+++ b/NFIPM/NFIPM-IOC-01App/db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+DB += motor.db motorSim.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/NFIPM/NFIPM-IOC-01App/db/motor.substitutions
+++ b/NFIPM/NFIPM-IOC-01App/db/motor.substitutions
@@ -1,0 +1,14 @@
+file $(MOTOR)/db/motor.db {
+pattern {P,    M,         DTYP,      DESC,   EGU,  DIR,  VELO,  VBAS, ACCL, BDST, BVEL, BACC,    MRES,    ERES, UEIP, PREC, DHLM, DLLM, INIT, C, S, OFF }
+{"\$(P)", "\$(M)", "PMNC87xx", "\$(NAME) (New Focus)",    "\$(EGU)",  "Pos",  "\$(VELO)",   "\$(VBAS)",  "\$(ACCL)",    0,    1,   0,   "\$(MRES)",   "\$(ERES)", "\$(UEIP)",    3,   "\$(DHLM)",   "\$(DLLM)",  "", "\$(C)", "\$(S)"}
+}
+
+file $(MOTOR)/db/motor_init_extra.db {
+pattern {P, M, OFF, JVEL}
+{"\$(P)", "\$(M)", "\$(OFF)", "\$(JVEL)"}
+}
+
+file $(MOTOR)/db/periodic_polling.db {
+pattern {P, M}
+{"\$(P)", "\$(M)"}
+}

--- a/NFIPM/NFIPM-IOC-01App/db/motorSim.substitutions
+++ b/NFIPM/NFIPM-IOC-01App/db/motorSim.substitutions
@@ -1,0 +1,13 @@
+#file $(MOTOR)/db/motor.db {
+#
+#pattern {P,    M,         DTYP,      DESC,   EGU,  DIR,  VELO,  VBAS, ACCL, BDST, BVEL, BACC,    MRES,    ERES, UEIP, PREC, DHLM, DLLM, INIT, C, S, MOTORSIM }
+#{"\$(P)", "\$(M)", "Motor Simulation", "\$(NAME) (LITRON PWR)",    "degree",  "Pos",  "\$(VELO)",   1,  "\$(ACCL)",    0,    1,   0,   "\$(MRES)",   "\$(ERES)", "\$(UEIP)",    3,   "\$(DHLM)",   "\$(DLLM)",  "", "\$(C)", "\$(S)", "motorSim" }
+#
+#}
+
+file $(MOTOR)/db/asyn_motor.db {
+
+pattern {P,    M,         DTYP,      DESC,   EGU,  DIR,  VELO,  VBAS, ACCL, BDST, BVEL, BACC,    MRES,    ERES, UEIP, PREC, DHLM, DLLM, INIT, C, S, MOTORSIM, PORT, ADDR }
+{"\$(P)", "\$(M)", "asynMotor", "\$(NAME) (New Focus)",    "\$(EGU)",  "Pos",  "\$(VELO)",   1,  "\$(ACCL)",    0,    1,   0,   "\$(MRES)",   "\$(ERES)", "\$(UEIP)",    3,   "\$(DHLM)",   "\$(DLLM)",  "", "\$(C)", "\$(S)", "motorSim", "motorSim", "$(S)" }
+
+}

--- a/NFIPM/NFIPM-IOC-01App/src/Makefile
+++ b/NFIPM/NFIPM-IOC-01App/src/Makefile
@@ -1,0 +1,9 @@
+TOP=../..
+# This file should do very little - it's purpose is to set the APPNAME and then load build.mak
+
+# this definition is used in build.mak
+APPNAME=NFIPM-IOC-01
+
+# If we are ###-IOC-01 leave this as is, if we are ###-IOC-02 or higher change to ###-IOC-01 and delete build.mak from this directory
+# there should only be a single build.mak for all IOCs of a given family and it is located in the ###-IOC-01 directory
+include $(TOP)/NFIPM-IOC-01App/src/build.mak

--- a/NFIPM/NFIPM-IOC-01App/src/NFIPM-IOC-01Main.cpp
+++ b/NFIPM/NFIPM-IOC-01App/src/NFIPM-IOC-01Main.cpp
@@ -1,0 +1,23 @@
+/* NFIPM-IOC-01Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/NFIPM/NFIPM-IOC-01App/src/build.mak
+++ b/NFIPM/NFIPM-IOC-01App/src/build.mak
@@ -1,0 +1,94 @@
+TOP=../..
+
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+#=============================
+
+### NOTE: there should only be one build.mak for a given IOC family and this should be located in the ###-IOC-01 directory
+
+#=============================
+# Build the IOC application NFIPM-IOC-01
+# We actually use $(APPNAME) below so this file can be included by multiple IOCs
+
+PROD_IOC = $(APPNAME)
+# NFIPM-IOC-01.dbd will be created and installed
+DBD += $(APPNAME).dbd
+
+# NFIPM-IOC-01.dbd will be made up from these files:
+$(APPNAME)_DBD += base.dbd
+## ISIS standard dbd ##
+$(APPNAME)_DBD += icpconfig.dbd
+$(APPNAME)_DBD += pvdump.dbd
+$(APPNAME)_DBD += asSupport.dbd
+$(APPNAME)_DBD += devIocStats.dbd
+$(APPNAME)_DBD += caPutLog.dbd
+$(APPNAME)_DBD += utilities.dbd
+## Stream device support ##
+$(APPNAME)_DBD += calcSupport.dbd
+$(APPNAME)_DBD += asyn.dbd
+$(APPNAME)_DBD += drvAsynSerialPort.dbd
+$(APPNAME)_DBD += drvAsynIPPort.dbd
+$(APPNAME)_DBD += luaSupport.dbd
+$(APPNAME)_DBD += stream.dbd
+## add other dbd here ##
+#$(APPNAME)_DBD += xxx.dbd
+$(APPNAME)_DBD += motorSupport.dbd
+$(APPNAME)_DBD += motorSimSupport.dbd
+$(APPNAME)_DBD += devNewFocus.dbd
+$(APPNAME)_DBD += devSoftMotor.dbd
+$(APPNAME)_DBD += motionSetPoints.dbd
+
+# Add all the support libraries needed by this IOC
+
+## Add additional libraries here ##
+#$(APPNAME)_LIBS += xxx
+
+## ISIS standard libraries ##
+## Stream device libraries ##
+$(APPNAME)_LIBS += stream
+$(APPNAME)_LIBS += lua
+$(APPNAME)_LIBS += asyn
+## other standard libraries here ##
+$(APPNAME)_LIBS += devIocStats 
+$(APPNAME)_LIBS += pvdump $(MYSQLLIB) easySQLite sqlite 
+$(APPNAME)_LIBS += caPutLog
+$(APPNAME)_LIBS += icpconfig
+$(APPNAME)_LIBS += autosave
+$(APPNAME)_LIBS += utilities pugixml libjson zlib
+$(APPNAME)_LIBS += calc sscan
+$(APPNAME)_LIBS += pcrecpp pcre
+$(APPNAME)_LIBS += seq pv
+$(APPNAME)_LIBS += NewFocus
+$(APPNAME)_LIBS += motorSimSupport
+$(APPNAME)_LIBS += softMotor motor
+$(APPNAME)_LIBS += motionSetPoints
+$(APPNAME)_LIBS += busy asyn
+$(APPNAME)_LIBS += std calc sscan
+$(APPNAME)_LIBS += TinyXML
+$(APPNAME)_LIBS += seq pv
+
+# NFIPM-IOC-01_registerRecordDeviceDriver.cpp derives from NFIPM-IOC-01.dbd
+$(APPNAME)_SRCS += $(APPNAME)_registerRecordDeviceDriver.cpp
+
+# Build the main IOC entry point on workstation OSs.
+$(APPNAME)_SRCS_DEFAULT += $(APPNAME)Main.cpp
+$(APPNAME)_SRCS_vxWorks += -nil-
+
+# Add support from base/src/vxWorks if needed
+#$(APPNAME)_OBJS_vxWorks += $(EPICS_BASE_BIN)/vxComLibrary
+
+# Finally link to the EPICS Base libraries
+## area detector already includes PVA, so avoid including it twice
+ifeq ($(AREA_DETECTOR),)
+include $(CONFIG)/CONFIG_PVA_ISIS
+endif
+
+$(APPNAME)_LIBS += $(EPICS_BASE_IOC_LIBS)
+
+#===========================
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/NFIPM/configure/CONFIG
+++ b/NFIPM/configure/CONFIG
@@ -1,0 +1,29 @@
+# CONFIG - Load build configuration data
+#
+# Do not make changes to this file!
+
+# Allow user to override where the build rules come from
+RULES = $(EPICS_BASE)
+
+# RELEASE files point to other application tops
+include $(TOP)/configure/RELEASE
+-include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).Common
+ifdef T_A
+-include $(TOP)/configure/RELEASE.Common.$(T_A)
+-include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).$(T_A)
+endif
+
+CONFIG = $(RULES)/configure
+include $(CONFIG)/CONFIG
+
+# Override the Base definition:
+INSTALL_LOCATION = $(TOP)
+
+# CONFIG_SITE files contain other build configuration settings
+include $(TOP)/configure/CONFIG_SITE
+-include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+ifdef T_A
+ -include $(TOP)/configure/CONFIG_SITE.Common.$(T_A)
+ -include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+endif
+

--- a/NFIPM/configure/CONFIG_SITE
+++ b/NFIPM/configure/CONFIG_SITE
@@ -1,0 +1,43 @@
+# CONFIG_SITE
+
+# Make any application-specific changes to the EPICS build
+#   configuration variables in this file.
+#
+# Host/target specific settings can be specified in files named
+#   CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+#   CONFIG_SITE.Common.$(T_A)
+#   CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+
+# CHECK_RELEASE controls the consistency checking of the support
+#   applications pointed to by the RELEASE* files.
+# Normally CHECK_RELEASE should be set to YES.
+# Set CHECK_RELEASE to NO to disable checking completely.
+# Set CHECK_RELEASE to WARN to perform consistency checking but
+#   continue building even if conflicts are found.
+CHECK_RELEASE = YES
+
+# Set this when you only want to compile this application
+#   for a subset of the cross-compiled target architectures
+#   that Base is built for.
+#CROSS_COMPILER_TARGET_ARCHS = vxWorks-ppc32
+
+# To install files into a location other than $(TOP) define
+#   INSTALL_LOCATION here.
+#INSTALL_LOCATION=</absolute/path/to/install/top>
+
+# Set this when the IOC and build host use different paths
+#   to the install location. This may be needed to boot from
+#   a Microsoft FTP server say, or on some NFS configurations.
+#IOCS_APPL_TOP = </IOC's/absolute/path/to/install/top>
+
+# For application debugging purposes, override the HOST_OPT and/
+#   or CROSS_OPT settings from base/configure/CONFIG_SITE
+#HOST_OPT = NO
+#CROSS_OPT = NO
+
+# These allow developers to override the CONFIG_SITE variable
+# settings without having to modify the configure/CONFIG_SITE
+# file itself.
+-include $(TOP)/../CONFIG_SITE.local
+-include $(TOP)/configure/CONFIG_SITE.local
+

--- a/NFIPM/configure/Makefile
+++ b/NFIPM/configure/Makefile
@@ -1,0 +1,8 @@
+TOP=..
+
+include $(TOP)/configure/CONFIG
+
+TARGETS = $(CONFIG_TARGETS)
+CONFIGS += $(subst ../,,$(wildcard $(CONFIG_INSTALLS)))
+
+include $(TOP)/configure/RULES

--- a/NFIPM/configure/RELEASE
+++ b/NFIPM/configure/RELEASE
@@ -1,0 +1,86 @@
+# RELEASE - Location of external support modules
+#
+# IF YOU CHANGE ANY PATHS in this file or make API changes to
+# any modules it refers to, you should do a "make rebuild" in
+# this application's top level directory.
+#
+# The EPICS build process does not check dependencies against
+# any files from outside the application, so it is safest to
+# rebuild it completely if any modules it depends on change.
+#
+# Host- or target-specific settings can be given in files named
+#  RELEASE.$(EPICS_HOST_ARCH).Common
+#  RELEASE.Common.$(T_A)
+#  RELEASE.$(EPICS_HOST_ARCH).$(T_A)
+#
+# This file is parsed by both GNUmake and an EPICS Perl script,
+# so it may ONLY contain definititions of paths to other support
+# modules, variable definitions that are used in module paths,
+# and include statements that pull in other RELEASE files.
+# Variables may be used before their values have been set.
+# Build variables that are NOT used in paths should be set in
+# the CONFIG_SITE file.
+
+# Variables and paths to dependent modules:
+#MODULES = /path/to/modules
+#MYMODULE = $(MODULES)/my-module
+
+# If using the sequencer, point SNCSEQ at its top directory:
+#SNCSEQ = $(MODULES)/seq-ver
+
+# EPICS_BASE should appear last so earlier modules can override stuff:
+EPICS_BASE = C:/Instrument/Apps/EPICS/base/master
+
+# Set RULES here if you want to use build rules from somewhere
+# other than EPICS_BASE:
+#RULES = $(MODULES)/build-rules
+
+# These lines allow developers to override these RELEASE settings
+# without having to modify this file directly.
+-include $(TOP)/../RELEASE.local
+-include $(TOP)/../RELEASE.$(EPICS_HOST_ARCH).local
+-include $(TOP)/configure/RELEASE.local
+
+# Macros required for basic ioc/stream device
+ACCESSSECURITY=$(SUPPORT)/AccessSecurity/master
+ASUBFUNCTIONS=$(SUPPORT)/asubFunctions/master
+ASYN=$(SUPPORT)/asyn/master
+AUTOSAVE=$(SUPPORT)/autosave/master
+CALC=$(SUPPORT)/calc/master
+CAPUTLOG=$(SUPPORT)/caPutLog/master
+DEVIOCSTATS=$(SUPPORT)/devIocStats/master
+ICPCONFIG=$(SUPPORT)/icpconfig/master
+LIBJSON=$(SUPPORT)/libjson/master
+LUA=$(SUPPORT)/lua/master
+MYSQL=$(SUPPORT)/MySQL/master
+ONCRPC=$(SUPPORT)/oncrpc/master
+PCRE=$(SUPPORT)/pcre/master
+PUGIXML=$(SUPPORT)/pugixml/master
+PVDUMP=$(SUPPORT)/pvdump/master
+SNCSEQ=$(SUPPORT)/seq/master
+SQLITE=$(SUPPORT)/sqlite/master
+SSCAN=$(SUPPORT)/sscan/master
+STREAMDEVICE=$(SUPPORT)/StreamDevice/master
+UTILITIES=$(SUPPORT)/utilities/master
+ZLIB=$(SUPPORT)/zlib/master
+
+# optional extra local definitions here
+ASYN=$(SUPPORT)/asyn/master
+AUTOSAVE=$(SUPPORT)/autosave/master
+BUSY=$(SUPPORT)/busy/master
+CALC=$(SUPPORT)/calc/master
+MOTOR=$(SUPPORT)/motor/master
+MOTORSIM=$(MOTOR)/modules/motorMotorSim
+MOTORNEWFOCUS=$(MOTOR)/modules/motorNewFocus
+MOTIONSETPOINTS=$(SUPPORT)/motionSetPoints/master
+AXIS=$(SUPPORT)/axis/master
+TINYXML=$(SUPPORT)/TinyXML/master
+STD=$(SUPPORT)/std/master
+MOTOREXT=$(SUPPORT)/motorExtensions/master
+-include $(TOP)/configure/RELEASE.private
+
+include $(TOP)/../../../ISIS_CONFIG
+-include $(TOP)/../../../ISIS_CONFIG.$(EPICS_HOST_ARCH)
+
+# IOC-specific support module
+

--- a/NFIPM/configure/RULES
+++ b/NFIPM/configure/RULES
@@ -1,0 +1,6 @@
+# RULES
+
+include $(CONFIG)/RULES
+
+# Library should be rebuilt because LIBOBJS may have changed.
+$(LIBNAME): ../Makefile

--- a/NFIPM/configure/RULES.ioc
+++ b/NFIPM/configure/RULES.ioc
@@ -1,0 +1,2 @@
+#RULES.ioc
+include $(CONFIG)/RULES.ioc

--- a/NFIPM/configure/RULES_DIRS
+++ b/NFIPM/configure/RULES_DIRS
@@ -1,0 +1,2 @@
+#RULES_DIRS
+include $(CONFIG)/RULES_DIRS

--- a/NFIPM/configure/RULES_TOP
+++ b/NFIPM/configure/RULES_TOP
@@ -1,0 +1,3 @@
+#RULES_TOP
+include $(CONFIG)/RULES_TOP
+

--- a/NFIPM/iocBoot/Makefile
+++ b/NFIPM/iocBoot/Makefile
@@ -1,0 +1,6 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS += $(wildcard *ioc*)
+DIRS += $(wildcard as*)
+include $(CONFIG)/RULES_DIRS
+

--- a/NFIPM/iocBoot/iocNFIPM-IOC-01/Makefile
+++ b/NFIPM/iocBoot/iocNFIPM-IOC-01/Makefile
@@ -1,0 +1,6 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+#ARCH = windows-x64
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths dllPath.bat relPaths.sh runIOC.bat runIOC.sh
+include $(TOP)/configure/RULES.ioc

--- a/NFIPM/iocBoot/iocNFIPM-IOC-01/axes.cmd
+++ b/NFIPM/iocBoot/iocNFIPM-IOC-01/axes.cmd
@@ -1,0 +1,1 @@
+< $(NFIPMCONFIG)/axes.cmd

--- a/NFIPM/iocBoot/iocNFIPM-IOC-01/config.xml
+++ b/NFIPM/iocBoot/iocNFIPM-IOC-01/config.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<config_part>
+<ioc_desc>NewFocus Intelligent Picometer</ioc_desc>
+<ioc_details>New Focus Intelligent Picometer for Litron laser power control</ioc_details>
+<macros>
+
+<macro name="MTRCTRL" pattern="^[0-9]{1,2}$" description="Controller number used in motor address assignment" hasDefault="NO" />
+<xi:include href="../../../COMMON/PORT.xml" />
+<xi:include href="../../../COMMON/BAUD9600.xml" />
+<xi:include href="../../../COMMON/BITS8.xml" />
+<xi:include href="../../../COMMON/PARITYNONE.xml" />
+<xi:include href="../../../COMMON/STOP1.xml" />
+
+<macro name="AXIS1" pattern="^(yes|no)$" description="Motor is attached to axis 1 (default: no)" defaultValue="no" hasDefault="YES" />
+<macro name="AXIS2" pattern="^(yes|no)$" description="Motor is attached to axis 2 (default: no)" defaultValue="no" hasDefault="YES" />
+<macro name="AXIS3" pattern="^(yes|no)$" description="Motor is attached to axis 3 (default: no)" defaultValue="no" hasDefault="YES" />
+<macro name="AXIS4" pattern="^(yes|no)$" description="Motor is attached to axis 4 (default: no)" defaultValue="no" hasDefault="YES" />
+<macro name="AXIS5" pattern="^(yes|no)$" description="Motor is attached to axis 5 (default: no)" defaultValue="no" hasDefault="YES" />
+<macro name="AXIS6" pattern="^(yes|no)$" description="Motor is attached to axis 6 (default: no)" defaultValue="no" hasDefault="YES" />
+<macro name="AXIS7" pattern="^(yes|no)$" description="Motor is attached to axis 7 (default: no)" defaultValue="no" hasDefault="YES" />
+<macro name="AXIS8" pattern="^(yes|no)$" description="Motor is attached to axis 8 (default: no)" defaultValue="no" hasDefault="YES" />
+
+<macro name="OFST1" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)" defaultValue="0" hasDefault="YES" />
+<macro name="OFST2" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)" defaultValue="0" hasDefault="YES" />
+<macro name="OFST3" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)" defaultValue="0" hasDefault="YES" />
+<macro name="OFST4" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)" defaultValue="0" hasDefault="YES" />
+<macro name="OFST5" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)" defaultValue="0" hasDefault="YES" />
+<macro name="OFST6" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)" defaultValue="0" hasDefault="YES" />
+<macro name="OFST7" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)" defaultValue="0" hasDefault="YES" />
+<macro name="OFST8" pattern="-?[0-9]*\.?[0-9]*$" description="Offset in mm (default: 0)" defaultValue="0" hasDefault="YES" />
+
+<macro name="MRES1" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)" defaultValue="0.01" hasDefault="YES" />
+<macro name="MRES2" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)" defaultValue="0.01" hasDefault="YES" />
+<macro name="MRES3" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)" defaultValue="0.01" hasDefault="YES" />
+<macro name="MRES4" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)" defaultValue="0.01" hasDefault="YES" />
+<macro name="MRES5" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)" defaultValue="0.01" hasDefault="YES" />
+<macro name="MRES6" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)" defaultValue="0.01" hasDefault="YES" />
+<macro name="MRES7" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)" defaultValue="0.01" hasDefault="YES" />
+<macro name="MRES8" pattern="-?[0-9]*\.?[0-9]*$" description="mm/step (default: 0.01)" defaultValue="0.01" hasDefault="YES" />
+
+<!-- speed is in internal controller units, just take the labview value, find its !SV command -->
+<macro name="VELO1" pattern="[0-9]*\.?[0-9]*$" description="Speed in controller_units/s (default: 10)" defaultValue="10" hasDefault="YES" />
+<macro name="VELO2" pattern="[0-9]*\.?[0-9]*$" description="Speed in controller_units/s (default: 10)" defaultValue="10" hasDefault="YES" />
+<macro name="VELO3" pattern="[0-9]*\.?[0-9]*$" description="Speed in controller_units/s (default: 10)" defaultValue="10" hasDefault="YES" />
+<macro name="VELO4" pattern="[0-9]*\.?[0-9]*$" description="Speed in controller_units/s (default: 10)" defaultValue="10" hasDefault="YES" />
+<macro name="VELO5" pattern="[0-9]*\.?[0-9]*$" description="Speed in controller_units/s (default: 10)" defaultValue="10" hasDefault="YES" />
+<macro name="VELO6" pattern="[0-9]*\.?[0-9]*$" description="Speed in controller_units/s (default: 10)" defaultValue="10" hasDefault="YES" />
+<macro name="VELO7" pattern="[0-9]*\.?[0-9]*$" description="Speed in controller_units/s (default: 10)" defaultValue="10" hasDefault="YES" />
+<macro name="VELO8" pattern="[0-9]*\.?[0-9]*$" description="Speed in controller_units/s (default: 10)" defaultValue="10" hasDefault="YES" />
+
+<macro name="NAME1" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" hasDefault="NO" />
+<macro name="NAME2" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" hasDefault="NO" />
+<macro name="NAME3" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" hasDefault="NO" />
+<macro name="NAME4" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" hasDefault="NO" />
+<macro name="NAME5" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" hasDefault="NO" />
+<macro name="NAME6" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" hasDefault="NO" />
+<macro name="NAME7" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" hasDefault="NO" />
+<macro name="NAME8" pattern="^[\x20-\x7E]*$" description="Name used to identify the motor" hasDefault="NO" />
+
+</macros>
+<pvsets>
+</pvsets>
+</config_part>
+</ioc_config>

--- a/NFIPM/iocBoot/iocNFIPM-IOC-01/jaws.cmd
+++ b/NFIPM/iocBoot/iocNFIPM-IOC-01/jaws.cmd
@@ -1,0 +1,1 @@
+< $(NFIPMCONFIG)/jaws.cmd

--- a/NFIPM/iocBoot/iocNFIPM-IOC-01/motionsetpoints.cmd
+++ b/NFIPM/iocBoot/iocNFIPM-IOC-01/motionsetpoints.cmd
@@ -1,0 +1,1 @@
+< $(NFIPMCONFIG)/motionsetpoints.cmd

--- a/NFIPM/iocBoot/iocNFIPM-IOC-01/st-axes.cmd
+++ b/NFIPM/iocBoot/iocNFIPM-IOC-01/st-axes.cmd
@@ -1,0 +1,7 @@
+
+## set MN before calling
+## if MN=1 the defines asyn port SD1 and uses macros such as VELO1, ACCL1 to configure 
+
+# this defines macros we can use for conditional loading later
+stringiftest("AXIS$(MN)", "$(AXIS$(MN)=)",5,"yes")
+$(IFAXIS$(MN)) < ${TOP}/iocBoot/iocNFIPM-IOC-01/st-motor.cmd

--- a/NFIPM/iocBoot/iocNFIPM-IOC-01/st-common.cmd
+++ b/NFIPM/iocBoot/iocNFIPM-IOC-01/st-common.cmd
@@ -1,0 +1,83 @@
+
+< $(IOCSTARTUP)/init.cmd
+
+## whether to use autosaved SP for jaws on IOC restart
+stringiftest("INIT_JAWS_FROM_AS", "$(JAWS_POS_FROM_AS=N)", 5, "Y")
+
+< $(IOCSTARTUP)/dbload.cmd
+
+# specify additional directories in which to to search for included request files
+set_requestfile_path("${MOTOR}/motorApp/Db", "")
+## as we are common, we need to explicity define the 01 area for when we are run by 02, 03 etc 
+set_requestfile_path("${TOP}/iocBoot/iocNFIPM-IOC-01", "")
+
+iocshCmdLoop("< ${TOP}/iocBoot/iocNFIPM-IOC-01/st-ctrl.cmd", "CNUM=\$(I)", "I", 1, 24)
+iocshCmdLoop("< ${TOP}/iocBoot/iocNFIPM-IOC-01/st-max-axis.cmd", "MN=\$(I)", "I", 1, 8)
+
+# Make sure controller number is 2 digits long
+calc("MTRCTRL", "$(MTRCTRL=11)", 2, 2)
+## asyn serial port internal device name and motor name 
+epicsEnvSet("ASERIAL", "serial$(MTRCTRL)")
+
+$(IFRECSIM) drvAsynSerialPortConfigure("$(ASERIAL)", "NUL", 0, 1)
+$(IFRECSIM) motorSimCreateController("motorSim", $(NAXES))
+$(IFRECSIM) epicsEnvSet("SIMSFX","Sim")
+
+$(IFDEVSIM) drvAsynIPPortConfigure("$(ASERIAL)", "localhost:$(EMULATOR_PORT=57677)")
+$(IFDEVSIM) epicsEnvSet("SIMSFX","")
+  
+$(IFNOTDEVSIM) $(IFNOTRECSIM) drvAsynSerialPortConfigure("$(ASERIAL)", "$(PORT=NUL)", 0, 0, 0)
+$(IFNOTRECSIM) asynOctetSetInputEos("$(ASERIAL)",0,"\r") 
+$(IFNOTRECSIM) asynOctetSetOutputEos("$(ASERIAL)",0,"\r\n")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(ASERIAL)",0,"baud","$(BAUD=9600)") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(ASERIAL)",0,"bits","$(BITS=8)") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(ASERIAL)",0,"stop","$(STOP=1)") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(ASERIAL)",0,"parity","$(PARITY=none)")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(ASERIAL)",0,"clocal","Y") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(ASERIAL)",0,"crtscts","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(ASERIAL)",0,"ixon","N") 
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(ASERIAL)",0,"ixoff","N") 
+
+# PMNC87xxSetup(controller count, drivers per controller, poll rate (1 to 60Hz))
+$(IFNOTRECSIM) PMNC87xxSetup(1, $(NAXES=1), 10) 
+
+# PMNC87xxConfig(card being configured, asyn port name)
+$(IFNOTRECSIM) PMNC87xxConfig(0, "$(ASERIAL)")
+
+iocshCmdLoop("< ${TOP}/iocBoot/iocNFIPM-IOC-01/st-axes.cmd", "MN=\$(I)", "I", 1, 8)
+
+epicsEnvSet("NFIPMCONFIG","$(NFIPMCONFIGDIR=$(MOTOREXT)/settings/$(INSTRUMENT)/nfipm)")
+
+# Special configurations
+< ${TOP}/iocBoot/iocNFIPM-IOC-01/axes.cmd
+< ${TOP}/iocBoot/iocNFIPM-IOC-01/jaws.cmd
+< ${TOP}/iocBoot/iocNFIPM-IOC-01/motionsetpoints.cmd
+
+
+# motor extensions
+$(IFNOTRECSIM) < $(NFIPMCONFIG)/motorExtensions.cmd
+$(IFRECSIM) < $(MOTOREXT)/settings/motorExtensions.cmd
+
+## motor util package
+dbLoadRecords("$(MOTOR)/db/motorUtil.db","P=$(MYPVPREFIX)$(IOCNAME):,$(IFIOC)= ,PVPREFIX=$(MYPVPREFIX)")
+
+## per controller PVs
+dbLoadRecords("$(MOTOR)/db/motorController.db","P=$(MYPVPREFIX),Q=MOT:MTR$(MTRCTRL):,AXES_NUM=$(NAXES=1)")
+
+##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
+< $(IOCSTARTUP)/preiocinit.cmd
+
+iocInit()
+
+## motor util package
+#var motorUtil_debug 1
+#motorUtilInit("$(MYPVPREFIX)$(IOCNAME):")
+
+# Save motor positions every 5 seconds
+create_monitor_set("$(IOCNAME)_positions.req", 5, "P=$(MYPVPREFIX)MOT:")
+
+# Save motor settings every 30 seconds
+create_monitor_set("$(IOCNAME)_settings.req", 30, "P=$(MYPVPREFIX)MOT:")
+
+##ISIS## Stuff that needs to be done after iocInit is called e.g. sequence programs 
+< $(IOCSTARTUP)/postiocinit.cmd

--- a/NFIPM/iocBoot/iocNFIPM-IOC-01/st-ctrl.cmd
+++ b/NFIPM/iocBoot/iocNFIPM-IOC-01/st-ctrl.cmd
@@ -1,0 +1,2 @@
+# Set IF/IFNOT macro for controller number CNUM
+stringiftest("MTRCTRL$(CNUM)", "$(MTRCTRL)", 5, "$(CNUM)")

--- a/NFIPM/iocBoot/iocNFIPM-IOC-01/st-max-axis.cmd
+++ b/NFIPM/iocBoot/iocNFIPM-IOC-01/st-max-axis.cmd
@@ -1,0 +1,3 @@
+# Find the maximum active axis number
+stringiftest("ACTIVE", "$(AXIS$(MN)=)",5,"yes")
+$(IFACTIVE) calc("NAXES", "$(MN)", 1, 0)

--- a/NFIPM/iocBoot/iocNFIPM-IOC-01/st-motor.cmd
+++ b/NFIPM/iocBoot/iocNFIPM-IOC-01/st-motor.cmd
@@ -1,0 +1,40 @@
+epicsEnvSet("AMOTOR", "motor$(MN)")
+epicsEnvSet("AMOTORNAME", "MTR$(MTRCTRL)0$(MN)")
+epicsEnvSet("AMOTORPV", "MOT:$(AMOTORNAME)")
+
+## Load record instances
+
+# Set motor specific initial conditions
+epicsEnvSet("EGUI",$(UNIT$(MN)=mm))
+epicsEnvSet("VELOI",$(VELO$(MN)=10))
+epicsEnvSet("OFSTI",$(OFST$(MN)=0))
+epicsEnvSet("MRESI",$(MRES$(MN)=0.01))
+# LinMots set velocity always in C*mm/s where C is internal to the motor.
+# so just use the value that labview supplied to its !SV command
+# The motor record adds in a factor of 1/MRES when calling the driver
+# so we need to take that out here so that what we originally set the VELOI
+# macro to gets sent to the driver
+dcalc("VELOI", "abs($(VELOI)*$(MRESI))", 1, 0)
+$(IFSIM) epicsEnvSet("ERESI",1)
+$(IFNOTSIM) epicsEnvSet("ERESI",0)
+epicsEnvSet("DHLMI",$(DHLM$(MN)=100))
+epicsEnvSet("DLLMI",$(DLLM$(MN)=0))
+epicsEnvSet("ACCLI",$(ACCL$(MN)=1))
+epicsEnvSet("NAMEI","$(NAME$(MN)=$(AMOTORNAME))")
+
+# The signal number is the axis-1
+calc("SN", "$(MN)-1", 2, 2)
+#$(IFSIM) motorSimConfigAxis("motorSim", $(SN), $(DHLMI), $(DLLMI),  $(DLLMI), 0)
+
+# Load asyn record 
+dbLoadRecords("$(ASYN)/db/asynRecord.db", "P=$(MYPVPREFIX),R=$(AMOTORPV):ASYN,PORT=$(ASERIAL),ADDR=0,OMAX=256,IMAX=256")
+#
+# S is the signal number (axis-1), C is the card number
+#
+# Set the VBAS, the base speed, to 0.0 as it has no effect (that I know of) on the motor except that the acceleration won't be set
+# on an absolute move unless the speed and base speed are different
+#
+dbLoadRecords("$(TOP)/db/motor$(SIMSFX=).db", "P=$(MYPVPREFIX),M=$(AMOTORPV),VELO=$(VELOI),JVEL=$(VELOI),VBAS=0.0,ACCL=$(ACCLI),MRES=$(MRESI),ERES=$(ERESI),DHLM=$(DHLMI),DLLM=$(DLLMI),NAME=$(NAMEI),S=$(SN),C=0,UEIP=0,OFF=$(OFSTI),EGU=$(EGUI)") 
+dbLoadRecords("$(MOTOR)/db/motorStatus.db", "P=$(MYPVPREFIX),M=$(AMOTORPV),IOCNAME=$(IOCNAME)") 
+#dbLoadRecords("$(AXIS)/db/axis.db", "P=$(MYPVPREFIX),AXIS=$(IOCNAME):AXIS$(MN),mAXIS=$(AMOTORPV)") 
+

--- a/NFIPM/iocBoot/iocNFIPM-IOC-01/st.cmd
+++ b/NFIPM/iocBoot/iocNFIPM-IOC-01/st.cmd
@@ -1,0 +1,18 @@
+#!../../bin/windows-x64/NFIPM-IOC-01
+
+## You may have to change NFIPM-IOC-01 to something else
+## everywhere it appears in this file
+
+# Increase this if you get <<TRUNCATED>> or discarded messages warnings in your errlog output
+errlogInit2(65536, 256)
+
+< envPaths
+
+cd "${TOP}"
+
+## Register all support components
+dbLoadDatabase "dbd/NFIPM-IOC-01.dbd"
+NFIPM_IOC_01_registerRecordDeviceDriver pdbbase
+
+## calling common command file in ioc 01 boot dir
+< ${TOP}/iocBoot/iocNFIPM-IOC-01/st-common.cmd


### PR DESCRIPTION
### Description of work
Added an IOC for the new focus intelligent picometer for use in the litron laser power control. There was already a motor support for this, so just ioc work to setup a motor nesecart

### To test

[*Which ticket does this PR fix?*](https://github.com/ISISComputingGroup/IBEX/issues/8331)

### Acceptance criteria
Motor can be used in conjunction with OPI to recreate capabilities of this vi:
![393326113-a09e60ac-af26-434b-998f-69fba985d0d6](https://github.com/user-attachments/assets/a9261f17-cb66-41a7-a481-f702fd270203)


---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
