### PR TITLE
Litronlasertiming#6090

### DIFF
--- a/DG645/iocBoot/iocDG645-IOC-01/config.xml
+++ b/DG645/iocBoot/iocDG645-IOC-01/config.xml
@@ -8,6 +8,7 @@
 <xi:include href="../../../COMMON/PORT.xml" />
 <macro name="ADDR" pattern="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$" description="IP address of the device" hasDefault="NO" />
 <xi:include href="../../../COMMON/BAUD9600.xml" />
+<macro name="APPLICATION" pattern="^(|LITRON)$" description="Whether to load application specific DBs" defaultValue="" hasDefault="YES" />
 </macros>
 <pvsets>
 </pvsets>

--- a/DG645/iocBoot/iocDG645-IOC-01/config.xml
+++ b/DG645/iocBoot/iocDG645-IOC-01/config.xml
@@ -8,7 +8,7 @@
 <xi:include href="../../../COMMON/PORT.xml" />
 <macro name="ADDR" pattern="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$" description="IP address of the device" hasDefault="NO" />
 <xi:include href="../../../COMMON/BAUD9600.xml" />
-<macro name="APPLICATION" pattern="^(|LITRON)$" description="Whether to load application specific DBs" defaultValue="" hasDefault="YES" />
+<macro name="APPLICATION" pattern="^(|LITRON)$" description="Whether to load application specific DBs e.g Litron Laser Timing" defaultValue="" hasDefault="YES" />
 </macros>
 <pvsets>
 </pvsets>

--- a/DG645/iocBoot/iocDG645-IOC-01/st-common.cmd
+++ b/DG645/iocBoot/iocDG645-IOC-01/st-common.cmd
@@ -14,6 +14,7 @@ $(IFRECSIM) drvAsynSerialPortConfigure("$(DEVICE)", "$(PORT=NUL)", 0, 1, 0, 0)
 
 stringiftest("SERIAL", "$(INTERFACE=SERIAL)", 5, "SERIAL")
 stringiftest("ETHERNET", "$(INTERFACE=SERIAL)", 5, "ETHERNET")
+stringiftest("LITRON", "$(APPLICATION=)", 5, "LITRON")
 
 $(IFETHERNET) $(IFNOTDEVSIM) $(IFNOTRECSIM) drvAsynIPPortConfigure("$(DEVICE)", "$(ADDR=):5024 COM")
 $(IFSERIAL) $(IFNOTDEVSIM) $(IFNOTRECSIM) drvAsynSerialPortConfigure("$(DEVICE)", "$(PORT=NO_PORT_MACRO)", 0, 0, 0, 0)
@@ -53,6 +54,8 @@ dbLoadRecordsList("$(DG645)/db/dg645_logic.db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVP
 dbLoadRecordsList("$(DG645)/db/dg645_delay.db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX),R=$(IOCNAME):,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),PORT=$(ASYNPORT)", "Q", "T0;T1;A;B;C;D;E;F;G;H", ";")
 dbLoadRecordsList("$(DG645)/db/dg645_width.db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX),R=$(IOCNAME):,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),PORT=$(ASYNPORT)", "Q", "TRG;AB;CD;EF;GH", ";")
 dbLoadRecordsList("$(DG645)/db/dg645_delay_width_shared.db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX),R=$(IOCNAME):,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),PORT=$(ASYNPORT)", "Q", "T0;T1;A;B;C;D;E;F;G;H;TRG;AB;CD;EF;GH", ";")
+
+$(IFLITRON) dbLoadRecords("$(DG645)/db/litron.db", "PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX),R=$(IOCNAME):,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),PORT=$(ASYNPORT)")
 
 ## load autosave configMenu for managing sets of PVs
 dbLoadRecords("$(AUTOSAVE)/db/configMenu.db","P=$(MYPVPREFIX)AS:$(IOCNAME):,CONFIG=dgconfig")


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/6090 for original ticket.
See https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Litron-Laser-Timing-Control-(Stanford-DG645) for newly created wiki page.

This creates a new macro in the DG645 IOC that allows for a litron laser timing control 'mode'. Using this will load an extra db file which allows the use of extra PVs for this use case.

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
