### PR TITLE
Ticket8704: Range change timer

### DIFF
--- a/G3HALLPR/iocBoot/iocG3HALLPR-IOC-01/st-common.cmd
+++ b/G3HALLPR/iocBoot/iocG3HALLPR-IOC-01/st-common.cmd
@@ -33,9 +33,9 @@ epicsEnvSet("P", "$(MYPVPREFIX)$(IOCNAME):")
 ## Load our record instances
 dbLoadRecords("$(G3HALLPR)/db/group3hallprobe.db","PVPREFIX=$(MYPVPREFIX),P=$(P),RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),PORT=$(DEVICE)")
 
-dbLoadRecords("$(G3HALLPR)/db/group3hallprobe_probe.db","P=$(P),SENSORID=0,ADDR=$(ADDR0=0),PORT=$(DEVICE),NAME=$(NAME0=probe0),SCALE=$(SCALE0=1),FIELD_SCAN_RATE=$(FIELD_SCAN_RATE=1 second),TEMP_SCAN_RATE=$(TEMP_SCAN_RATE=5 second),FLNK=$(FLNK0=)")
-dbLoadRecords("$(G3HALLPR)/db/group3hallprobe_probe.db","P=$(P),SENSORID=1,ADDR=$(ADDR1=1),PORT=$(DEVICE),NAME=$(NAME1=probe1),SCALE=$(SCALE1=1),FIELD_SCAN_RATE=$(FIELD_SCAN_RATE=1 second),TEMP_SCAN_RATE=$(TEMP_SCAN_RATE=5 second),FLNK=$(FLNK1=)")
-dbLoadRecords("$(G3HALLPR)/db/group3hallprobe_probe.db","P=$(P),SENSORID=2,ADDR=$(ADDR2=2),PORT=$(DEVICE),NAME=$(NAME2=probe2),SCALE=$(SCALE2=1),FIELD_SCAN_RATE=$(FIELD_SCAN_RATE=1 second),TEMP_SCAN_RATE=$(TEMP_SCAN_RATE=5 second),FLNK=$(FLNK2=)")
+dbLoadRecords("$(G3HALLPR)/db/group3hallprobe_probe.db","PVPREFIX=$(MYPVPREFIX),IOCNAME=$(IOCNAME),P=$(P),SENSORID=0,ADDR=$(ADDR0=0),PORT=$(DEVICE),NAME=$(NAME0=probe0),SCALE=$(SCALE0=1),FIELD_SCAN_RATE=$(FIELD_SCAN_RATE=1 second),TEMP_SCAN_RATE=$(TEMP_SCAN_RATE=5 second),FLNK=$(FLNK0=)")
+dbLoadRecords("$(G3HALLPR)/db/group3hallprobe_probe.db","PVPREFIX=$(MYPVPREFIX),IOCNAME=$(IOCNAME),P=$(P),SENSORID=1,ADDR=$(ADDR1=1),PORT=$(DEVICE),NAME=$(NAME1=probe1),SCALE=$(SCALE1=1),FIELD_SCAN_RATE=$(FIELD_SCAN_RATE=1 second),TEMP_SCAN_RATE=$(TEMP_SCAN_RATE=5 second),FLNK=$(FLNK1=)")
+dbLoadRecords("$(G3HALLPR)/db/group3hallprobe_probe.db","PVPREFIX=$(MYPVPREFIX),IOCNAME=$(IOCNAME),P=$(P),SENSORID=2,ADDR=$(ADDR2=2),PORT=$(DEVICE),NAME=$(NAME2=probe2),SCALE=$(SCALE2=1),FIELD_SCAN_RATE=$(FIELD_SCAN_RATE=1 second),TEMP_SCAN_RATE=$(TEMP_SCAN_RATE=5 second),FLNK=$(FLNK2=)")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd

--- a/IPS/IPS-IOC-01App/Db/ips.db
+++ b/IPS/IPS-IOC-01App/Db/ips.db
@@ -554,6 +554,47 @@ record(ai, "$(P)MAGNET:INDUCTANCE") {
   info(archive, "VAL")
 }
 
+# --------------- The following work around limitation of getting legacy status from SCPI protocol -------------
+
+# Get the status DWORD from each group UID
+record(mbbiDirect, "$(P)GET:MAGNET:SUPPLY:STATUS") {
+  field(DESC, "Examine status")
+  field(DTYP, "stream")
+  field(INP, "@OxInstIPS.protocol getMagnetSupplyStatus($(P)) $(PORT)")
+  field(NOBT, "32")
+  field(SCAN, "1 second")
+
+  field(SIML, "$(P)SIM")
+  field(SIOL, "$(P)SIM:DONOTHING")
+  field(SDIS, "$(P)DISABLE")
+}
+
+# Determine the quench status from the supply status bit
+record(bi, "$(P)MAGNET:SUPPLY:STATUS:QUENCHED") {
+  field(DESC, "Quench status")
+  field(DTYP, "Soft Channel")
+  field(SCAN, "Passive")
+  field(INP, "$(P)GET:MAGNET:SUPPLY:STATUS.B8 CP MS")
+  field(ZNAM, "No")
+  field(ONAM, "Yes")
+  field(ZSV,  "NO_ALARM")
+  field(OSV,  "MAJOR")
+}
+
+# The over temperature status should be an or'd output from the numerous temperature alarms
+record(bi, "$(P)MAGNET:SUPPLY:STATUS:OVERTEMP") {
+  field(DESC, "Temperature status")
+  field(DTYP, "Soft Channel")
+  field(SCAN, "Passive")
+  field(INP, "$(P)GET:MAGNET:SUPPLY:STATUS.B4 CP MS")
+  field(ZNAM, "No")
+  field(ONAM, "Yes")
+  field(ZSV,  "NO_ALARM")
+  field(OSV,  "MAJOR")
+}
+
+# --------------------------------------------------------------------------------------------------------------
+
 # # Run the Examine Status command, X.
 # The reply comes back and is split amongst other records.
 record(stringin, "$(P)GET:STATUS") {


### PR DESCRIPTION
### Description of work
For Group3 Hall Probe, Inhibit taking field readings for two seconds after a range change.

A patch has already been deployed to HIFI and testing is underway.

### To test

8704

### Acceptance criteria

EPICS records in group3hallprobe_probe.db OK
New macros provided in st-common.cmd OK

---

#### Code Review

- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
