### PR TITLE
Added litron logic to st.common and added macro to pass in buffer size

### DIFF
--- a/LITRON/iocBoot/iocLITRON-IOC-01/config.xml
+++ b/LITRON/iocBoot/iocLITRON-IOC-01/config.xml
@@ -5,6 +5,7 @@
 <ioc_details>Uses LVREMOTE to control LabVIEW VI of Litron Laser</ioc_details>
 <macros>
 <xi:include href="../../../COMMON/PORT.xml" />
+<macro name="STALE_TIME" pattern="^(0|[1-9]\d+)$" description="Number of seconds with identical value before assuming wavelength is stale." hasDefault="YES" defaultValue="10"/>
 <macro name="IPADDR" pattern="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$" description="IP Address of machine running VI" hasDefault="NO" />
 <macro name="VI_PATH" pattern="^([A-Z]:|~)*(\/[\w \.]+)+\/$" description="File path of the VI using / separation (e.g. 'C:/path/to/Vi/' )." hasDefault="YES" defaultValue="C:/labview modules/Instruments/HIFI/HIFI Laser/HIFI Laser - FrontPanel.vi"/>
 </macros>

--- a/LITRON/iocBoot/iocLITRON-IOC-01/st-common.cmd
+++ b/LITRON/iocBoot/iocLITRON-IOC-01/st-common.cmd
@@ -30,6 +30,7 @@ $(IFNOTRECSIM) epicsThreadSleep(5)
 
 ## Load our record instances
 dbLoadRecords("$(LITRON)/db/litron.db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX)$(IOCNAME):,RECSIM=$(RECSIM=0),IFNOTRECSIM=$(IFNOTRECSIM),VI_PATH=$(VI_PATH=C:/labview modules/Instruments/HIFI/HIFI Laser/HIFI Laser - FrontPanel.vi),NUM_PORT=$(NUM_PORT),DISABLE=$(DISABLE=0),PORT=$(DEVICE)")
+dbLoadRecords("$(LITRON)/db/litron_logic.db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX)$(IOCNAME):,RECSIM=$(RECSIM=0),IFNOTRECSIM=$(IFNOTRECSIM),BUFFER_SIZE=$(STALE_TIME=10)")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd


### PR DESCRIPTION
### Description of work
Added Litron_logic db to St common, and added `STALE_TIME` macro to set the size of buffer (number of reads and therefore seconds) that must have the same value in order to be considered stale.

[### To test](https://github.com/ISISComputingGroup/IBEX/issues/8687)

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://isiscomputinggroup.github.io/ibex_developers_manual/Specific-IOCs.html)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/conventions/PV-Naming.html).
    - [Disable records](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/testing/Disable-records.html)
    - [Record simulation](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/testing/Record-Simulation.html)
    - [Finishing touches](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/creation/IOC-Finishing-Touches.html)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://isiscomputinggroup.github.io/ibex_developers_manual/client/opis/OPI-Creation.html)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/compiling/Reducing-Build-Dependencies.html)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/tips_tricks/Flow-control.html).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://isiscomputinggroup.github.io/ibex_developers_manual/processes/git_and_github/Git-workflow.html) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
