### PR TITLE
Fix modbus data types

### DIFF
--- a/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-comms-modbus.cmd
+++ b/EUROTHRM/iocBoot/iocEUROTHRM-IOC-01/st-comms-modbus.cmd
@@ -30,35 +30,35 @@ modbusInterposeConfig("L0", 1, 2000, 4)
 #                        pollMsec, 
 #                        plcType);
 
-drvModbusAsynConfigure("MODBUS_RX_01","L0", 1, 3, -1, 1, 4, 1000, "")
-drvModbusAsynConfigure("MODBUS_TX_01","L0", 1, 6, -1, 1, 4, 0, "")
+drvModbusAsynConfigure("MODBUS_RX_01","L0", 1, 3, -1, 1, "INT16", 1000, "")
+drvModbusAsynConfigure("MODBUS_TX_01","L0", 1, 6, -1, 1, "INT16", 0, "")
 										    
-drvModbusAsynConfigure("MODBUS_RX_02","L0", 2, 3, -1, 1, 4, 1000, "")
-drvModbusAsynConfigure("MODBUS_TX_02","L0", 2, 6, -1, 1, 4, 0, "")
+drvModbusAsynConfigure("MODBUS_RX_02","L0", 2, 3, -1, 1, "INT16", 1000, "")
+drvModbusAsynConfigure("MODBUS_TX_02","L0", 2, 6, -1, 1, "INT16", 0, "")
 										    
-drvModbusAsynConfigure("MODBUS_RX_03","L0", 3, 3, -1, 1, 4, 1000, "")
-drvModbusAsynConfigure("MODBUS_TX_03","L0", 3, 6, -1, 1, 4, 0, "")
+drvModbusAsynConfigure("MODBUS_RX_03","L0", 3, 3, -1, 1, "INT16", 1000, "")
+drvModbusAsynConfigure("MODBUS_TX_03","L0", 3, 6, -1, 1, "INT16", 0, "")
 										    
-drvModbusAsynConfigure("MODBUS_RX_04","L0", 4, 3, -1, 1, 4, 1000, "")
-drvModbusAsynConfigure("MODBUS_TX_04","L0", 4, 6, -1, 1, 4, 0, "")
+drvModbusAsynConfigure("MODBUS_RX_04","L0", 4, 3, -1, 1, "INT16", 1000, "")
+drvModbusAsynConfigure("MODBUS_TX_04","L0", 4, 6, -1, 1, "INT16", 0, "")
 										    
-drvModbusAsynConfigure("MODBUS_RX_05","L0", 5, 3, -1, 1, 4, 1000, "")
-drvModbusAsynConfigure("MODBUS_TX_05","L0", 5, 6, -1, 1, 4, 0, "")
+drvModbusAsynConfigure("MODBUS_RX_05","L0", 5, 3, -1, 1, "INT16", 1000, "")
+drvModbusAsynConfigure("MODBUS_TX_05","L0", 5, 6, -1, 1, "INT16", 0, "")
 
-drvModbusAsynConfigure("MODBUS_RX_06","L0", 6, 3, -1, 1, 4, 1000, "")
-drvModbusAsynConfigure("MODBUS_TX_06","L0", 6, 6, -1, 1, 4, 0, "")
+drvModbusAsynConfigure("MODBUS_RX_06","L0", 6, 3, -1, 1, "INT16", 1000, "")
+drvModbusAsynConfigure("MODBUS_TX_06","L0", 6, 6, -1, 1, "INT16", 0, "")
 
-drvModbusAsynConfigure("MODBUS_RX_07","L0", 7, 3, -1, 1, 4, 1000, "")
-drvModbusAsynConfigure("MODBUS_TX_07","L0", 7, 6, -1, 1, 4, 0, "")
+drvModbusAsynConfigure("MODBUS_RX_07","L0", 7, 3, -1, 1, "INT16", 1000, "")
+drvModbusAsynConfigure("MODBUS_TX_07","L0", 7, 6, -1, 1, "INT16", 0, "")
 
-drvModbusAsynConfigure("MODBUS_RX_08","L0", 8, 3, -1, 1, 4, 1000, "")
-drvModbusAsynConfigure("MODBUS_TX_08","L0", 8, 6, -1, 1, 4, 0, "")
+drvModbusAsynConfigure("MODBUS_RX_08","L0", 8, 3, -1, 1, "INT16", 1000, "")
+drvModbusAsynConfigure("MODBUS_TX_08","L0", 8, 6, -1, 1, "INT16", 0, "")
 
-drvModbusAsynConfigure("MODBUS_RX_09","L0", 9, 3, -1, 1, 4, 1000, "")
-drvModbusAsynConfigure("MODBUS_TX_09","L0", 9, 6, -1, 1, 4, 0, "")
+drvModbusAsynConfigure("MODBUS_RX_09","L0", 9, 3, -1, 1, "INT16", 1000, "")
+drvModbusAsynConfigure("MODBUS_TX_09","L0", 9, 6, -1, 1, "INT16", 0, "")
 
-drvModbusAsynConfigure("MODBUS_RX_10","L0", 10, 3, -1, 1, 4, 1000, "")
-drvModbusAsynConfigure("MODBUS_TX_10","L0", 10, 6, -1, 1, 4, 0, "")
+drvModbusAsynConfigure("MODBUS_RX_10","L0", 10, 3, -1, 1, "INT16", 1000, "")
+drvModbusAsynConfigure("MODBUS_TX_10","L0", 10, 6, -1, 1, "INT16", 0, "")
 
 #asynSetTraceMask("L0", -1, 0x9)
 #asynSetTraceIOMask("L0", -1, 0x2)

--- a/MOXA12XX/iocBoot/iocMOXA12XX-IOC-01/st-e1210.cmd
+++ b/MOXA12XX/iocBoot/iocMOXA12XX-IOC-01/st-e1210.cmd
@@ -1,7 +1,7 @@
 ### E1210 (16 DI) ###
 
 # MOXA E1210 DIs (if NOT counter mode) : function 2 (Read Discrete Inputs), address 0x0, length 16, data_type = UINT16 = 0, # pollMsec = for read func, waits XXX msecs
-drvModbusAsynConfigure("$(E12XX_ASYNPORT)_DI",             "$(E12XX_ASYNPORT)", 0, 2, 0x0,   0x10, 0, 100, "ioLogik")
+drvModbusAsynConfigure("$(E12XX_ASYNPORT)_DI",             "$(E12XX_ASYNPORT)", 0, 2, 0x0,   0x10, "UINT16", 100, "ioLogik")
 
 ##ISIS## Load common DB records
 < $(IOCSTARTUP)/dbload.cmd

--- a/MOXA12XX/iocBoot/iocMOXA12XX-IOC-01/st-e1240.cmd
+++ b/MOXA12XX/iocBoot/iocMOXA12XX-IOC-01/st-e1240.cmd
@@ -1,20 +1,20 @@
 # MOXA E1240 AIs: function 4, address 0x0, 0x8 words , data_type = UINT16 = 0,
-drvModbusAsynConfigure("$(E12XX_ASYNPORT)_AI", "$(E12XX_ASYNPORT)", 0, 4, 0x000, 0x8, 0, 100, "ioLogik")
+drvModbusAsynConfigure("$(E12XX_ASYNPORT)_AI", "$(E12XX_ASYNPORT)", 0, 4, 0x000, 0x8, "UINT16", 100, "ioLogik")
 
 # MOXA E1240 Current mode status: function 4, address 0x3c, 0x8 words , data_type = UINT16 = 0,
-drvModbusAsynConfigure("$(E12XX_ASYNPORT)_AI_St", "$(E12XX_ASYNPORT)", 0, 4, 0x3c, 0x8, 0, 500, "ioLogik")
+drvModbusAsynConfigure("$(E12XX_ASYNPORT)_AI_St", "$(E12XX_ASYNPORT)", 0, 4, 0x3c, 0x8, "UINT16", 500, "ioLogik")
 
 # MOXA E1240 Current mode settings read: function 3, address 0x18, 0x8 words , data_type = UINT16 = 0,
-drvModbusAsynConfigure("$(E12XX_ASYNPORT)_AIMR", "$(E12XX_ASYNPORT)", 0, 3, 0x18, 0x8, 0, 500, "ioLogik")
+drvModbusAsynConfigure("$(E12XX_ASYNPORT)_AIMR", "$(E12XX_ASYNPORT)", 0, 3, 0x18, 0x8, "UINT16", 500, "ioLogik")
 
 # MOXA E1240 Current mode settings write: function 6, address 0x18, 0x8 words , data_type = UINT16 = 0,
-drvModbusAsynConfigure("$(E12XX_ASYNPORT)_AIMW", "$(E12XX_ASYNPORT)", 0, 6, 0x18, 0x8, 0, 1, "ioLogik")
+drvModbusAsynConfigure("$(E12XX_ASYNPORT)_AIMW", "$(E12XX_ASYNPORT)", 0, 6, 0x18, 0x8, "UINT16", 1, "ioLogik")
 
 # MOXA E1240 Burn out value read (float - two words): function 3, address 0x28, 0x8 double words => 0x10, data_type = FLOAT32_LE = 7,
-drvModbusAsynConfigure("$(E12XX_ASYNPORT)_BOR", "$(E12XX_ASYNPORT)", 0, 3, 0x0028, 0x10, 7, 500, "ioLogik")
+drvModbusAsynConfigure("$(E12XX_ASYNPORT)_BOR", "$(E12XX_ASYNPORT)", 0, 3, 0x0028, 0x10, "FLOAT32_LE", 500, "ioLogik")
 
 # MOXA E1240 Burn out value write (float - two words): function 16 write multiple regs, address 0x28, 0x8 double words => 0x10 , data_type = FLOAT32_LE = 7,
-drvModbusAsynConfigure("$(E12XX_ASYNPORT)_BOW", "$(E12XX_ASYNPORT)", 0, 16, 0x0028, 0x10, 7, 1, "ioLogik")
+drvModbusAsynConfigure("$(E12XX_ASYNPORT)_BOW", "$(E12XX_ASYNPORT)", 0, 16, 0x0028, 0x10, "FLOAT32_LE", 1, "ioLogik")
 
 
 ##ISIS## Load common DB records

--- a/MOXA12XX/iocBoot/iocMOXA12XX-IOC-01/st-e1242.cmd
+++ b/MOXA12XX/iocBoot/iocMOXA12XX-IOC-01/st-e1242.cmd
@@ -1,23 +1,23 @@
 # MOXA E1242 DIs: function 2 (Read Discrete Inputs), address 0x0, length 0x8, data_type = UINT16 = 0, # pollMsec = for read func, waits XXX msecs
-drvModbusAsynConfigure("$(E12XX_ASYNPORT)_DI", "$(E12XX_ASYNPORT)", 0, 2, 0x0,   0x8, 0, 100, "ioLogik")
+drvModbusAsynConfigure("$(E12XX_ASYNPORT)_DI", "$(E12XX_ASYNPORT)", 0, 2, 0x0,   0x8, "UINT16", 100, "ioLogik")
 
 # MOXA E1242 AIs: function 4 (Read Input Registers), address 0x200, 0x4 words , data_type = UINT16 = 0, 
-drvModbusAsynConfigure("$(E12XX_ASYNPORT)_AI", "$(E12XX_ASYNPORT)", 0, 4, 0x200, 0x4, 0, 100, "ioLogik")
+drvModbusAsynConfigure("$(E12XX_ASYNPORT)_AI", "$(E12XX_ASYNPORT)", 0, 4, 0x200, 0x4, "UINT16", 100, "ioLogik")
 
 # MOXA E1242 Current mode status: function 4, address 0x240, 0x4 words , data_type = UINT16 = 0, 
-drvModbusAsynConfigure("$(E12XX_ASYNPORT)_AI_St", "$(E12XX_ASYNPORT)", 0, 4, 0x0240, 0x4, 0, 500, "ioLogik")
+drvModbusAsynConfigure("$(E12XX_ASYNPORT)_AI_St", "$(E12XX_ASYNPORT)", 0, 4, 0x0240, 0x4, "UINT16", 500, "ioLogik")
 
 # MOXA E1242 Current mode settings read: function 3, address 0x220, 0x4 words , data_type = UINT16 = 0, 
-drvModbusAsynConfigure("$(E12XX_ASYNPORT)_AIMR", "$(E12XX_ASYNPORT)", 0, 3, 0x0220, 0x4, 0, 500, "ioLogik")
+drvModbusAsynConfigure("$(E12XX_ASYNPORT)_AIMR", "$(E12XX_ASYNPORT)", 0, 3, 0x0220, 0x4, "UINT16", 500, "ioLogik")
 
 # MOXA E1242 Current mode settings write: function 6, address 0x220, 0x4 double words => 0x8, data_type = UINT16 = 0, 
-drvModbusAsynConfigure("$(E12XX_ASYNPORT)_AIMW", "$(E12XX_ASYNPORT)", 0, 6, 0x0220, 0x4, 0, 1, "ioLogik")
+drvModbusAsynConfigure("$(E12XX_ASYNPORT)_AIMW", "$(E12XX_ASYNPORT)", 0, 6, 0x0220, 0x4, "UINT16", 1, "ioLogik")
 
 # MOXA E1242 Burn out value read (float - two words): function 3, address 0x230, 0x4 double words => 0x8, data_type = FLOAT32_LE = 7, 
-drvModbusAsynConfigure("$(E12XX_ASYNPORT)_BOR", "$(E12XX_ASYNPORT)", 0, 3, 0x0230, 0x8, 7, 500, "ioLogik")
+drvModbusAsynConfigure("$(E12XX_ASYNPORT)_BOR", "$(E12XX_ASYNPORT)", 0, 3, 0x0230, 0x8, "FLOAT32_LE", 500, "ioLogik")
 
 # MOXA E1242 Burn out value write (float - two words): function 16 write multiple regs, address 0x230, 0x4 double words => 0x8 , data_type = FLOAT32_LE = 7, 
-drvModbusAsynConfigure("$(E12XX_ASYNPORT)_BOW", "$(E12XX_ASYNPORT)", 0, 16, 0x0230, 0x8, 7, 1, "ioLogik")
+drvModbusAsynConfigure("$(E12XX_ASYNPORT)_BOW", "$(E12XX_ASYNPORT)", 0, 16, 0x0230, 0x8, "FLOAT32_LE", 1, "ioLogik")
 
 
 ##ISIS## Load common DB records

--- a/MOXA12XX/iocBoot/iocMOXA12XX-IOC-01/st-e1262.cmd
+++ b/MOXA12XX/iocBoot/iocMOXA12XX-IOC-01/st-e1262.cmd
@@ -1,5 +1,5 @@
 # MOXA E1262 AIs: function 4, address 0x810, 2 words => 0x10, data_type = FLOAT32_LE = 7,
-drvModbusAsynConfigure("$(E12XX_ASYNPORT)_AI", "$(E12XX_ASYNPORT)", 0, 4, 0x810, 0x10, 7, 500, "ioLogik")
+drvModbusAsynConfigure("$(E12XX_ASYNPORT)_AI", "$(E12XX_ASYNPORT)", 0, 4, 0x810, 0x10, "FLOAT32_LE", 500, "ioLogik")
 
 ##ISIS## Load common DB records
 < $(IOCSTARTUP)/dbload.cmd

--- a/PRE4500/iocBoot/iocPRE4500-IOC-01/st-comms-modbus.cmd
+++ b/PRE4500/iocBoot/iocPRE4500-IOC-01/st-comms-modbus.cmd
@@ -29,13 +29,13 @@ modbusInterposeConfig("L0", 1, 2000, 4)
 #                        pollMsec, 
 #                        plcType);
 
-drvModbusAsynConfigure("L0MODBUS_RX_01","L0", 1, 3, 1001, 1, 4, 1000, "")
+drvModbusAsynConfigure("L0MODBUS_RX_01","L0", 1, 3, 1001, 1, "INT16", 1000, "")
 										    
-drvModbusAsynConfigure("L0MODBUS_RX_02","L0", 2, 3, 1001, 1, 4, 1000, "")
+drvModbusAsynConfigure("L0MODBUS_RX_02","L0", 2, 3, 1001, 1, "INT16", 1000, "")
 										    
-drvModbusAsynConfigure("L0MODBUS_RX_03","L0", 3, 3, 1001, 1, 4, 1000, "")
+drvModbusAsynConfigure("L0MODBUS_RX_03","L0", 3, 3, 1001, 1, "INT16", 1000, "")
 										    
-drvModbusAsynConfigure("L0MODBUS_RX_04","L0", 4, 3, 1001, 1, 4, 1000, "")
+drvModbusAsynConfigure("L0MODBUS_RX_04","L0", 4, 3, 1001, 1, "INT16", 1000, "")
 
 asynSetTraceMask("L0", -1, 0x0)
 asynSetTraceIOMask("L0", -1, 0x0)

--- a/SCHNDR/iocBoot/iocSCHNDR-IOC-01/devices/GEMGateValve.cmd
+++ b/SCHNDR/iocBoot/iocSCHNDR-IOC-01/devices/GEMGateValve.cmd
@@ -13,8 +13,8 @@
 ## but is for RTU/ASCII
 ## subtract 40001 offset from 4x register addresses that are read by code 3
 ## addresss here are 41315 and 40650
-drvModbusAsynConfigure("$(PLC)heartbeat", "$(PLC)", 1, 3, 649, 1, 0, 1000, "PLC")
-drvModbusAsynConfigure("$(PLC)gatevalve", "$(PLC)", 1, 3, 1314, 1, 0, 1000, "PLC")
+drvModbusAsynConfigure("$(PLC)heartbeat", "$(PLC)", 1, 3, 649, 1, "UINT16", 1000, "PLC")
+drvModbusAsynConfigure("$(PLC)gatevalve", "$(PLC)", 1, 3, 1314, 1, "UINT16", 1000, "PLC")
 
 ## Load our record instances
 dbLoadRecords("$(TOP)/db/GEMGateValve.db","P=$(MYPVPREFIX)$(IOCNAME):,PORT=$(PLC),R=")

--- a/SCHNDR/iocBoot/iocSCHNDR-IOC-01/devices/RIKENFE.cmd
+++ b/SCHNDR/iocBoot/iocSCHNDR-IOC-01/devices/RIKENFE.cmd
@@ -25,7 +25,7 @@ $(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)solenoid_status",              "$(P
 #       (1.6.a & 1.6.b additional sub-sections created for ease of programming and efficiency of reading PLC memory in blocks)
 
 # 1.6.1 Kickers General Status
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)kickers_status",                "$(PLC)", 255, 3, 4004,  "INT16", "UINT16", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4004
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)kickers_status",                "$(PLC)", 255, 3, 4004,  4, "UINT16", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4004
 
 # 1.6.a Kickers 1-4 Readback Status
 $(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)kickers_1-4_status"            "$(PLC)", 255, 3, 4007, 20, "UINT16", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4007

--- a/SCHNDR/iocBoot/iocSCHNDR-IOC-01/devices/RIKENFE.cmd
+++ b/SCHNDR/iocBoot/iocSCHNDR-IOC-01/devices/RIKENFE.cmd
@@ -10,13 +10,13 @@
 # 1.4.1 *_NOT_* TODO PSU Control (PSUs controlled via separate IOCs)
 
 # 1.4.2 Separator Vacuum Interlock Status
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)separator_status",             "$(PLC)", 255, 3, 4000,  3, 0, 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4000
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)separator_status",             "$(PLC)", 255, 3, 4000,  3, "UINT16", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4000
 
 
 # 1.5   Solenoid
 # ===============
 
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)solenoid_status",              "$(PLC)", 255, 3, 4003,  1, 0, 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4003
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)solenoid_status",              "$(PLC)", 255, 3, 4003,  1, "UINT16", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4003
 
 
 # 1.6   Kickers
@@ -25,81 +25,81 @@ $(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)solenoid_status",              "$(P
 #       (1.6.a & 1.6.b additional sub-sections created for ease of programming and efficiency of reading PLC memory in blocks)
 
 # 1.6.1 Kickers General Status
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)kickers_status",                "$(PLC)", 255, 3, 4004,  4, 0, 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4004
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)kickers_status",                "$(PLC)", 255, 3, 4004,  "INT16", "UINT16", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4004
 
 # 1.6.a Kickers 1-4 Readback Status
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)kickers_1-4_status"            "$(PLC)", 255, 3, 4007, 20, 0, 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4007
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)kickers_1-4_status"            "$(PLC)", 255, 3, 4007, 20, "UINT16", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4007
 
 # 1.6.b Kickers 1-4 Output
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)kickers_1-4_output"            "$(PLC)", 255, 3, 4500, 16, 7, 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4500
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)kickers_1-4_output"            "$(PLC)", 255, 3, 4500, 16, "FLOAT32_LE", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4500
 
 # 2     Vacuum
 # =============
 
 # 2.1   Vacuum Status
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)vacuum_status",                "$(PLC)", 255, 3, 4027, 44, 0, 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4027
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)vacuum_status",                "$(PLC)", 255, 3, 4027, 44, "UINT16", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4027
 
 # 2.2   Vacuum Valve Status
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)vacuum_valve_status",          "$(PLC)", 255, 3, 4071, 21, 0, 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4071
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)vacuum_valve_status",          "$(PLC)", 255, 3, 4071, 21, "UINT16", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4071
 
 # 2.3   Vacuum Valve Controls
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)lv1_vacuum_valve_open",        "$(PLC)", 255, 5,  638,  1, 0,    0, "Schneider M580 PLC")         # IEC61131 start address: %MW0638
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)lv2_vacuum_valve_open",        "$(PLC)", 255, 5,  639,  1, 0,    0, "Schneider M580 PLC")         # IEC61131 start address: %MW0639
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)lv3_vacuum_valve_open",        "$(PLC)", 255, 5,  640,  1, 0,    0, "Schneider M580 PLC")         # IEC61131 start address: %MW0640
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)lv4_vacuum_valve_open",        "$(PLC)", 255, 5,  643,  1, 0,    0, "Schneider M580 PLC")         # IEC61131 start address: %MW0643
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)lv5_vacuum_valve_open",        "$(PLC)", 255, 5,  644,  1, 0,    0, "Schneider M580 PLC")         # IEC61131 start address: %MW0644
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)lv6_vacuum_valve_open",        "$(PLC)", 255, 5,  645,  1, 0,    0, "Schneider M580 PLC")         # IEC61131 start address: %MW0645
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)lv7_vacuum_valve_open",        "$(PLC)", 255, 5,  702,  1, 0,    0, "Schneider M580 PLC")         # IEC61131 start address: %MW0702
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)amgv_vacuum_valve_open",       "$(PLC)", 255, 5,  651,  1, 0,    0, "Schneider M580 PLC")         # IEC61131 start address: %MW0651
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)fsov_vacuum_valve_open",       "$(PLC)", 255, 5,  652,  1, 0,    0, "Schneider M580 PLC")         # IEC61131 start address: %MW0652
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)lv1_vacuum_valve_open",        "$(PLC)", 255, 5,  638,  1, "UINT16",    0, "Schneider M580 PLC")         # IEC61131 start address: %MW0638
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)lv2_vacuum_valve_open",        "$(PLC)", 255, 5,  639,  1, "UINT16",    0, "Schneider M580 PLC")         # IEC61131 start address: %MW0639
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)lv3_vacuum_valve_open",        "$(PLC)", 255, 5,  640,  1, "UINT16",    0, "Schneider M580 PLC")         # IEC61131 start address: %MW0640
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)lv4_vacuum_valve_open",        "$(PLC)", 255, 5,  643,  1, "UINT16",    0, "Schneider M580 PLC")         # IEC61131 start address: %MW0643
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)lv5_vacuum_valve_open",        "$(PLC)", 255, 5,  644,  1, "UINT16",    0, "Schneider M580 PLC")         # IEC61131 start address: %MW0644
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)lv6_vacuum_valve_open",        "$(PLC)", 255, 5,  645,  1, "UINT16",    0, "Schneider M580 PLC")         # IEC61131 start address: %MW0645
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)lv7_vacuum_valve_open",        "$(PLC)", 255, 5,  702,  1, "UINT16",    0, "Schneider M580 PLC")         # IEC61131 start address: %MW0702
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)amgv_vacuum_valve_open",       "$(PLC)", 255, 5,  651,  1, "UINT16",    0, "Schneider M580 PLC")         # IEC61131 start address: %MW0651
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)fsov_vacuum_valve_open",       "$(PLC)", 255, 5,  652,  1, "UINT16",    0, "Schneider M580 PLC")         # IEC61131 start address: %MW0652
 
 # 2.4   Vacuum Pump Status
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)vacuum_pump_status",           "$(PLC)", 255, 3, 4092, 22, 0, 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4092
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)vacuum_pump_status",           "$(PLC)", 255, 3, 4092, 22, "UINT16", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4092
 
 # 2.4.1 Vacuum Pump Valve Interlocks (PIV - Pump Isolation Valve)
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)piv_interlock_status",         "$(PLC)", 255, 3, 4114, 12, 0, 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4114
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)piv_interlock_status",         "$(PLC)", 255, 3, 4114, 12, "UINT16", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4114
 
 # 2.4.2 LV Interlocks (LV - Line Valve)
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)lv_interlock_status",          "$(PLC)", 255, 3, 4125,  7, 0, 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4125
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)lv_interlock_status",          "$(PLC)", 255, 3, 4125,  7, "UINT16", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4125
 
 # 2.4.3 Other Valve Interlocks
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)other_valve_interlock_status", "$(PLC)", 255, 3, 4132,  3, 0, 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4132
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)other_valve_interlock_status", "$(PLC)", 255, 3, 4132,  3, "UINT16", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4132
 
 # 2.5   Beam Blocker Status
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)beamblocker_status",           "$(PLC)", 255, 3, 4135,  5, 0, 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4135
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)beamblocker_status",           "$(PLC)", 255, 3, 4135,  5, "UINT16", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4135
 
 # 2.6   Beam Blocker Information
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)beamblocker_information",      "$(PLC)", 255, 3, 4140,  5, 0, 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4140
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)beamblocker_information",      "$(PLC)", 255, 3, 4140,  5, "UINT16", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4140
 
 # 3     PSU Interlocks
 # =====================
 
 # 3.1   Klixon Interlock Status
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)klixon_interlock_status",      "$(PLC)", 255, 3, 4145, 36, 0, 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4145
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)klixon_interlock_status",      "$(PLC)", 255, 3, 4145, 36, "UINT16", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4145
 
 # 3.2   Water Interlock Status
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)water_interlock_status",       "$(PLC)", 255, 3, 4181, 40, 0, 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4181
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)water_interlock_status_extra", "$(PLC)", 255, 3, 4285,  1, 0, 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4285
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)water_interlock_status",       "$(PLC)", 255, 3, 4181, 40, "UINT16", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4181
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)water_interlock_status_extra", "$(PLC)", 255, 3, 4285,  1, "UINT16", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4285
 
 # 3.3   Water Flow Rate
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)water_flow_rate",              "$(PLC)", 255, 3, 4516, 80, 7, 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4516
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)water_flow_rate",              "$(PLC)", 255, 3, 4516, 80, "FLOAT32_LE", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4516
 
 # 3.4   R-Box Interlock Status (R-Box - Rectifier Box)
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)rbox_interlock_status",        "$(PLC)", 255, 3, 4220, 56, 0, 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4220
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)rbox_interlock_status",        "$(PLC)", 255, 3, 4220, 56, "UINT16", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4220
 
 # 3.5   MOL Status (MOL - Magnet Off Light)
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)mol_status",                   "$(PLC)", 255, 3, 4276,  9, 0, 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4276
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)mol_status",                   "$(PLC)", 255, 3, 4276,  9, "UINT16", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4276
 
 # 3.6   *_NOT_* TODO PSU Control / On  (PSUs controlled via separate IOCs)
 
 # 3.7   Water Temperature
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)water_temperature",            "$(PLC)", 255, 3, 4672, 66, 7, 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4672
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)water_temperature",            "$(PLC)", 255, 3, 4672, 66, "FLOAT32_LE", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4672
 
 
 # 4     Temperature monitoring
 # ============================
 
-$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)temperature_monitoring",       "$(PLC)", 255, 3, 4596, 75, 4, 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4596
+$(IFNOTRECSIM) drvModbusAsynConfigure("$(PLC)temperature_monitoring",       "$(PLC)", 255, 3, 4596, 75, "INT16", 1000, "Schneider M580 PLC")         # IEC61131 start address: %MW4596
 
 
 # ----------------------===========================------------------------ #


### PR DESCRIPTION
### Description of work

Fix modbus datatypes after upgrade to 3.x

(Though this PR is part of a larger ticket, it is the only PR that would affects ibex code that is actually run. The other modules that are part of the ticket are example code. Hence putting this one forward early as flash review to fix system tests)  

### To test

See ISISComputingGroup/IBEX#8779

basically check that only the seventh argument to function has changed and the integer has become a string as per maping on ticket
 
### Acceptance criteria

*List the acceptance criteria for the PR*

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://isiscomputinggroup.github.io/ibex_developers_manual/Specific-IOCs.html)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/conventions/PV-Naming.html).
    - [Disable records](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/testing/Disable-records.html)
    - [Record simulation](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/testing/Record-Simulation.html)
    - [Finishing touches](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/creation/IOC-Finishing-Touches.html)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://isiscomputinggroup.github.io/ibex_developers_manual/client/opis/OPI-Creation.html)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/compiling/Reducing-Build-Dependencies.html)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/tips_tricks/Flow-control.html).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://isiscomputinggroup.github.io/ibex_developers_manual/processes/git_and_github/Git-workflow.html) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
