### PR TITLE
make use of epics-snmp passivepoll

### DIFF
--- a/LNDYISW/iocBoot/iocLNDYISW-IOC-01/st-common.cmd
+++ b/LNDYISW/iocBoot/iocLNDYISW-IOC-01/st-common.cmd
@@ -15,6 +15,10 @@ epicsEnvSet("MIBDIRS", "+$(LNDYISW)/mibs")
 ## uncomment for debug messages
 #devSnmpSetParam("DebugLevel", 10)
 
+## Used to handle outlet status
+devSnmpSetParam("PassivePollMSec", 2000)
+devSnmpSetParam("SetSkipReadbackMSec", 8000)
+
 ## need to set snmp version before we load records
 devSnmpSetSnmpVersion("$(HOST)", "SNMP_VERSION_1")
 


### PR DESCRIPTION
### Description of work
enabled use of epics SNMP passive poll

### To test
https://github.com/ISISComputingGroup/IBEX/issues/8736

### Acceptance criteria
Setting two outlet's status back to back no longer causes a race condition where one is reset. (checked in new ioc test, and can be double checked by writing a small script of the form 
```
g.cset("outlet1", "ON")
g.cset("outlet2", "ON")
```
and running it a few times.

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://isiscomputinggroup.github.io/ibex_developers_manual/Specific-IOCs.html)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/conventions/PV-Naming.html).
    - [Disable records](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/testing/Disable-records.html)
    - [Record simulation](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/testing/Record-Simulation.html)
    - [Finishing touches](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/creation/IOC-Finishing-Touches.html)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://isiscomputinggroup.github.io/ibex_developers_manual/client/opis/OPI-Creation.html)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/compiling/Reducing-Build-Dependencies.html)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/tips_tricks/Flow-control.html).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://isiscomputinggroup.github.io/ibex_developers_manual/processes/git_and_github/Git-workflow.html) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
