### PR TITLE
Correct regex to allow default value to pass

### DIFF
--- a/NGEM/iocBoot/iocNGEM-IOC-01/config.xml
+++ b/NGEM/iocBoot/iocNGEM-IOC-01/config.xml
@@ -3,7 +3,7 @@
 	<config_part>
 		<ioc_desc>NGEM detector</ioc_desc>
 		<macros>
-			<macro name ="IPADDR" pattern="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:[0-9]+$" description="IP address and port of the device (default: localhost:61000)" defaultValue="localhost:61000" hasDefault="YES" />
+			<macro name ="IPADDR" pattern="^(localhost|[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+):[0-9]+$" description="IP address and port of the device (default: localhost:61000)" defaultValue="localhost:61000" hasDefault="YES" />
 		</macros>
 	</config_part>
 </ioc_config>


### PR DESCRIPTION
### Description of work
Fixed the REGEX in ngem config.xml to allow the default value (localhost) to pass.
