### PR TITLE
Reduce logging rate

### DIFF
--- a/LKSH218/LKSH218-IOC-01App/Db/Lakeshore218Sensor.template
+++ b/LKSH218/LKSH218-IOC-01App/Db/Lakeshore218Sensor.template
@@ -11,7 +11,7 @@ record(ai, "$(P)TEMP$(SN)")
     field(SIOL, "$(P)SIM:TEMP$(SN)")
     field(EGU, "K")
     info(INTEREST, "HIGH")
-    info(archive, "5.0 VAL")
+    info(archive, "60.0 VAL")
 	info(alarm, "LKSH218")
 }
 
@@ -33,7 +33,7 @@ record(ai, "$(P)SENSOR$(SN)")
     field(SIOL, "$(P)SIM:SENSOR$(SN)")
     field(EGU, "")
     info(INTEREST, "HIGH")
-    info(archive, "5.0 VAL")
+    info(archive, "60.0 VAL")
 	info(alarm, "LKSH218")
 }
 


### PR DESCRIPTION
We cannot log once per 5s with our current disk-space situation. Drop to logging every minute only.