### PR TITLE
Ticket8688 add attributes to eurotherm

### DIFF
--- a/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
+++ b/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
@@ -989,6 +989,175 @@ record(calc, "$(P)TEMP:RANGE:OVER") {
     field(CALC, "B < A")
 }
 
+record(ai, "$(P)AUTOMAN") {
+    field(DESC, "Auto or Manual selected")
+    field(SCAN, "10 second")
+    
+    $(IFUSES_BISYNCH) field(DTYP, "stream")
+    $(IFUSES_BISYNCH) field(INP, "@eurotherm2k.proto read($(P),mA,$(GAD),$(LAD)) $(PORT)")
+    
+    $(IFNOTUSES_BISYNCH) field(DTYP, "asynInt32")
+    $(IFNOTUSES_BISYNCH) field(INP, "@asyn(MODBUS_RX_$(GAD)$(LAD),273,1000)MODBUS_DATA")
+    $(IFNOTUSES_BISYNCH) field(ASLO, "$(TEMP_SCALING)")
+    
+    field(SIML, "$(Q)SIM")
+    field(SIOL, "$(P)SIM:AUTOMAN")
+    field(SDIS, "$(Q)DISABLE")
+    field(PREC, "3")
+}
+
+record(ao, "$(P)AUTOMAN:SP") {
+    field(DESC, "Auto or Manual Setpoint")
+    
+    $(IFUSES_BISYNCH) field(DTYP, "stream")
+    $(IFUSES_BISYNCH) field(OUT, "@eurotherm2k.proto write($(P),mA,$(GAD),$(LAD)) $(PORT)")
+    
+    $(IFNOTUSES_BISYNCH) field(DTYP, "asynInt32")
+    $(IFNOTUSES_BISYNCH) field(OUT, "@asyn(MODBUS_TX_$(GAD)$(LAD),273,1000)MODBUS_DATA")
+    
+    field(SIML, "$(Q)SIM")
+    field(SIOL, "$(P)SIM:AUTOMAN:SP")
+    field(SDIS, "$(Q)DISABLE")
+    field(FLNK, "$(P)AUTOMAN.PROC")
+    field(EGU, "")
+}
+
+record(ai, "$(P)LOWRANGE") {
+    field(DESC, "Low range limit")
+    field(SCAN, "10 second")
+    
+    $(IFUSES_BISYNCH) field(DTYP, "stream")
+    $(IFUSES_BISYNCH) field(INP, "@eurotherm2k.proto read($(P),QC,$(GAD),$(LAD)) $(PORT)")
+    
+    $(IFNOTUSES_BISYNCH) field(DTYP, "asynInt32")
+    $(IFNOTUSES_BISYNCH) field(INP, "@asyn(MODBUS_RX_$(GAD)$(LAD),11,1000)MODBUS_DATA")
+    $(IFNOTUSES_BISYNCH) field(ASLO, "$(TEMP_SCALING)")
+    
+    field(SIML, "$(Q)SIM")
+    field(SIOL, "$(P)SIM:LOWRANGE")
+    field(SDIS, "$(Q)DISABLE")
+    field(PREC, "3")
+}
+
+record(ai, "$(P)HIRANGE") {
+    field(DESC, "High range limit")
+    field(SCAN, "10 second")
+    
+    $(IFUSES_BISYNCH) field(DTYP, "stream")
+    $(IFUSES_BISYNCH) field(INP, "@eurotherm2k.proto read($(P),QB,$(GAD),$(LAD)) $(PORT)")
+    
+    $(IFNOTUSES_BISYNCH) field(DTYP, "asynInt32")
+    $(IFNOTUSES_BISYNCH) field(INP, "@asyn(MODBUS_RX_$(GAD)$(LAD),12,1000)MODBUS_DATA")
+    $(IFNOTUSES_BISYNCH) field(ASLO, "$(TEMP_SCALING)")
+    
+    field(SIML, "$(Q)SIM")
+    field(SIOL, "$(P)SIM:HIRANGE")
+    field(SDIS, "$(Q)DISABLE")
+    field(PREC, "3")
+}
+
+record(ai, "$(P)WORKOUTP") {
+    field(DESC, "Working Output")
+    field(SCAN, "10 second")
+    
+    $(IFUSES_BISYNCH) field(DTYP, "stream")
+    $(IFUSES_BISYNCH) field(INP, "@eurotherm2k.proto read($(P),WO,$(GAD),$(LAD)) $(PORT)")
+    
+    $(IFNOTUSES_BISYNCH) field(DTYP, "asynInt32")
+    $(IFNOTUSES_BISYNCH) field(INP, "@asyn(MODBUS_RX_$(GAD)$(LAD),4,1000)MODBUS_DATA")
+    $(IFNOTUSES_BISYNCH) field(ASLO, "$(TEMP_SCALING)")
+    
+    field(SIML, "$(Q)SIM")
+    field(SIOL, "$(P)SIM:WORKOUTP")
+    field(SDIS, "$(Q)DISABLE")
+    field(PREC, "3")
+}
+
+record(ai, "$(P)OUTLOWLM") {
+    field(DESC, "Low power limit")
+    field(SCAN, "10 second")
+    
+    $(IFUSES_BISYNCH) field(DTYP, "stream")
+    $(IFUSES_BISYNCH) field(INP, "@eurotherm2k.proto read($(P),LO,$(GAD),$(LAD)) $(PORT)")
+    
+    $(IFNOTUSES_BISYNCH) field(DTYP, "asynInt32")
+    $(IFNOTUSES_BISYNCH) field(INP, "@asyn(MODBUS_RX_$(GAD)$(LAD),31,1000)MODBUS_DATA")
+    $(IFNOTUSES_BISYNCH) field(ASLO, "$(TEMP_SCALING)")
+    
+    field(SIML, "$(Q)SIM")
+    field(SIOL, "$(P)SIM:OUTLOWLM")
+    field(SDIS, "$(Q)DISABLE")
+    field(PREC, "3")
+}
+
+record(ai, "$(P)OUTPCOMP") {
+    field(DESC, "Proportional component of output")
+    field(SCAN, "10 second")
+    
+    $(IFUSES_BISYNCH) field(DTYP, "stream")
+    $(IFUSES_BISYNCH) field(INP, "@eurotherm2k.proto read($(P),xP,$(GAD),$(LAD)) $(PORT)")
+    
+    $(IFNOTUSES_BISYNCH) field(DTYP, "asynInt32")
+    $(IFNOTUSES_BISYNCH) field(INP, "@asyn(MODBUS_RX_$(GAD)$(LAD),214,1000)MODBUS_DATA")
+    $(IFNOTUSES_BISYNCH) field(ASLO, "$(TEMP_SCALING)")
+    
+    field(SIML, "$(Q)SIM")
+    field(SIOL, "$(P)SIM:OUTPCOMP")
+    field(SDIS, "$(Q)DISABLE")
+    field(PREC, "3")
+}
+
+record(ai, "$(P)OUTICOMP") {
+    field(DESC, "Integral component of output")
+    field(SCAN, "10 second")
+    
+    $(IFUSES_BISYNCH) field(DTYP, "stream")
+    $(IFUSES_BISYNCH) field(INP, "@eurotherm2k.proto read($(P),xI,$(GAD),$(LAD)) $(PORT)")
+    
+    $(IFNOTUSES_BISYNCH) field(DTYP, "asynInt32")
+    $(IFNOTUSES_BISYNCH) field(INP, "@asyn(MODBUS_RX_$(GAD)$(LAD),55,1000)MODBUS_DATA")
+    $(IFNOTUSES_BISYNCH) field(ASLO, "$(TEMP_SCALING)")
+    
+    field(SIML, "$(Q)SIM")
+    field(SIOL, "$(P)SIM:OUTICOMP")
+    field(SDIS, "$(Q)DISABLE")
+    field(PREC, "3")
+}
+
+record(ai, "$(P)OUTDCOMP") {
+    field(DESC, "Derivative component of output")
+    field(SCAN, "10 second")
+    
+    $(IFUSES_BISYNCH) field(DTYP, "stream")
+    $(IFUSES_BISYNCH) field(INP, "@eurotherm2k.proto read($(P),xD,$(GAD),$(LAD)) $(PORT)")
+    
+    $(IFNOTUSES_BISYNCH) field(DTYP, "asynInt32")
+    $(IFNOTUSES_BISYNCH) field(INP, "@asyn(MODBUS_RX_$(GAD)$(LAD),55,1000)MODBUS_DATA")
+    $(IFNOTUSES_BISYNCH) field(ASLO, "$(TEMP_SCALING)")
+    
+    field(SIML, "$(Q)SIM")
+    field(SIOL, "$(P)SIM:OUTDCOMP")
+    field(SDIS, "$(Q)DISABLE")
+    field(PREC, "3")
+}
+
+record(ai, "$(P)SNBRKPST") {
+    field(DESC, "Sensor break status flag")
+    field(SCAN, "10 second")
+    
+    $(IFUSES_BISYNCH) field(DTYP, "stream")
+    $(IFUSES_BISYNCH) field(INP, "@eurotherm2k.proto read($(P),sb,$(GAD),$(LAD)) $(PORT)")
+    
+    $(IFNOTUSES_BISYNCH) field(DTYP, "asynInt32")
+    $(IFNOTUSES_BISYNCH) field(INP, "@asyn(MODBUS_RX_$(GAD)$(LAD),258,1000)MODBUS_DATA")
+    $(IFNOTUSES_BISYNCH) field(ASLO, "$(TEMP_SCALING)")
+    
+    field(SIML, "$(Q)SIM")
+    field(SIOL, "$(P)SIM:SNBRKPST")
+    field(SDIS, "$(Q)DISABLE")
+    field(PREC, "3")
+}
+
 ### SIMULATION RECORDS ###
 
 record(ai, "$(P)SIM:MAX_OUTPUT")

--- a/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
+++ b/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
@@ -1255,3 +1255,59 @@ record(ai, "$(P)SIM:TEMP:HIGHLIMIT")
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")
 }
+
+record(ai, "$(P)SIM:AUTOMAN")
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+}
+
+alias("$(P)SIM:AUTOMAN","$(P)SIM:AUTOMAN:SP")
+
+record(ai, "$(P)SIM:LOWRANGE")
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+}
+
+record(ai, "$(P)SIM:HIRANGE")
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+}
+
+record(ai, "$(P)SIM:WORKOUTP")
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+}
+
+record(ai, "$(P)SIM:OUTLOWLM")
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+}
+
+record(ai, "$(P)SIM:OUTPCOMP")
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+}
+
+record(ai, "$(P)SIM:OUTICOMP")
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+}
+
+record(ai, "$(P)SIM:OUTDCOMP")
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+}
+
+record(ai, "$(P)SIM:SNBRKPST")
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+}

--- a/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
+++ b/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
@@ -989,7 +989,7 @@ record(calc, "$(P)TEMP:RANGE:OVER") {
     field(CALC, "B < A")
 }
 
-record(ai, "$(P)AUTOMAN") {
+record(bi, "$(P)AUTOMAN") {
     field(DESC, "Auto or Manual selected")
     field(SCAN, "10 second")
     
@@ -1006,7 +1006,7 @@ record(ai, "$(P)AUTOMAN") {
     field(PREC, "3")
 }
 
-record(ao, "$(P)AUTOMAN:SP") {
+record(bo, "$(P)AUTOMAN:SP") {
     field(DESC, "Auto or Manual Setpoint")
     
     $(IFUSES_BISYNCH) field(DTYP, "stream")
@@ -1141,7 +1141,7 @@ record(ai, "$(P)OUTDCOMP") {
     field(PREC, "3")
 }
 
-record(ai, "$(P)SNBRKPST") {
+record(bi, "$(P)SNBRKPST") {
     field(DESC, "Sensor break status flag")
     field(SCAN, "10 second")
     
@@ -1256,7 +1256,7 @@ record(ai, "$(P)SIM:TEMP:HIGHLIMIT")
     field(DTYP, "Soft Channel")
 }
 
-record(ai, "$(P)SIM:AUTOMAN")
+record(bi, "$(P)SIM:AUTOMAN")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")
@@ -1306,7 +1306,7 @@ record(ai, "$(P)SIM:OUTDCOMP")
     field(DTYP, "Soft Channel")
 }
 
-record(ai, "$(P)SIM:SNBRKPST")
+record(bi, "$(P)SIM:SNBRKPST")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")

--- a/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
+++ b/EUROTHRM/EUROTHRM-IOC-01App/Db/devEurothrm.db
@@ -1004,6 +1004,8 @@ record(bi, "$(P)AUTOMAN") {
     field(SIOL, "$(P)SIM:AUTOMAN")
     field(SDIS, "$(Q)DISABLE")
     field(PREC, "3")
+	field(ZNAM, "OFF")
+    field(ONAM, "ON")
 }
 
 record(bo, "$(P)AUTOMAN:SP") {
@@ -1020,6 +1022,8 @@ record(bo, "$(P)AUTOMAN:SP") {
     field(SDIS, "$(Q)DISABLE")
     field(FLNK, "$(P)AUTOMAN.PROC")
     field(EGU, "")
+	field(ZNAM, "OFF")
+    field(ONAM, "ON")
 }
 
 record(ai, "$(P)LOWRANGE") {
@@ -1156,6 +1160,8 @@ record(bi, "$(P)SNBRKPST") {
     field(SIOL, "$(P)SIM:SNBRKPST")
     field(SDIS, "$(Q)DISABLE")
     field(PREC, "3")
+	field(ZNAM, "OFF")
+    field(ONAM, "ON")
 }
 
 ### SIMULATION RECORDS ###


### PR DESCRIPTION
### Description of work

This is the IOC change for additional attributes for Eurotherm OPI required for better debugging.

### To test

[Fixes](https://github.com/ISISComputingGroup/IBEX/issues/8688)

### Acceptance criteria

*List the acceptance criteria for the PR*

- [ ] ** If this PR changes GALIL / GALILMUL ioc are these changes applicable to both the old (`galil-old` branch based) and new (`master` branch based) drivers? If so have [all appropriate PRs been created](https://isiscomputinggroup.github.io/ibex_developers_manual/specific_iocs/motors/galil/Updating-old-galil-driver.html) **

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://isiscomputinggroup.github.io/ibex_developers_manual/Specific-IOCs.html)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/conventions/PV-Naming.html).
    - [Disable records](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/testing/Disable-records.html)
    - [Record simulation](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/testing/Record-Simulation.html)
    - [Finishing touches](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/creation/IOC-Finishing-Touches.html)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://isiscomputinggroup.github.io/ibex_developers_manual/client/opis/OPI-Creation.html)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/compiling/Reducing-Build-Dependencies.html)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/tips_tricks/Flow-control.html).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://isiscomputinggroup.github.io/ibex_developers_manual/processes/git_and_github/Git-workflow.html) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
