### PR TITLE
Enable multiple lasers

### DIFF
--- a/CHTOBISR/iocBoot/iocCHTOBISR-IOC-01/config.xml
+++ b/CHTOBISR/iocBoot/iocCHTOBISR-IOC-01/config.xml
@@ -5,6 +5,11 @@
 <ioc_details></ioc_details>
 <macros>
 <xi:include href="../../../COMMON/PORT.xml" />
+<macro name="ADDR1" pattern="^[0-9]*$" description="Address of laser 1"  hasDefault="YES" defaultValue="" />
+<macro name="ADDR2" pattern="^[0-9]*$" description="Address of laser 2"  hasDefault="YES" defaultValue="" />
+<macro name="ADDR3" pattern="^[0-9]*$" description="Address of laser 3"  hasDefault="YES" defaultValue="" />
+<macro name="ADDR4" pattern="^[0-9]*$" description="Address of laser 4"  hasDefault="YES" defaultValue="" />
+<macro name="ADDR5" pattern="^[0-9]*$" description="Address of laser 5"  hasDefault="YES" defaultValue="" />
 </macros>
 <pvsets>
 </pvsets>

--- a/CHTOBISR/iocBoot/iocCHTOBISR-IOC-01/st-common.cmd
+++ b/CHTOBISR/iocBoot/iocCHTOBISR-IOC-01/st-common.cmd
@@ -32,9 +32,31 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)",0,"ixoff","N")
 < $(IOCSTARTUP)/dbload.cmd
 
 ## Load our record instances
-dbLoadRecords("$(CHTOBISR)/db/chtobisr.db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX)$(IOCNAME):,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),PORT=$(DEVICE)")
-dbLoadRecords("$(CHTOBISR)/db/chtobisr_status.db","P=$(MYPVPREFIX)$(IOCNAME):")
-dbLoadRecords("$(CHTOBISR)/db/chtobisr_faults.db","P=$(MYPVPREFIX)$(IOCNAME):")
+stringiftest("ADDR1", "$(ADDR1=)")
+stringiftest("ADDR2", "$(ADDR2=)")
+stringiftest("ADDR3", "$(ADDR3=)")
+stringiftest("ADDR4", "$(ADDR4=)")
+stringiftest("ADDR5", "$(ADDR5=)")
+
+$(IFADDR1) dbLoadRecords("$(CHTOBISR)/db/chtobisr.db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX)$(IOCNAME):1:,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),PORT=$(DEVICE),ADDR=$(ADDR1=)")
+$(IFADDR1) dbLoadRecords("$(CHTOBISR)/db/chtobisr_status.db","P=$(MYPVPREFIX)$(IOCNAME):1:")
+$(IFADDR1) dbLoadRecords("$(CHTOBISR)/db/chtobisr_faults.db","P=$(MYPVPREFIX)$(IOCNAME):1:")
+
+$(IFADDR2) dbLoadRecords("$(CHTOBISR)/db/chtobisr.db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX)$(IOCNAME):2:,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),PORT=$(DEVICE),ADDR=$(ADDR2=)")
+$(IFADDR2) dbLoadRecords("$(CHTOBISR)/db/chtobisr_status.db","P=$(MYPVPREFIX)$(IOCNAME):2:")
+$(IFADDR2) dbLoadRecords("$(CHTOBISR)/db/chtobisr_faults.db","P=$(MYPVPREFIX)$(IOCNAME):2:")
+
+$(IFADDR3) dbLoadRecords("$(CHTOBISR)/db/chtobisr.db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX)$(IOCNAME):3:,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),PORT=$(DEVICE),ADDR=$(ADDR3=)")
+$(IFADDR3) dbLoadRecords("$(CHTOBISR)/db/chtobisr_status.db","P=$(MYPVPREFIX)$(IOCNAME):3:")
+$(IFADDR3) dbLoadRecords("$(CHTOBISR)/db/chtobisr_faults.db","P=$(MYPVPREFIX)$(IOCNAME):3:")
+
+$(IFADDR4) dbLoadRecords("$(CHTOBISR)/db/chtobisr.db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX)$(IOCNAME):4:,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),PORT=$(DEVICE),ADDR=$(ADDR4=)")
+$(IFADDR4) dbLoadRecords("$(CHTOBISR)/db/chtobisr_status.db","P=$(MYPVPREFIX)$(IOCNAME):4:")
+$(IFADDR4) dbLoadRecords("$(CHTOBISR)/db/chtobisr_faults.db","P=$(MYPVPREFIX)$(IOCNAME):4:")
+
+$(IFADDR5) dbLoadRecords("$(CHTOBISR)/db/chtobisr.db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX)$(IOCNAME):5:,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),PORT=$(DEVICE),ADDR=$(ADDR5=)")
+$(IFADDR5) dbLoadRecords("$(CHTOBISR)/db/chtobisr_status.db","P=$(MYPVPREFIX)$(IOCNAME):5:")
+$(IFADDR5) dbLoadRecords("$(CHTOBISR)/db/chtobisr_faults.db","P=$(MYPVPREFIX)$(IOCNAME):5:")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd


### PR DESCRIPTION
### Description of work

*Add your own description here*

### To test

https://github.com/ISISComputingGroup/IBEX/issues/8798

### Acceptance criteria

*List the acceptance criteria for the PR*

- [ ] ** If this PR changes GALIL / GALILMUL ioc are these changes applicable to both the old (`galil-old` branch based) and new (`master` branch based) drivers? If so have [all appropriate PRs been created](https://isiscomputinggroup.github.io/ibex_developers_manual/specific_iocs/motors/galil/Updating-old-galil-driver.html) **

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://isiscomputinggroup.github.io/ibex_developers_manual/Specific-IOCs.html)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/conventions/PV-Naming.html).
    - [Disable records](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/testing/Disable-records.html)
    - [Record simulation](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/testing/Record-Simulation.html)
    - [Finishing touches](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/creation/IOC-Finishing-Touches.html)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://isiscomputinggroup.github.io/ibex_developers_manual/client/opis/OPI-Creation.html)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/compiling/Reducing-Build-Dependencies.html)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/tips_tricks/Flow-control.html).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://isiscomputinggroup.github.io/ibex_developers_manual/processes/git_and_github/Git-workflow.html) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
