### PR TITLE
Change EGU unit from 'um' to 'mm' in substitutions

### DIFF
--- a/TC/TC-IOC-01App/Db/single_axis.substitutions
+++ b/TC/TC-IOC-01App/Db/single_axis.substitutions
@@ -1,5 +1,5 @@
 file $(MOTOR)/db/basic_asyn_motor.db {
 pattern
 {P,                 M,                 DESC,                       DTYP,      DIR, VELO, VBAS, ACCL, BDST, BVEL, BACC, PORT,           ADDR,       MRES,  PREC, EGU, DHLM,  DLLM,   INIT, RTRY}
-{\$(MYPVPREFIX),    MOT:\$(MOTOR_PV),  "\$(MOTOR_PV) Beckhoff",    asynMotor, 0,   1,  0,   1,    0,    0,    0,    \$(MOTOR_PORT), \$(ADDR),   0.001, 3,    um,  10000, -10000, 0, 0}
+{\$(MYPVPREFIX),    MOT:\$(MOTOR_PV),  "\$(MOTOR_PV) Beckhoff",    asynMotor, 0,   1,  0,   1,    0,    0,    0,    \$(MOTOR_PORT), \$(ADDR),   0.001, 3,    mm,  10000, -10000, 0, 0}
 }


### PR DESCRIPTION
This is `um` by default but in reality most axes are `mm` - this changes the default. 

There is an ongoing ticket to get this from the controller on startup and set it (https://github.com/ISISComputingGroup/IBEX/issues/6855) but for now it's a manual step when commissioning (as documented [here](https://isiscomputinggroup.github.io/ibex_developers_manual/specific_iocs/motors/beckhoff/Beckhoff-commissioning.html#beckhoff-manual-commission-step)) 