### PR TITLE
Allow ethernet comms for Mercury ITC

### DIFF
--- a/MERCURY_ITC/iocBoot/iocMERCURY-IOC-01/config.xml
+++ b/MERCURY_ITC/iocBoot/iocMERCURY-IOC-01/config.xml
@@ -14,6 +14,9 @@
 <macro name="PRESSURE_1" pattern="^.*[.].*$" description="Card identifier for Pressure 1 (e.g. DB1.P1). Blank for no controller." hasDefault="YES" defaultValue="" />
 <macro name="PRESSURE_2" pattern="^.*[.].*$" description="Card identifier for Pressure 2 (e.g. DB1.P1). Blank for no controller." hasDefault="YES" defaultValue="" />
 
+<macro name="IPADDR" pattern="^.*$" description="IP Address for Ethernet comms" hasDefault="YES" defaultValue="" />
+<macro name="IPPORT" pattern="^.*$" description="IP Port for Ethernet comms" hasDefault="YES" defaultValue="7020" />
+
 <macro name="SPC_TYPE_1" pattern="^(FLOW|VTI|NONE)$" description="Software pressure control method to use on Temperature 1" hasDefault="YES" defaultValue="NONE" />
 <macro name="SPC_TYPE_2" pattern="^(FLOW|VTI|NONE)$" description="Software pressure control method to use on Temperature 2" hasDefault="YES" defaultValue="NONE" />
 <macro name="SPC_TYPE_3" pattern="^(FLOW|VTI|NONE)$" description="Software pressure control method to use on Temperature 3" hasDefault="YES" defaultValue="NONE" />

--- a/MERCURY_ITC/iocBoot/iocMERCURY-IOC-01/st-common.cmd
+++ b/MERCURY_ITC/iocBoot/iocMERCURY-IOC-01/st-common.cmd
@@ -13,18 +13,21 @@ $(IFRECSIM) drvAsynSerialPortConfigure("L0", "$(PORT=NUL)", 0, 1, 0, 0)
 # For dev sim devices
 $(IFDEVSIM) drvAsynIPPortConfigure("L0", "localhost:$(EMULATOR_PORT=57677)")
 
-## For real device use:
-$(IFNOTDEVSIM) $(IFNOTRECSIM) drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "baud", "$(BAUD=57600)")
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "bits", "$(BITS=8)")
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "parity", "$(PARITY=none)")
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", -1, "stop", "$(STOP=2)")
+stringiftest("IPADDR", "$(IPADDR=)", 0x2)
 
-## Flow control off
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0", 0, "clocal", "Y")
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"crtscts","N")
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixon","N")
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("L0",0,"ixoff","N")
+## If serial comms mode
+$(IFNOTDEVSIM) $(IFNOTRECSIM) $(IFNOTIPADDR) drvAsynSerialPortConfigure("L0", "$(PORT)", 0, 0, 0, 0)
+$(IFNOTDEVSIM) $(IFNOTRECSIM) $(IFNOTIPADDR) asynSetOption("L0", -1, "baud", "$(BAUD=57600)")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) $(IFNOTIPADDR) asynSetOption("L0", -1, "bits", "$(BITS=8)")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) $(IFNOTIPADDR) asynSetOption("L0", -1, "parity", "$(PARITY=none)")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) $(IFNOTIPADDR) asynSetOption("L0", -1, "stop", "$(STOP=2)")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) $(IFNOTIPADDR) asynSetOption("L0", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) $(IFNOTIPADDR) asynSetOption("L0",0,"crtscts","N")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) $(IFNOTIPADDR) asynSetOption("L0",0,"ixon","N")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) $(IFNOTIPADDR) asynSetOption("L0",0,"ixoff","N")
+
+## If ethernet comms mode
+$(IFNOTDEVSIM) $(IFNOTRECSIM) $(IFIPADDR) drvAsynIPPortConfigure("L0", "$(IPADDR=):$(IPPORT=7020)")
 
 ## Load record instances
 


### PR DESCRIPTION
### Description of work

Allow ethernet comms for mercury ITC

### To test

Closes https://github.com/ISISComputingGroup/IBEX/issues/8955

### Acceptance criteria

Ethernet comms and serial comms both allowed for Mercury ITC

- [ ] ** If this PR changes GALIL / GALILMUL ioc are these changes applicable to both the old (`galil-old` branch based) and new (`master` branch based) drivers? If so have [all appropriate PRs been created](https://isiscomputinggroup.github.io/ibex_developers_manual/specific_iocs/motors/galil/Updating-old-galil-driver.html) **

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://isiscomputinggroup.github.io/ibex_developers_manual/Specific-IOCs.html)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/conventions/PV-Naming.html).
    - [Disable records](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/testing/Disable-records.html)
    - [Record simulation](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/testing/Record-Simulation.html)
    - [Finishing touches](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/creation/IOC-Finishing-Touches.html)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://isiscomputinggroup.github.io/ibex_developers_manual/client/opis/OPI-Creation.html)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/compiling/Reducing-Build-Dependencies.html)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/tips_tricks/Flow-control.html).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://isiscomputinggroup.github.io/ibex_developers_manual/processes/git_and_github/Git-workflow.html) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
