### PR TITLE
Added PVs for E1213

### DIFF
--- a/MOXA12XX/MOXA12XX-IOC-01App/Db/Makefile
+++ b/MOXA12XX/MOXA12XX-IOC-01App/Db/Makefile
@@ -12,6 +12,7 @@ include $(TOP)/configure/CONFIG
 # databases, templates, substitutions like this
 #DB += xxx.db
 DB += moxa_e1210_PVs.db
+DB += moxa_e1213_PVs.db
 DB += moxa_e1240_PVs.db
 DB += moxa_e1242_PVs.db
 DB += moxa_e1262_PVs.db

--- a/MOXA12XX/MOXA12XX-IOC-01App/Db/moxa_e1213_PVs.substitutions
+++ b/MOXA12XX/MOXA12XX-IOC-01App/Db/moxa_e1213_PVs.substitutions
@@ -1,0 +1,27 @@
+file "IBEX_PVs_counters.template" {
+
+pattern {NAME, P, ASYNPORT, OLDFNCTN, CHAN, NEWFNCTN}
+{"\$(NAME)", "\$(P)", "\$(ASYNPORT)", "DI", "0", "DI"}
+{"\$(NAME)", "\$(P)", "\$(ASYNPORT)", "DI", "1", "DI"}
+{"\$(NAME)", "\$(P)", "\$(ASYNPORT)", "DI", "2", "DI"}
+{"\$(NAME)", "\$(P)", "\$(ASYNPORT)", "DI", "3", "DI"}
+{"\$(NAME)", "\$(P)", "\$(ASYNPORT)", "DI", "4", "DI"}
+{"\$(NAME)", "\$(P)", "\$(ASYNPORT)", "DI", "5", "DI"}
+{"\$(NAME)", "\$(P)", "\$(ASYNPORT)", "DI", "6", "DI"}
+{"\$(NAME)", "\$(P)", "\$(ASYNPORT)", "DI", "7", "DI"}
+}
+
+file "IBEX_PVs_channels.template" {
+
+pattern {NAME, P, ASYNPORT, OLDFNCTN, CHAN, NEWFNCTN}
+
+# DO Mode  WRITE
+{"\$(NAME)", "\$(P)", "\$(ASYNPORT)", "DO", "0", "DO:SP"}
+{"\$(NAME)", "\$(P)", "\$(ASYNPORT)", "DO", "1", "DO:SP"}
+{"\$(NAME)", "\$(P)", "\$(ASYNPORT)", "DO", "2", "DO:SP"}
+{"\$(NAME)", "\$(P)", "\$(ASYNPORT)", "DO", "3", "DO:SP"}
+{"\$(NAME)", "\$(P)", "\$(ASYNPORT)", "DO", "4", "DO:SP"}
+{"\$(NAME)", "\$(P)", "\$(ASYNPORT)", "DO", "5", "DO:SP"}
+{"\$(NAME)", "\$(P)", "\$(ASYNPORT)", "DO", "6", "DO:SP"}
+{"\$(NAME)", "\$(P)", "\$(ASYNPORT)", "DO", "7", "DO:SP"}
+}

--- a/MOXA12XX/iocBoot/iocMOXA12XX-IOC-01/config.xml
+++ b/MOXA12XX/iocBoot/iocMOXA12XX-IOC-01/config.xml
@@ -6,7 +6,7 @@
 <macros>
     <macro name="ADDR" pattern="^.*$" description="IP address to connect to." hasDefault="NO" />
     <macro name="PORT" pattern="^[0-9]*$" description="Modbus Port number of device. Defaults to 502" defaultValue="502" hasDefault="YES" />
-    <macro name="MODELNO" pattern="^12(10|40|42|62)+$" description="Moxa model number. 1210, 1240, 1242 or 1262." hasDefault="NO" />
+    <macro name="MODELNO" pattern="^12(10|13|40|42|62)+$" description="Moxa model number. 1210, 1213, 1240, 1242 or 1262." hasDefault="NO" />
     <macro name="CHAN0NAME" pattern="^[a-zA-Z0-9 \-\_]{0,39}+$" description="Name of channel 0, max 39 characters. Defaults to blank" defaultValue="" hasDefault="YES" />
     <macro name="CHAN1NAME" pattern="^[a-zA-Z0-9 \-\_]{0,39}+$" description="Name of channel 1, max 39 characters. Defaults to blank" defaultValue="" hasDefault="YES" />
     <macro name="CHAN2NAME" pattern="^[a-zA-Z0-9 \-\_]{0,39}+$" description="Name of channel 2, max 39 characters. Defaults to blank" defaultValue="" hasDefault="YES" />

--- a/MOXA12XX/iocBoot/iocMOXA12XX-IOC-01/st-common.cmd
+++ b/MOXA12XX/iocBoot/iocMOXA12XX-IOC-01/st-common.cmd
@@ -14,11 +14,13 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) drvAsynIPPortConfigure ("$(E12XX_ASYNPORT)","$(ADD
 modbusInterposeConfig("$(E12XX_ASYNPORT)", 0, 2000, 0)
 
 stringiftest("MOXA1210", $(MODELNO), 5, "1210")
+stringiftest("MOXA1213", $(MODELNO), 5, "1213")
 stringiftest("MOXA1240", $(MODELNO), 5, "1240")
 stringiftest("MOXA1242", $(MODELNO), 5, "1242")
 stringiftest("MOXA1262", $(MODELNO), 5, "1262")
 
 $(IFMOXA1210) < ${TOP}/iocBoot/iocMOXA12XX-IOC-01/st-e1210.cmd
+$(IFMOXA1213) < ${TOP}/iocBoot/iocMOXA12XX-IOC-01/st-e1213.cmd
 $(IFMOXA1240) < ${TOP}/iocBoot/iocMOXA12XX-IOC-01/st-e1240.cmd
 $(IFMOXA1242) < ${TOP}/iocBoot/iocMOXA12XX-IOC-01/st-e1242.cmd
 $(IFMOXA1262) < ${TOP}/iocBoot/iocMOXA12XX-IOC-01/st-e1262.cmd

--- a/MOXA12XX/iocBoot/iocMOXA12XX-IOC-01/st-e1213.cmd
+++ b/MOXA12XX/iocBoot/iocMOXA12XX-IOC-01/st-e1213.cmd
@@ -1,0 +1,18 @@
+# MOXA E1213 DIs: function 2 (Read Discrete Inputs), address 0x0, length 0x8, data_type = 0, # pollMsec = for read func, waits XXX msecs
+drvModbusAsynConfigure("$(E12XX_ASYNPORT)_DI", "$(E12XX_ASYNPORT)", 0, 2, 0x0,   0x8, 0, 100, "ioLogik E1213")
+
+# MOXA E1213 DOs read back: function 1 (Read from coils), address 0x0, length 0x8, data_type = 0, # pollMsec = for read func, waits XXX msecs
+drvModbusAsynConfigure("$(E12XX_ASYNPORT)_DO_RBV", "$(E12XX_ASYNPORT)", 0, 1, 0x0,   0x8, 0, 100, "ioLogik E1213")
+
+# MOXA E1213 DOs: function 5 (Write to coils), address 0x0, length 0x8, data_type = 0, # pollMsec = No significance
+drvModbusAsynConfigure("$(E12XX_ASYNPORT)_DO", "$(E12XX_ASYNPORT)", 0, 5, 0x0,   0x8, 0, 100, "ioLogik E1213")
+
+##ISIS## Load common DB records
+< $(IOCSTARTUP)/dbload.cmd
+
+
+dbLoadRecords("$(MOXA12XX)/db/ioLogik_E1213.db","NAME=$(MYPVPREFIX)$(IOCNAME), ASYNPORT=$(E12XX_ASYNPORT)")
+
+dbLoadRecords("${TOP}/db/moxa_e1213_PVs.db","NAME=$(MYPVPREFIX)$(IOCNAME), P=$(MYPVPREFIX)$(IOCNAME), ASYNPORT=$(E12XX_ASYNPORT)")
+
+iocshCmdList("< ${TOP}/iocBoot/iocMOXA12XX-IOC-01/st-aliases.cmd", "CHAN=\$(I), FNCTN=DI, CHANPREFIX=DI", "I", "0;1;2;3;4;5;6;7", ";")


### PR DESCRIPTION
### Description of work
The changes add the support for Moxa ioLogik E1213 as requested [here](https://github.com/ISISComputingGroup/IBEX/issues/8919)

### Acceptance criteria

*List the acceptance criteria for the PR*

- [ ] ** If this PR changes GALIL / GALILMUL ioc are these changes applicable to both the old (`galil-old` branch based) and new (`master` branch based) drivers? If so have [all appropriate PRs been created](https://isiscomputinggroup.github.io/ibex_developers_manual/specific_iocs/motors/galil/Updating-old-galil-driver.html) **

---

#### Code Review

- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/conventions/PV-Naming.html).
    - [Disable records](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/testing/Disable-records.html)
    - [Record simulation](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/testing/Record-Simulation.html)
    - [Finishing touches](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/creation/IOC-Finishing-Touches.html)
- [ ] Do the IOC and support module conform to the new [build guidelines](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/compiling/Reducing-Build-Dependencies.html)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/tips_tricks/Flow-control.html).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://isiscomputinggroup.github.io/ibex_developers_manual/processes/git_and_github/Git-workflow.html) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
