### PR TITLE
add conditional for frozen offsets for TC

### DIFF
--- a/TC/iocBoot/iocTC-IOC-01/config.xml
+++ b/TC/iocBoot/iocTC-IOC-01/config.xml
@@ -8,6 +8,8 @@
 <macro name="ADS_PORT" pattern="^[0-9]{1,5}$" description="ADS port to use for communication" hasDefault="YES" defaultValue="852"/>
 <macro name="MTRCTRL" pattern="^[0-9]{1,2}$" description="Controller number used in motor address assignment" hasDefault="NO"/>
 <macro name="PLC_VERSION" pattern="^[1]$" description="The PLC version to communicate with: 0 for the old ISIS code (now removed) and 1 for new collaboration code" defaultValue="1" hasDefault="YES" />
+<macro name="FORWARD_DESC" pattern="^1|0$" description="Whether to poll and forward axis description to .DESC" hasDefault="YES" defaultValue="0" />
+<macro name="ALLOW_FROZEN_OFFSETS" pattern="^1|0$" description="Whether to allow frozen offset behaviour" hasDefault="YES" defaultValue="0" />
 </macros>
 </config_part>
 </ioc_config>

--- a/TC/iocBoot/iocTC-IOC-01/st-common.lua
+++ b/TC/iocBoot/iocTC-IOC-01/st-common.lua
@@ -10,6 +10,7 @@ function twincat_stcommon_main()
 	local plc_version = ibex_utils.getMacroValue{macro="PLC_VERSION", default="1"}
 	local ads_port = ibex_utils.getMacroValue{macro="ADS_PORT"}
 	local forward_desc = ibex_utils.getMacroValue{macro="FORWARD_DESC", default="0"}
+	local enable_frozen_offsets = ibex_utils.getMacroValue{macro="ALLOW_FROZEN_OFFSETS", default="0"}
 	asyn_port = ibex_utils.getMacroValue{macro="PORT"}
 
 	num_axes = ibex_utils.getMacroValue{macro="NUM_AXES"} -- todo: actually poll the device to get this
@@ -32,6 +33,11 @@ function twincat_stcommon_main()
 		if forward_desc == "1" then 
 			local desc_tc_args = string.format("P=%s,AXIS_NUM=%s,ADSPORT=%s,PORT=%s", ioc_prefix, axis_num, ads_port, asyn_port)
 			iocsh.dbLoadRecords("$(MOTOREXT)/db/desc_tc.db", desc_tc_args)
+		end
+
+		if enable_frozen_offsets == "1" then
+			local frozen_offsets_db_args = string.format("P=%s,AXIS_NUM=%s,ADSPORT=%s,PORT=%s", ioc_prefix, axis_num, ads_port, asyn_port)
+			iocsh.dbLoadRecords("$(MOTOREXT)/db/frozen_offsets.db", frozen_offsets_db_args)
 		end
 
 		motor_pv = string.format("MTR%02i%02i", mtrctrl, axis_num)


### PR DESCRIPTION
### Description of work

*Add your own description here*

### To test

*Which ticket does this PR fix?*

### Acceptance criteria

*List the acceptance criteria for the PR*

- [ ] ** If this PR changes GALIL / GALILMUL ioc are these changes applicable to both the old (`galil-old` branch based) and new (`master` branch based) drivers? If so have [all appropriate PRs been created](https://isiscomputinggroup.github.io/ibex_developers_manual/specific_iocs/motors/galil/Updating-old-galil-driver.html) **

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://isiscomputinggroup.github.io/ibex_developers_manual/Specific-IOCs.html)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/conventions/PV-Naming.html).
    - [Disable records](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/testing/Disable-records.html)
    - [Record simulation](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/testing/Record-Simulation.html)
    - [Finishing touches](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/creation/IOC-Finishing-Touches.html)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://isiscomputinggroup.github.io/ibex_developers_manual/client/opis/OPI-Creation.html)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/compiling/Reducing-Build-Dependencies.html)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/tips_tricks/Flow-control.html).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://isiscomputinggroup.github.io/ibex_developers_manual/processes/git_and_github/Git-workflow.html) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
