### PR TITLE
remove todo comment for NUM_AXES

### DIFF
--- a/TC/iocBoot/iocTC-IOC-01/st-common.lua
+++ b/TC/iocBoot/iocTC-IOC-01/st-common.lua
@@ -12,7 +12,7 @@ function twincat_stcommon_main()
 	local forward_desc = ibex_utils.getMacroValue{macro="FORWARD_DESC", default="0"}
 	asyn_port = ibex_utils.getMacroValue{macro="PORT"}
 
-	num_axes = ibex_utils.getMacroValue{macro="NUM_AXES"} -- todo: actually poll the device to get this
+	num_axes = ibex_utils.getMacroValue{macro="NUM_AXES"}
 	local mtrctrl = os.getenv("MTRCTRL")
 	local ioc_prefix = pv_prefix .. ioc_name .. ":"
 


### PR DESCRIPTION
Removes the TODO comment saying about getting number of axes from the controller - we do this in st-common.cmd now (L23)