### PR TITLE
PS300: Add GPIB support

### DIFF
--- a/PS300/PS300-IOC-01App/src/build.mak
+++ b/PS300/PS300-IOC-01App/src/build.mak
@@ -29,6 +29,7 @@ $(APPNAME)_DBD += calcSupport.dbd
 $(APPNAME)_DBD += asyn.dbd
 $(APPNAME)_DBD += drvAsynSerialPort.dbd
 $(APPNAME)_DBD += drvAsynIPPort.dbd
+$(APPNAME)_DBD += drvPrologixGPIB.dbd
 $(APPNAME)_DBD += luaSupport.dbd
 $(APPNAME)_DBD += stream.dbd
 ## add other dbd here ##

--- a/PS300/iocBoot/iocPS300-IOC-01/config.xml
+++ b/PS300/iocBoot/iocPS300-IOC-01/config.xml
@@ -6,7 +6,8 @@
 		<macros>
 			<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM port" hasDefault="NO" />
 			<macro name="IPADDR" pattern="^[0-9]+\.[0-9]\.+[0-9]\.+[0-9]+$" description="IP Address of prologix GPIB" hasDefault="NO" />
-			<macro name="MODEL" pattern="^[0-9]{3}((_neg)|(_pos))*$" description="Serial COM port" hasDefault="YES" defaultValue="350_pos"/>
+			<macro name="GPIBADDR" pattern="^[0-9]+\.[0-9]\.+[0-9]\.+[0-9]+$" description="GPIB Address for prologix GPIB, usually 14" hasDefault="YES" defaultValue="-1" />
+			<macro name="MODEL" pattern="^[0-9]{3}((_neg)|(_pos))*$" description="PS Model" hasDefault="YES" defaultValue="350_pos"/>
 		</macros>
 		<pvsets>
 		</pvsets>

--- a/PS300/iocBoot/iocPS300-IOC-01/config.xml
+++ b/PS300/iocBoot/iocPS300-IOC-01/config.xml
@@ -6,7 +6,7 @@
 		<macros>
 			<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM port" hasDefault="NO" />
 			<macro name="IPADDR" pattern="^[0-9]+\.[0-9]\.+[0-9]\.+[0-9]+$" description="IP Address of prologix GPIB" hasDefault="NO" />
-			<macro name="GPIBADDR" pattern="^[0-9]+\.[0-9]\.+[0-9]\.+[0-9]+$" description="GPIB Address for prologix GPIB, usually 14" hasDefault="YES" defaultValue="-1" />
+			<macro name="GPIBADDR" pattern="^[0-9]+\.[0-9]\.+[0-9]\.+[0-9]+$" description="GPIB Address for prologix GPIB, usually 14" hasDefault="YES" defaultValue="14" />
 			<macro name="MODEL" pattern="^[0-9]{3}((_neg)|(_pos))*$" description="PS Model" hasDefault="YES" defaultValue="350_pos"/>
 		</macros>
 		<pvsets>

--- a/PS300/iocBoot/iocPS300-IOC-01/config.xml
+++ b/PS300/iocBoot/iocPS300-IOC-01/config.xml
@@ -5,7 +5,7 @@
 		<ioc_details>IOC to control the Stanford powersupply 300 series IOCs</ioc_details>
 		<macros>
 			<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM port" hasDefault="NO" />
-			<macro name="IPADDR" pattern="^[0-9]+\.[0-9]\.+[0-9]\.+[0-9]+$" description="IP Address of prologix GPIB" hasDefault="NO" />
+			<macro name="IPADDR" pattern="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$" description="IP Address of prologix GPIB" hasDefault="NO" />
 			<macro name="GPIBADDR" pattern="^[0-9]{1,2}$" description="GPIB Address for prologix GPIB, usually 14" hasDefault="YES" defaultValue="14" />
 			<macro name="MODEL" pattern="^[0-9]{3}((_neg)|(_pos))*$" description="PS Model" hasDefault="YES" defaultValue="350_pos"/>
 		</macros>

--- a/PS300/iocBoot/iocPS300-IOC-01/config.xml
+++ b/PS300/iocBoot/iocPS300-IOC-01/config.xml
@@ -5,6 +5,7 @@
 		<ioc_details>IOC to control the Stanford powersupply 300 series IOCs</ioc_details>
 		<macros>
 			<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM port" hasDefault="NO" />
+			<macro name="IPADDR" pattern="^[0-9]+\.[0-9]\.+[0-9]\.+[0-9]+$" description="IP Address of prologix GPIB" hasDefault="NO" />
 			<macro name="MODEL" pattern="^[0-9]{3}((_neg)|(_pos))*$" description="Serial COM port" hasDefault="YES" defaultValue="350_pos"/>
 		</macros>
 		<pvsets>

--- a/PS300/iocBoot/iocPS300-IOC-01/config.xml
+++ b/PS300/iocBoot/iocPS300-IOC-01/config.xml
@@ -6,7 +6,7 @@
 		<macros>
 			<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM port" hasDefault="NO" />
 			<macro name="IPADDR" pattern="^[0-9]+\.[0-9]\.+[0-9]\.+[0-9]+$" description="IP Address of prologix GPIB" hasDefault="NO" />
-			<macro name="GPIBADDR" pattern="^[0-9]+\.[0-9]\.+[0-9]\.+[0-9]+$" description="GPIB Address for prologix GPIB, usually 14" hasDefault="YES" defaultValue="14" />
+			<macro name="GPIBADDR" pattern="^[0-9]{1,2}$" description="GPIB Address for prologix GPIB, usually 14" hasDefault="YES" defaultValue="14" />
 			<macro name="MODEL" pattern="^[0-9]{3}((_neg)|(_pos))*$" description="PS Model" hasDefault="YES" defaultValue="350_pos"/>
 		</macros>
 		<pvsets>

--- a/PS300/iocBoot/iocPS300-IOC-01/st-common.cmd
+++ b/PS300/iocBoot/iocPS300-IOC-01/st-common.cmd
@@ -25,10 +25,12 @@ $(IFSERIAL) $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)",0,"crtscts",
 ## Software flow control off
 $(IFSERIAL) $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)",0,"ixon","N")
 $(IFSERIAL) $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)",0,"ixoff","N")
+$(IFSERIAL) epicsEnvSet("ADDR", "-1")
 
 ## GPIB prologix
 $(IFGPIB) $(IFNOTDEVSIM) $(IFNOTRECSIM) prologixGPIBConfigure("$(DEVICE)", "$(IPADDR=)")
 $(IFGPIB) $(IFNOTDEVSIM) $(IFNOTRECSIM) prologixGPIBSetOption("$(DEVICE)", "timeout_ms", 2000)
+$(IFGPIB) epicsEnvSet("ADDR", "$(GPIBADDR)")
 
 ## Load record instances
 
@@ -36,7 +38,7 @@ $(IFGPIB) $(IFNOTDEVSIM) $(IFNOTRECSIM) prologixGPIBSetOption("$(DEVICE)", "time
 < $(IOCSTARTUP)/dbload.cmd
 
 ## Load our record instances
-dbLoadRecords("$(PS300)/db/devSRS_PS$(MODEL).db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX),R=$(IOCNAME):,A=$(GPIBADDR),PORT=$(DEVICE)")
+dbLoadRecords("$(PS300)/db/devSRS_PS$(MODEL).db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX),R=$(IOCNAME):,A=$(ADDR),PORT=$(DEVICE)")
 dbLoadRecords("$(PS300)/db/devSRS_PS300_common.db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX),R=$(IOCNAME):,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),PORT=$(DEVICE)")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 

--- a/PS300/iocBoot/iocPS300-IOC-01/st-common.cmd
+++ b/PS300/iocBoot/iocPS300-IOC-01/st-common.cmd
@@ -4,24 +4,32 @@ epicsEnvSet "DEVICE" "L0"
 ##ISIS## Run IOC initialisation 
 < $(IOCSTARTUP)/init.cmd
 
+stringiftest("GPIB", "$(IPADDR=)", 3)
+stringiftest("SERIAL", "$(PORT=)", 3)
+
 ## Device simulation mode IP configuration
 $(IFDEVSIM) drvAsynIPPortConfigure("$(DEVICE)", "localhost:$(EMULATOR_PORT=57677)")
 
 ## For recsim:
 $(IFRECSIM) drvAsynSerialPortConfigure("$(DEVICE)", "$(PORT=NUL)", 0, 1, 0, 0)
 
-## For real device:
-$(IFNOTDEVSIM) $(IFNOTRECSIM) drvAsynSerialPortConfigure("$(DEVICE)", "$(PORT=NO_PORT_MACRO)", 0, 0, 0, 0)
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "baud", "$(BAUD=9600)")
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "bits", "$(BITS=8)")
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "parity", "$(PARITY=none)")
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)")
+## For real RS2323 serial device:
+$(IFSERIAL) $(IFNOTDEVSIM) $(IFNOTRECSIM) drvAsynSerialPortConfigure("$(DEVICE)", "$(PORT=NO_PORT_MACRO)", 0, 0, 0, 0)
+$(IFSERIAL) $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "baud", "$(BAUD=9600)")
+$(IFSERIAL) $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "bits", "$(BITS=8)")
+$(IFSERIAL) $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "parity", "$(PARITY=none)")
+$(IFSERIAL) $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)")
 ## Hardware flow control off
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", 0, "clocal", "Y")
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)",0,"crtscts","N")
+$(IFSERIAL) $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", 0, "clocal", "Y")
+$(IFSERIAL) $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)",0,"crtscts","N")
 ## Software flow control off
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)",0,"ixon","N")
-$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)",0,"ixoff","N")
+$(IFSERIAL) $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)",0,"ixon","N")
+$(IFSERIAL) $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)",0,"ixoff","N")
+
+## GPIB prologix
+$(IFGPIB) $(IFNOTDEVSIM) $(IFNOTRECSIM) prologixGPIBConfigure("$(DEVICE)", "$(IPADDR=)")
+$(IFGPIB) $(IFNOTDEVSIM) $(IFNOTRECSIM) prologixGPIBSetOption("$(DEVICE)", "timeout_ms", 2000)
+#$(IFGPIB) $(IFNOTDEVSIM) $(IFNOTRECSIM) prologixGPIBSetOption("$(DEVICE)", "send_eoi", 0)
 
 ## Load record instances
 

--- a/PS300/iocBoot/iocPS300-IOC-01/st-common.cmd
+++ b/PS300/iocBoot/iocPS300-IOC-01/st-common.cmd
@@ -29,7 +29,6 @@ $(IFSERIAL) $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)",0,"ixoff","N
 ## GPIB prologix
 $(IFGPIB) $(IFNOTDEVSIM) $(IFNOTRECSIM) prologixGPIBConfigure("$(DEVICE)", "$(IPADDR=)")
 $(IFGPIB) $(IFNOTDEVSIM) $(IFNOTRECSIM) prologixGPIBSetOption("$(DEVICE)", "timeout_ms", 2000)
-#$(IFGPIB) $(IFNOTDEVSIM) $(IFNOTRECSIM) prologixGPIBSetOption("$(DEVICE)", "send_eoi", 0)
 
 ## Load record instances
 
@@ -37,7 +36,7 @@ $(IFGPIB) $(IFNOTDEVSIM) $(IFNOTRECSIM) prologixGPIBSetOption("$(DEVICE)", "time
 < $(IOCSTARTUP)/dbload.cmd
 
 ## Load our record instances
-dbLoadRecords("$(PS300)/db/devSRS_PS$(MODEL=350_pos).db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX),R=$(IOCNAME):,A=-1, PORT=$(DEVICE)")
+dbLoadRecords("$(PS300)/db/devSRS_PS$(MODEL).db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX),R=$(IOCNAME):,A=$(GPIBADDR),PORT=$(DEVICE)")
 dbLoadRecords("$(PS300)/db/devSRS_PS300_common.db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX),R=$(IOCNAME):,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),PORT=$(DEVICE)")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 


### PR DESCRIPTION
### Description of work

Add GPIB as a connection option to the PS300 series of power supplies, some modeal have both serial and GPIB whereas others are just GPIB. Connection is via a prologix GPIB to ethernet adapter.

### To test

Borrowed device is in end room if you wish to connect and test
See ISISComputingGroup/IBEX#8470

### Acceptance criteria

Connects to device and can read back voltage and current pvs

- [ ] ** If this PR changes GALIL / GALILMUL ioc are these changes applicable to both the old (`galil-old` branch based) and new (`master` branch based) drivers? If so have [all appropriate PRs been created](https://isiscomputinggroup.github.io/ibex_developers_manual/specific_iocs/motors/galil/Updating-old-galil-driver.html) **

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://isiscomputinggroup.github.io/ibex_developers_manual/Specific-IOCs.html)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/conventions/PV-Naming.html).
    - [Disable records](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/testing/Disable-records.html)
    - [Record simulation](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/testing/Record-Simulation.html)
    - [Finishing touches](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/creation/IOC-Finishing-Touches.html)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://isiscomputinggroup.github.io/ibex_developers_manual/client/opis/OPI-Creation.html)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/compiling/Reducing-Build-Dependencies.html)
- [ ] Have the changes been recorded appropriately in a PR for [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://isiscomputinggroup.github.io/ibex_developers_manual/iocs/tips_tricks/Flow-control.html).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://isiscomputinggroup.github.io/ibex_developers_manual/processes/git_and_github/Git-workflow.html) page for details.
- [ ] Reviewer has merged the associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)
